### PR TITLE
Allow using iadd on constant parameter

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -835,7 +835,9 @@ class Parameter(object):
                 _old = obj.__dict__.get(self._internal_name,self.default)
                 obj.__dict__[self._internal_name] = val
             else:
-                raise TypeError("Constant parameter '%s' cannot be modified"%self.name)
+                _old = obj.__dict__.get(self._internal_name,self.default)
+                if val is not _old:
+                    raise TypeError("Constant parameter '%s' cannot be modified"%self.name)
 
         else:
             if obj is None:


### PR DESCRIPTION
Allows using `__iadd__` on parameters that support in-place operations even if it is constant as long as the return value `is` the same as the previous parameter value. Note that this is only my particular usecase and this will also allow any other `__i<operator>__` method and even `parameterized.object = parameterized.object` but I don't think any of those are harmful since it does not break the `constant` contract of changing the actual object identity.

```python
import param

class Test(param.Parameterized):
    
    list = param.List([], constant=True)
    
test = Test()
test.list += [1, 2, 3]
```