### PR TITLE
Provide Version fix when project is copied to foreign GIT repository

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -23,7 +23,7 @@ from param.parameterized import Parameterized, Parameter, String, \
 
 from param.version import Version
 __version__ = Version(release=(1,2,0), fpath=__file__,
-                      commit="$Format:%h$", name="param")
+                      commit="$Format:%h$", reponame="param")
 
 #: Top-level object to allow messaging not tied to a particular
 #: Parameterized object, as in 'param.main.warning("Invalid option")'.

--- a/param/version.py
+++ b/param/version.py
@@ -78,11 +78,11 @@ class Version(object):
     __init__.py export-subst
     """
 
-    def __init__(self, release=None, fpath=None, commit=None, name=None):
+    def __init__(self, release=None, fpath=None, commit=None, reponame=None):
         """
         release:  Release tuple (corresponding to the current git tag)
         fpath:    Set to __file__ to access version control information
-        name:     Optional name for project.
+        reponame: Used to verify VCS repository name.
         """
         self.fpath = fpath
         self._expected_commit = commit
@@ -92,7 +92,7 @@ class Version(object):
         self._commit_count = 0
         self._release = None
         self._dirty = False
-        self.name = name
+        self.reponame = reponame
 
     @property
     def release(self):
@@ -140,11 +140,11 @@ class Version(object):
 
     def git_fetch(self, cmd='git'):
         try:
-            if self.name is not None:
+            if self.reponame is not None:
                 # Verify this is the correct repository
                 output = run_cmd([cmd, 'remote', '-v'],
                                  cwd=os.path.dirname(self.fpath))
-                if '/' + self.name + '.git' not in output:
+                if '/' + self.reponame + '.git' not in output:
                     return self
 
             output = run_cmd([cmd, 'describe', '--long', '--match', 'v*.*', '--dirty'],


### PR DESCRIPTION
Implement fix for Version to not cause Exception when the project's
source code is copied to a foreign GIT repository.

The fix is to specify an optional project-name, passed to Version. If a
name is provided, the code obtaining version information from GIT first
tries to verify we are in the correct GIT repository. A simple heuristic
was implemented, which checks the output of 'git remote -v' for the name
of the project.
