### PR TITLE
Fix ClassSelector.get_range() for class_ tuple

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1335,8 +1335,11 @@ class ClassSelector(SelectorBase):
         Only classes from modules that have been imported are added
         (see concrete_descendents()).
         """
-        classes = concrete_descendents(self.class_)
-        d=OrderedDict((name,class_) for name,class_ in classes.items())
+        classes = self.class_ if isinstance(self.class_, tuple) else (self.class_,)
+        all_classes = {}
+        for cls in classes:
+            all_classes.update(concrete_descendents(cls))
+        d=OrderedDict((name,class_) for name,class_ in all_classes.items())
         if self.allow_None:
             d['None']=None
         return d

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1292,7 +1292,7 @@ class Selector(ObjectSelector):
 
 class ClassSelector(SelectorBase):
     """
-    Parameter whose value is a specified class or an instance of that class.
+    Parameter allowing selection of either a subclass or an instance of a given set of classes.
     By default, requires an instance, but if is_instance=False, accepts a class instead.
     Both class and instance values respect the instantiate slot, though it matters only
     for is_instance=True.

--- a/tests/API1/testclassselector.py
+++ b/tests/API1/testclassselector.py
@@ -60,6 +60,12 @@ class TestClassSelectorParameters(API1TestCase):
         p = self.P(h=str)
         self.assertEqual(p.h, str)
 
+    def test_class_selector_get_range(self):
+        p = self.P()
+        classes = p.param.g.get_range()
+        self.assertIn('int', classes)
+        self.assertIn('str', classes)
+
     def test_multiple_class_type_error(self):
         exception = "Parameter 'float' must be a subclass of \(int, str\), not 'type'"
         with self.assertRaisesRegexp(ValueError, exception):


### PR DESCRIPTION
ClassSelector allowed using `class_=some_tuple` but ClassSelector.get_range() would error in that case.