### PR TITLE
Fixed ParameterizedFunction's __reduce__ helper (only pass class to Parameterized.__new__)

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1569,8 +1569,9 @@ class ParamOverrides(dict):
         return extra_keywords
 
 
-def _new_parameterized(*a,**k):
-    return Parameterized.__new__(*a,**k)
+# See ParameterizedFunction.__reduce__
+def _new_parameterized(*a):
+    return Parameterized.__new__(*a)
 
 class ParameterizedFunction(Parameterized):
     """


### PR DESCRIPTION
See #48, but I think this change makes sense whether or not pull request #49 works.
