### PR TITLE
Alternative implementation of ParamOverrides

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
-  - "pypy3"
 
 notifications:
   email:
@@ -15,13 +14,15 @@ notifications:
 
 # no dependencies for py2.7+ (coveralls, ipython, flake8 only needed for testing)
 install:
-#  - pip install coveralls flake8
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict; fi
+  - pip install coveralls flake8
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict flake8==2.6; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install ipython==5.3; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install ipython; fi
 
 script:
-  - nosetests --verbose --with-doctest
-#  - flake8 --statistics --exit-zero --ignore=E231 param numbergen
+  # hmm, let's at least record exactly which python is being used
+  - python --version
+  - nosetests --verbose --nologcapture --with-doctest --with-coverage --cover-package=param
+  - flake8 --statistics --exit-zero --ignore=E231 param numbergen
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ notifications:
 
 # no dependencies for py2.7+ (coveralls, ipython, flake8 only needed for testing)
 install:
-  - pip install coveralls flake8
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict flake8==2.6; fi
+#  - pip install coveralls flake8
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install ipython==5.3; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install ipython; fi
 
 script:
-  - nosetests --verbose --with-doctest --with-coverage --cover-package=param
-  - flake8 --statistics --exit-zero --ignore=E231 param numbergen
+  - nosetests --verbose --with-doctest
+#  - flake8 --statistics --exit-zero --ignore=E231 param numbergen
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
+  - "pypy3"
 
 notifications:
   email:
@@ -20,7 +21,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install ipython; fi
 
 script:
-  - nosetests --with-doctest --with-coverage --cover-package=param
+  - nosetests --verbose --with-doctest --with-coverage --cover-package=param
   - flake8 --statistics --exit-zero --ignore=E231 param numbergen
 
 after_success: coveralls

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1762,37 +1762,21 @@ class ParamOverrides(Parameterized):
         Parameterized.__init__(self,**dict_)
 
 
-<<<<<<< HEAD
-    def __getattribute__(self,name): 
-        # If name is 'special' (e.g. it's one of the various special
-        # method names) or if (param-mangled)name is set locally on
-        # this instance, return (param-mangled)name from this
-        # instance. Otherwise, return name from the overridden
-        # Parameterized instance.
-        look_in = self if (name.startswith('_') or '_%s_param_value'%name in self.__dict__ or name in self.__dict__) else self._overridden
-        return Parameterized.__getattribute__(look_in,name)
-=======
     def __getattribute__(self,name):
         """
-        If the requested name is a parameter of the overridden object:
-        return its value from this ParamOverrides instance if it's
-        been set on this instance; otherwise, return its value from
-        the overridden instance.
->>>>>>> Simplify ParamOverrides.__getattribute__ by only looking for parameters on overridden. Allows ParamOverrides to act like regular Parameterized otherwise.
+        If the requested name is a parameter of the overridden object
+        and the parameter hasn't been set on this ParamOverrides
+        instance, then get name from overridden.
 
-        If the requested name is not a parameter, look up name as
-        usual.
+        Otherwise get name as usual.
         """
         # Note: type(overridden) is like super() because
         # ParamOverrides inherits from overridden's class
         overridden = object.__getattribute__(self,'_overridden')
         if name in overridden.params():
-            if '_%s_param_value'%name in object.__getattribute__(self,'__dict__'):
-                return type(overridden).__getattribute__(self,name)
-            else:
+            if '_%s_param_value'%name not in object.__getattribute__(self,'__dict__'):
                 return getattr(overridden,name)
-        else:
-            return type(overridden).__getattribute__(self,name)
+        return type(overridden).__getattribute__(self,name)
     
     def _instantiate_param(self,param_obj,dict_=None,key=None):
         # Don't instantiate params into this object because that

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1800,8 +1800,6 @@ class ParamOverrides(Parameterized):
         return key in self.params() or key in self.__dict__
     ##########
 
-    # TODO: check pickling (should work fine)
-    
     def extra_keywords(self):
         """
         Dictionary containing items from the originally supplied dict_

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1812,17 +1812,6 @@ class ParamOverrides(Parameterized):
         """
         return self._extra_keywords
 
-
-def overrides(m):
-    """Class decorator for creating a class with a metaclass."""
-    @wraps(m)
-    def wrapper(parameterized,*args,**params):
-        assert not hasattr(parameterized,'_overrides')
-        parameterized._overrides = ParamOverrides(parameterized,params)
-        result = m(parameterized,*args,**params)
-        del parameterized._overrides
-        return result
-    return wrapper
     
 
 # Helper function required by ParameterizedFunction.__reduce__

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1802,8 +1802,6 @@ class ParamOverrides(Parameterized):
 
     # TODO: check pickling (should work fine)
     
-# TODO...
-#
     def extra_keywords(self):
         """
         Dictionary containing items from the originally supplied dict_
@@ -1811,29 +1809,6 @@ class ParamOverrides(Parameterized):
         """
         return self._extra_keywords
 
-#    def param_keywords(self):
-#        """
-#        Return a dictionary containing items from the originally
-#        supplied dict_ whose names are parameters of the
-#        overridden object (i.e. not extra keywords/parameters).
-#        """
-#        return dict((key, self[key]) for key in self if key not in self.extra_keywords())
-#
-#
-#    def _extract_extra_keywords(self,params):
-#        """
-#        Return any items in params that are not also
-#        parameters of the overridden object.
-#        """
-#        extra_keywords = {}
-#        overridden_object_params = self._overridden.params()
-#        for name,val in params.items():
-#            if name not in overridden_object_params:
-#                extra_keywords[name]=val
-#                # CEBALERT: should we remove name from params
-#                # (i.e. del params[name]) so that it's only available
-#                # via extra_keywords()?
-#        return extra_keywords
 
 def overrides(m):
     """Class decorator for creating a class with a metaclass."""

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1770,14 +1770,16 @@ class ParamOverrides(Parameterized):
 
         Otherwise get name as usual.
         """
-        # Note: type(overridden) is like super() because
-        # ParamOverrides inherits from overridden's class
         overridden = object.__getattribute__(self,'_overridden')
         if name in overridden.params():
             if '_%s_param_value'%name not in object.__getattribute__(self,'__dict__'):
                 return getattr(overridden,name)
-        return type(overridden).__getattribute__(self,name)
-    
+        # type(overridden).__getattribute__ might be better in case
+        # __getattribute__ is ever overridden on some parameterized class,
+        # but that currently results in endless recursion on
+        # pypy (though it works on cpython)
+        return object.__getattribute__(self,name)
+ 
     def _instantiate_param(self,param_obj,dict_=None,key=None):
         # Don't instantiate params into this object because that
         # already happened on overridden

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1761,7 +1761,7 @@ class ParamOverrides(Parameterized):
 
         Parameterized.__init__(self,**dict_)
 
-
+        
     def __getattribute__(self,name):
         """
         If the requested name is a parameter of the overridden object
@@ -1783,16 +1783,62 @@ class ParamOverrides(Parameterized):
         # already happened on overridden
         pass
 
-    # ParamOverrides was previously a dict, so support dict access (TODO: more to add)
+    ##########
+    # ParamOverrides was previously a dict, so support dict access
+    # Do we need this, except for backwards compatibility?
     def __getitem__(self,name):
-        # try/except raise IndexError is probably necessary?
-        return getattr(self,name)
+        try:
+            return getattr(self,name)
+        except AttributeError:
+            raise KeyError("%s not in %s"%(name,self))
 
-    # TODO: missing methods that previously existed:
-    #   * extra_keywords(),
-    #   * param_keywords()
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __contains__(self, key):
+        return key in self.params() or key in self.__dict__
+    ##########
+
     # TODO: check pickling (should work fine)
+    
+# TODO...
+#
+#    def extra_keywords(self):
+#        """
+#        Return a dictionary containing items from the originally
+#        supplied dict_ whose names are not parameters of the
+#        overridden object.
+#        """
+#        return self._extra_keywords
+#
+#    def param_keywords(self):
+#        """
+#        Return a dictionary containing items from the originally
+#        supplied dict_ whose names are parameters of the
+#        overridden object (i.e. not extra keywords/parameters).
+#        """
+#        return dict((key, self[key]) for key in self if key not in self.extra_keywords())
+#
+#
+#    def _extract_extra_keywords(self,params):
+#        """
+#        Return any items in params that are not also
+#        parameters of the overridden object.
+#        """
+#        extra_keywords = {}
+#        overridden_object_params = self._overridden.params()
+#        for name,val in params.items():
+#            if name not in overridden_object_params:
+#                extra_keywords[name]=val
+#                # CEBALERT: should we remove name from params
+#                # (i.e. del params[name]) so that it's only available
+#                # via extra_keywords()?
+#        return extra_keywords
 
+    
 
 # Helper function required by ParameterizedFunction.__reduce__
 def _new_parameterized(cls):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1746,14 +1746,9 @@ class ParamOverrides(Parameterized):
         self._extra_keywords = {}
         if allow_extra_keywords:
             dict_ = dict_.copy() # avoid removing keys from incoming dict_
-
-            # CB: how to get keys as set for all the pythons?
+            # CB: only way I could think to support all the pythons
             for name in set(dict_.keys()).difference(set(overridden.params().keys())):
-                # we avoid warnings by setting extra names before this
-                # instance is 'Parameterized'
-                val = dict_.pop(name)
-                setattr(self,name,val)
-                self._extra_keywords[name] = val
+                self._extra_keywords[name] = dict_.pop(name)
 
         Parameterized.__init__(self,**dict_)
 
@@ -1782,8 +1777,10 @@ class ParamOverrides(Parameterized):
         pass
 
     ##########
-    # ParamOverrides was previously a dict, so support dict access
-    # Do we need this, except for backwards compatibility?
+    # ParamOverrides was previously a dict, so support whatever dict
+    # access appears to already be in use (not setting, hopefully...).
+    # Do we need this, except for backwards compatibility? Maybe mark
+    # for future removal?
     def __getitem__(self,name):
         try:
             return getattr(self,name)
@@ -1798,6 +1795,14 @@ class ParamOverrides(Parameterized):
 
     def __contains__(self, key):
         return key in self.params() or key in self.__dict__
+
+    # used a generator though params() itself is not
+    # Also, in py2.6, dict items wouldn't be generator...
+    def items(self):
+        for name in self.params().keys():
+            yield name,getattr(self,name)
+        for key,value in self._extra_keywords.items():
+            yield key,value
     ##########
 
     def extra_keywords(self):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1723,11 +1723,6 @@ def print_all_param_defaults():
 
 
 
-# Note that with Python 2.6, a fn's **args no longer has to be a
-# dictionary. This might allow us to use a decorator to simplify using
-# ParamOverrides (if that does indeed make them simpler to use).
-# http://docs.python.org/whatsnew/2.6.html
-
 # CB: closely tied to Parameterized's implementation
 class ParamOverrides(Parameterized):
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1723,7 +1723,6 @@ def print_all_param_defaults():
 
 
 
-# CB: closely tied to Parameterized's implementation
 class ParamOverrides(Parameterized):
 
     # Note: __getattribute__ is overridden: see that method before
@@ -1744,6 +1743,7 @@ class ParamOverrides(Parameterized):
                               # if necessary - see https://github.com/ioam/param/issues/8)                              
                               overridden.params())        
 
+        self._extra_keywords = {}
         if allow_extra_keywords:
             dict_ = dict_.copy() # avoid removing keys from incoming dict_
 
@@ -1751,8 +1751,9 @@ class ParamOverrides(Parameterized):
             for name in set(dict_.keys()).difference(set(overridden.params().keys())):
                 # we avoid warnings by setting extra names before this
                 # instance is 'Parameterized'
-                setattr(self,name,dict_[name])
-                del dict_[name]
+                val = dict_.pop(name)
+                setattr(self,name,val)
+                self._extra_keywords[name] = val
 
         Parameterized.__init__(self,**dict_)
 
@@ -1803,14 +1804,13 @@ class ParamOverrides(Parameterized):
     
 # TODO...
 #
-#    def extra_keywords(self):
-#        """
-#        Return a dictionary containing items from the originally
-#        supplied dict_ whose names are not parameters of the
-#        overridden object.
-#        """
-#        return self._extra_keywords
-#
+    def extra_keywords(self):
+        """
+        Dictionary containing items from the originally supplied dict_
+        whose names are not parameters of the overridden object.
+        """
+        return self._extra_keywords
+
 #    def param_keywords(self):
 #        """
 #        Return a dictionary containing items from the originally

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1840,6 +1840,16 @@ class ParamOverrides(Parameterized):
 #                # via extra_keywords()?
 #        return extra_keywords
 
+def overrides(m):
+    """Class decorator for creating a class with a metaclass."""
+    @wraps(m)
+    def wrapper(parameterized,*args,**params):
+        assert not hasattr(parameterized,'_overrides')
+        parameterized._overrides = ParamOverrides(parameterized,params)
+        result = m(parameterized,*args,**params)
+        del parameterized._overrides
+        return result
+    return wrapper
     
 
 # Helper function required by ParameterizedFunction.__reduce__

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -375,6 +375,33 @@ class TestParamOverrides(unittest.TestCase):
         assert overrides.get('bogus') is None
         assert overrides.get('bogus',20) is 20
 
+    # this test is about checking things are looked up normally (like
+    # for dynamic tests above) so is probably redundant now
+    # paramoverrides is itself a parameterized object.
+    def test_search_paths(self):
+        # TODO: only good on linux/max - should do this properly
+        test_file = 'passwd'
+        test_path = '/etc/'
+
+        ###
+        # this will fail if the test itsel isn't working
+        class A(param.Parameterized):
+            path = param.Path(search_paths=['/etc'])
+        a = A(path=test_file)
+        assert a.path==test_path+test_file
+        ###
+
+        # the actual test...
+        class A2(param.Parameterized):
+            path = param.Path(search_paths=['/etc'])
+            def __call__(self,**params):
+                p = param.ParamOverrides(self,params)
+                return p.path
+    
+        a2 = A2(path=test_file)
+        assert a2() == test_path+test_file, a2()
+        assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
+
 
 class TestSharedParameters(unittest.TestCase):
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -28,7 +28,7 @@ import random
 from nose.tools import istest, nottest
 
 
-from param.parameterized import ParamOverrides, shared_parameters
+from param.parameterized import ParamOverrides, shared_parameters, overrides
 
 @nottest
 class _SomeRandomNumbers(object):
@@ -402,6 +402,36 @@ class TestParamOverrides(unittest.TestCase):
         assert a2() == test_path+test_file, a2()
         assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
 
+    # this test's as bad as the one above except this one's still useful
+    def test_overrides_decorator(self):
+        # TODO: only good on linux/max - should do this properly
+        test_file = 'passwd'
+        test_path = '/etc/'
+
+        ###
+        # this will fail if the test itsel isn't working
+        class A2(param.Parameterized):
+            path = param.Path(search_paths=['/etc'])
+            def __call__(self,**params):
+                p = param.ParamOverrides(self,params)
+                return p.path
+
+        # the actual test...
+        a2 = A2(path=test_file)
+        assert a2() == test_path+test_file, a2()
+        assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
+        ###
+
+        class A2(param.Parameterized):
+            path = param.Path(search_paths=['/etc'])
+            @overrides
+            def __call__(self,**params):
+                return self._overrides.path
+    
+        a2 = A2(path=test_file)
+        assert a2() == test_path+test_file, a2()
+        assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
+        
 
 class TestSharedParameters(unittest.TestCase):
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -375,6 +375,8 @@ class TestParamOverrides(unittest.TestCase):
         assert overrides.get('bogus') is None
         assert overrides.get('bogus',20) is 20
 
+        assert [('name', overrides.name), ('print_level', 0), ('some_param', 'y')] == sorted(overrides.items())
+
     # this test is about checking things are looked up normally (like
     # for dynamic tests above) so is probably redundant now
     # paramoverrides is itself a parameterized object.

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -289,6 +289,50 @@ class TestParamOverrides(unittest.TestCase):
         self.assertEqual(overrides['name'], 'B')
         self.assertEqual(overrides['print_level'], 0)
 
+    # CB: would be nice if we could repeat an existing set of
+    # tests somehow (since here we're testing that ParamOverrides'
+    # behavior doesn't differ from that of the wrapped
+    # Parameterized instace).            
+
+    def test_dynamic_override(self):
+        class ATestPO(param.Parameterized):
+            a = param.Number(0.5, bounds=(0,1))
+
+        po = ParamOverrides(ATestPO(),dict(a=lambda:0.75))        
+        self.assertEqual(po.a,0.75)
+
+        po = ParamOverrides(ATestPO(),dict(a=lambda:2))
+        try:
+            po.a
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Dynamic value wasn't checked")
+    
+
+
+    def test_value_checking(self):
+        class ATestPO(param.Parameterized):
+            a = param.String('test')
+            b = param.Number(0.5, bounds=(0,1))
+
+        # these three similar tests might be overkill
+        try:
+            ParamOverrides(ATestPO(),dict(a=10))
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Shouldn't be able to override a param.String with a number")
+
+        try:
+            ParamOverrides(ATestPO(),dict(b=2))
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Shouldn't be able to override a param.Number to value outside its bounds")
+
+        self.assertRaises(ValueError, some_fn, num_phase='bad value') 
+
     # CEBALERT: missing test for allow_extra_keywords (e.g. getting a
     # warning on attempting to override non-existent parameter when
     # allow_extra_keywords is False)

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -431,6 +431,15 @@ class TestParamOverrides(unittest.TestCase):
         a2 = A2(path=test_file)
         assert a2() == test_path+test_file, a2()
         assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
+        assert not hasattr(a2,'_overrides')
+
+        class A3(param.ParameterizedFunction):
+            path = param.Path(search_paths=['/etc'])
+            @overrides
+            def __call__(self,**params):
+                return self._overrides.path
+
+        assert A3(path=test_file) == test_path+test_file, A3(path=test_file)
         
 
 class TestSharedParameters(unittest.TestCase):

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -440,7 +440,27 @@ class TestParamOverrides(unittest.TestCase):
                 return self._overrides.path
 
         assert A3(path=test_file) == test_path+test_file, A3(path=test_file)
-        
+
+    # another test to simplify one day!
+    def test_extra_keywords(self):
+        try:
+            old = param.parameterized.warnings_as_exceptions
+            param.parameterized.warnings_as_exceptions = True
+            p = param.ParamOverrides(self.po,{'extra':100},allow_extra_keywords=False)
+        except:
+            pass
+        else:
+            raise AssertionError
+        finally:
+            param.parameterized.warnings_as_exceptions = old
+            
+        p = param.ParamOverrides(self.po,{'extra':100},allow_extra_keywords=False)
+        assert len(p._extra_keywords) == 0
+
+        p = param.ParamOverrides(self.po,{'extra':100},allow_extra_keywords=True)
+        assert len(p._extra_keywords) == 1
+        assert p._extra_keywords['extra'] == 100
+
 
 class TestSharedParameters(unittest.TestCase):
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -281,6 +281,7 @@ class TestParamOverrides(unittest.TestCase):
         super(TestParamOverrides, self).setUp()
         class AnotherTestPO(param.Parameterized):
             print_level = param.Number(default=0)
+            some_param = param.Parameter(default="x")
         self.po = AnotherTestPO(name='A',print_level=0)
 
     def test_init_name(self):
@@ -343,12 +344,36 @@ class TestParamOverrides(unittest.TestCase):
         overrides = ParamOverrides(self.po,{'name':'B'})
         try:
             overrides['doesnotexist']
-        except AttributeError:
+        except KeyError:
             pass
         except:
-            raise AssertionError("ParamOverrides should give AttributeError when key can't be found.")
+            raise AssertionError("ParamOverrides should give KeyError when key can't be found.")
         else:
             raise AssertionError("Test supposed to lookup non-existent attribute and raise error.")
+
+        
+    def test_dict_like(self):
+        overrides = ParamOverrides(self.po,{'some_param':'y'})
+        
+        assert 'some_param' in overrides
+        assert 'print_level' in overrides        
+        assert 'bogus' not in overrides
+
+        overrides['some_param'] == 'y'
+        overrides['print_level'] == 0
+
+        try:
+            overrides['bogus']
+        except KeyError:
+            pass
+        else:
+            raise
+
+        assert overrides.get('some_param') == 'y'
+        assert overrides.get('print_level') == 0
+        
+        assert overrides.get('bogus') is None
+        assert overrides.get('bogus',20) is 20
 
 
 class TestSharedParameters(unittest.TestCase):
@@ -367,7 +392,6 @@ class TestSharedParameters(unittest.TestCase):
     def test_shared_list(self):
         self.assertTrue(self.p1.inst is self.p2.inst)
         self.assertTrue(self.p1.params('inst').default is not self.p2.inst)
-
 
 
 if __name__ == "__main__":

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -28,7 +28,7 @@ import random
 from nose.tools import istest, nottest
 
 
-from param.parameterized import ParamOverrides, shared_parameters, overrides
+from param.parameterized import ParamOverrides, shared_parameters
 
 @nottest
 class _SomeRandomNumbers(object):
@@ -404,44 +404,6 @@ class TestParamOverrides(unittest.TestCase):
         assert a2() == test_path+test_file, a2()
         assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
 
-    # this test's as bad as the one above except this one's still useful
-    def test_overrides_decorator(self):
-        # TODO: only good on linux/max - should do this properly
-        test_file = 'passwd'
-        test_path = '/etc/'
-
-        ###
-        # this will fail if the test itsel isn't working
-        class A2(param.Parameterized):
-            path = param.Path(search_paths=['/etc'])
-            def __call__(self,**params):
-                p = param.ParamOverrides(self,params)
-                return p.path
-
-        # the actual test...
-        a2 = A2(path=test_file)
-        assert a2() == test_path+test_file, a2()
-        assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
-        ###
-
-        class A2(param.Parameterized):
-            path = param.Path(search_paths=['/etc'])
-            @overrides
-            def __call__(self,**params):
-                return self._overrides.path
-    
-        a2 = A2(path=test_file)
-        assert a2() == test_path+test_file, a2()
-        assert a2(path=test_file) == test_path+test_file, a2(path=test_file)
-        assert not hasattr(a2,'_overrides')
-
-        class A3(param.ParameterizedFunction):
-            path = param.Path(search_paths=['/etc'])
-            @overrides
-            def __call__(self,**params):
-                return self._overrides.path
-
-        assert A3(path=test_file) == test_path+test_file, A3(path=test_file)
 
     # another test to simplify one day!
     def test_extra_keywords(self):

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -377,6 +377,11 @@ class TestParamOverrides(unittest.TestCase):
 
         assert [('name', overrides.name), ('print_level', 0), ('some_param', 'y')] == sorted(overrides.items())
 
+    def test_is_mapping(self):
+        def f(**kw): pass
+        overrides = ParamOverrides(self.po,{'some_param':'y'})
+        f(**overrides)
+    
     # this test is about checking things are looked up normally (like
     # for dynamic tests above) so is probably redundant now
     # paramoverrides is itself a parameterized object.
@@ -425,6 +430,23 @@ class TestParamOverrides(unittest.TestCase):
         assert len(p._extra_keywords) == 1
         assert p._extra_keywords['extra'] == 100
 
+    def test_nonparamattr(self):
+        x = AnotherTestPO(name='A')
+        x.some_other_thing = 1
+        assert x.some_other_thing == 1
+        overrides = ParamOverrides(x,{'some_param':'y'})
+        assert overrides.some_other_thing == 1
+        
+    def test_param_keywords(self):
+        overrides = ParamOverrides(self.po,{'name':'B','an_extra_thing':1},allow_extra_keywords=True)
+        assert 'an_extra_thing' in overrides.extra_keywords()
+        assert 'an_extra_thing' not in overrides.param_keywords()
+
+    def test_pickle(self):
+        overrides = ParamOverrides(self.po,{'name':'B','an_extra_thing':1},allow_extra_keywords=True)
+        import pickle
+        pkl = pickle.dumps(overrides)
+        
 
 class TestSharedParameters(unittest.TestCase):
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -279,7 +279,9 @@ class TestParamOverrides(unittest.TestCase):
 
     def setUp(self):
         super(TestParamOverrides, self).setUp()
-        self.po = param.Parameterized(name='A',print_level=0)
+        class AnotherTestPO(param.Parameterized):
+            print_level = param.Number(default=0)
+        self.po = AnotherTestPO(name='A',print_level=0)
 
     def test_init_name(self):
         self.assertEqual(self.po.name, 'A')


### PR DESCRIPTION
I've re-implemented ParamOverrides, following the suggestion made in #85 about sharing parameter objects. This PR isn't meant for merging at this stage, I'd just like some comments on the basic idea.

This new implementation passes all the tests (including one I added to check that dynamic overrides work), although the implementation's not yet complete (just missing some minor methods that the current ParamOverrides has). However, what I'd like to know is: is the whole idea crazy? If it's not crazy, is there a way to make the implementation simpler? I've left extra comments in the code for now to explain what I was thinking.

In case it's easier to look at the class in one piece:
https://github.com/ceball/param/blob/bug85_newParamOverrides/param/parameterized.py#L1580

(Also, note that I haven't considered speed.)
