### PR TITLE
Update links and text to point to holoviz.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ jobs:
           skip_cleanup: true
           github_token: $GITHUB_TOKEN
           local_dir: ./builtdocs
-          fqdn: param.pyviz.org
+          fqdn: param.holoviz.org
           on:
             tags: true
             all_branches: true

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ dependencies, and is provided freely for both non-commercial and
 commercial use under a BSD license, so that it can easily be included
 as part of other projects.
 
-Please see `param's website <http://param.pyviz.org>`_ for
+Please see `param's website <http://param.holoviz.org>`_ for
 official releases, installation instructions, documentation, and examples.
 
 .. |LinuxTests| image:: https://travis-ci.org/holoviz/param.svg?branch=master

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,7 +3,7 @@
 from nbsite.shared_conf import *
 
 project = u'Param'
-authors = u'PyViz authors'
+authors = u'HoloViz authors'
 copyright = u'\u00a9 2005-2018, ' + authors
 description = 'Declarative Python programming using Parameters.'
 
@@ -28,7 +28,7 @@ html_context.update({
     'DESCRIPTION': description,
     'AUTHOR': authors,
     # canonical URL (for search engines); can ignore for local builds
-    'WEBSITE_SERVER': 'https://param.pyviz.org',
+    'WEBSITE_SERVER': 'https://param.holoviz.org',
     'VERSION': version,
     'NAV': _NAV,
     'LINKS': _NAV,

--- a/examples/About.ipynb
+++ b/examples/About.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Param is part of [PyViz](http://pyviz.org), a collaborative project to produce a coherent solution to a wide range of Python visualization problems."
+    "Param is part of [HoloViz](http://holoviz.org), a collaborative project to produce a coherent solution to a wide range of Python visualization problems."
    ]
   }
  ],

--- a/param/version.py
+++ b/param/version.py
@@ -2,7 +2,7 @@
 Provide consistent and up-to-date ``__version__`` strings for
 Python packages.
 
-See https://github.com/pyviz/autover for more information.
+See https://github.com/holoviz/autover for more information.
 """
 
 # The Version class is a copy of autover.version.Version v0.2.5,


### PR DESCRIPTION
This substitutes pyviz for holoviz where appropriate (in some places the code would need to be changed but that is for a different PR)