### PR TITLE
include params when calling instance in __new__

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2807,7 +2807,7 @@ class ParameterizedFunction(Parameterized):
 
     def __new__(class_,*args,**params):
         # Create and __call__() an instance of this class.
-        inst = class_.instance()
+        inst = class_.instance(**params)
         inst.param._set_name(class_.__name__)
         return inst.__call__(*args,**params)
 


### PR DESCRIPTION
## Background
The `__new__` constructor method is overridden in the `ParameterizedFunction`  class to make it possible to call a parameterized function as if it were a regular function.  The `__new__` constructor calls `ParameterizedFunction.instance()` to create an instance of the class, and then calls the instance's `__call__` method to execute the function.

## Update
Previously, the `instance()` method was called without any keyword arguments and then the user provided arguments were passed to the `__call__` method on the instance.

This PR simply passes any user provided keyword arguments to `instance` as well as `__call__`, this way the user provided arguments are saved in the parameterized function instance.

## Motivation
I ran into this issue while working on `linked_selections` in HoloViews.  Without this change, the user provided arguments to operations like `rasterize` (e.g. `cmap`) were not being saved in the operation.