### PR TITLE
Prevent param.version from failing when used alongside async frameworks

### DIFF
--- a/param/version.py
+++ b/param/version.py
@@ -26,7 +26,7 @@ def run_cmd(args, cwd=None):
                             cwd=cwd)
     output, error = (str(s.decode()).strip() for s in proc.communicate())
 
-    if proc.returncode != 0:
+    if proc.returncode != 0 or len(error) > 0:
         raise Exception(proc.returncode, error)
     return output
 


### PR DESCRIPTION
In some weird environments, param's way of retrieving version information has many bugs (since it opens a subprocess to call git, for instance, which gives problems when Python processes are created with systems such as Supervisor or Gunicorn). This commit adds the option for the library to keep on going, even if the version cannot be correctly retreived.

It turns out that param.version is running (or at least trying to run) some git commands in order to retrieve the version. The way the git commands are launched is through subprocess.Popen() as you can see here: https://github.com/holoviz/param/blob/7d2d2a848dc79d9741709702f8b47f87497701b0/param/version.py#L23

And well, it turns out that subprocess.Popen() is nor particularly async-friendly when spawned from an os fork instruction (just like Gunicorn does). Apparently, one of the problems is that it misreports the return code for the launched command.

The only solution I can think of would be to slightly modify the run_cmd function, to make it read the return code as either 0 if everything runs correctly; or nonzero if either the actual returncode read by subprocess.Popen() is nonzero or if the stderr is something other than an empty byte array.

This PR does exactly that.