### PR TITLE
Changed signature of ParameterizedFunction.instance() to match signature of Parameterized.__init__()

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1590,7 +1590,7 @@ class ParameterizedFunction(Parameterized):
         return self.__class__.__name__+"()"
 
     @bothmethod
-    def instance(self_or_cls,*args,**params):
+    def instance(self_or_cls,**params):
         """
         Return an instance of this class, copying parameters from any
         existing instance provided.
@@ -1605,7 +1605,7 @@ class ParameterizedFunction(Parameterized):
             params.pop('name')
             cls = self_or_cls.__class__
 
-        inst=Parameterized.__new__(cls,*args)
+        inst=Parameterized.__new__(cls)
         Parameterized.__init__(inst,**params)
         return inst
 


### PR DESCRIPTION
ParameterizedFunction.instance() no longer accepts *args, and no longer erroneously passes *args to Parameterized.**new**(); see #48.

Does this make sense to anyone else...? 

Note: I've tested only on DICE python (2.6.6).
