### PR TITLE
Turn .param into a property

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1109,6 +1109,16 @@ class Parameters(object):
     def self_or_cls(self_):
         return self_.cls if self_.self is None else self_.self
 
+    def __setstate__(self, state):
+        # Set old parameters state on Parameterized._parameters_state
+        self_or_cls = state.get('self', state.get('cls'))
+        for k in self_or_cls._parameters_state:
+            key = '_'+k
+            if key in state:
+                self_or_cls._parameters_state[k] = state.pop(key)
+        for k, v in state.items():
+            setattr(self, k, v)
+            
     def __getitem__(self_, key):
         """
         Returns the class or instance parameter
@@ -2421,6 +2431,7 @@ class Parameterized(object):
             state['_instance__params'] = {}
         if '_param_watchers' not in state:
             state['_param_watchers'] = {}
+        state.pop('param', None)
 
         for name,value in state.items():
             setattr(self,name,value)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1116,7 +1116,7 @@ class Parameters(object):
         inst = self_.self
         parameters = self_.objects(False) if inst is None else inst.param.objects(False)
         p = parameters[key]
-        if (inst is not None and p.per_instance and
+        if (inst is not None and getattr(inst, 'initialized', False) and p.per_instance and
             not getattr(inst, '_disable_instance__params', False)):
             if key not in inst._instance__params:
                 try:
@@ -2385,7 +2385,7 @@ class Parameterized(object):
 
     @property
     def param(self):
-        return Parameters(self.__class__, self)
+        return Parameters(self.__class__, self=self)
 
     # 'Special' methods
 


### PR DESCRIPTION
Supersedes https://github.com/holoviz/param/pull/384

The reasoning behind this is that having accessors which hold a reference back to the Parameterized object create a circular reference which stops CPython's garbage collection from immediately collecting a Parameterized instance when it is no longer referenced by any external object instead having to wait for the next `gc.collect()` cycle.