### PR TITLE
JSON serialization and schema generation

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1456,7 +1456,7 @@ class DataFrame(ClassSelector):
         self.rows = rows
         self.columns = columns
         self.ordered = ordered
-        super(DataFrame,self).__init__(pdDFrame, default=default, allow_None=True, **params)
+        super(DataFrame,self).__init__(pdDFrame, default=default, **params)
         self._validate(self.default)
 
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1014,7 +1014,7 @@ class Tuple(Parameter):
                              (self.name,len(val),self.length))
 
 
-    def _deserialize(self, value):
+    def deserialize(self, value):
         return tuple(value) # As JSON has no tuple representation
 
 
@@ -1841,7 +1841,7 @@ class Date(Number):
 
         self._checkBounds(val)
 
-    def _deserialize(self, value):
+    def deserialize(self, value):
         return dt.datetime.fromisoformat(value)
 
 class CalendarDate(Number):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1853,7 +1853,7 @@ class Date(Number):
 
     @classmethod
     def serialize(cls, value):
-        return value.replace(microsecond=0).isoformat()
+        return value.isoformat()
     @classmethod
     def deserialize(cls, value):
         return dt.datetime.fromisoformat(value)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1884,6 +1884,14 @@ class CalendarDate(Number):
 
         self._checkBounds(val)
 
+    @classmethod
+    def serialize(cls, value):
+        return value.strftime("%Y-%m-%d")
+
+    @classmethod
+    def deserialize(cls, value):
+        return dt.datetime.strptime(value, "%Y-%m-%d").date()
+
 
 class Color(Parameter):
     """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1853,6 +1853,8 @@ class Date(Number):
 
     @classmethod
     def serialize(cls, value):
+        if not isinstance(value, (dt.datetime, dt.date)): # i.e np.datetime64
+            value = value.astype(dt.datetime)
         return value.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @classmethod

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1430,6 +1430,15 @@ class Array(ClassSelector):
         from numpy import ndarray
         super(Array,self).__init__(ndarray, allow_None=True, default=default, **params)
 
+    @classmethod
+    def serialize(cls, value):
+        return value.tolist()
+
+    @classmethod
+    def deserialize(cls, value):
+        from numpy import array
+        return array(value)
+
 
 class DataFrame(ClassSelector):
     """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1853,7 +1853,7 @@ class Date(Number):
 
     @classmethod
     def serialize(cls, value):
-        return value.isoformat()
+        return value.strftime("%Y-%m-%dT%H:%M:%S.%f")
     @classmethod
     def deserialize(cls, value):
         return dt.datetime.fromisoformat(value)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1014,7 +1014,8 @@ class Tuple(Parameter):
                              (self.name,len(val),self.length))
 
 
-    def deserialize(self, value):
+    @classmethod
+    def deserialize(cls, value):
         return tuple(value) # As JSON has no tuple representation
 
 
@@ -1841,7 +1842,8 @@ class Date(Number):
 
         self._checkBounds(val)
 
-    def deserialize(self, value):
+    @classmethod
+    def deserialize(cls, value):
         return dt.datetime.fromisoformat(value)
 
 class CalendarDate(Number):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1854,9 +1854,10 @@ class Date(Number):
     @classmethod
     def serialize(cls, value):
         return value.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
     @classmethod
     def deserialize(cls, value):
-        return dt.datetime.fromisoformat(value)
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
 
 class CalendarDate(Number):
     """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1014,6 +1014,9 @@ class Tuple(Parameter):
                              (self.name,len(val),self.length))
 
 
+    def _deserialize(self, value):
+        return tuple(value) # As JSON has no tuple representation
+
 
 class NumericTuple(Tuple):
     """A numeric tuple Parameter (e.g. (4.5,7.6,3)) with a fixed tuple length."""
@@ -1838,6 +1841,8 @@ class Date(Number):
 
         self._checkBounds(val)
 
+    def _deserialize(self, value):
+        return dt.datetime.fromisoformat(value)
 
 class CalendarDate(Number):
     """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1015,7 +1015,7 @@ class Tuple(Parameter):
 
 
     @classmethod
-    def deserialize(cls, value):
+    def ir_deserialize(cls, value):
         return tuple(value) # As JSON has no tuple representation
 
 
@@ -1431,11 +1431,11 @@ class Array(ClassSelector):
         super(Array,self).__init__(ndarray, allow_None=True, default=default, **params)
 
     @classmethod
-    def serialize(cls, value):
+    def ir_serialize(cls, value):
         return value.tolist()
 
     @classmethod
-    def deserialize(cls, value):
+    def ir_deserialize(cls, value):
         from numpy import array
         return array(value)
 
@@ -1511,11 +1511,11 @@ class DataFrame(ClassSelector):
             self._length_bounds_check(self.rows, len(val), 'Row')
 
     @classmethod
-    def serialize(cls, value):
+    def ir_serialize(cls, value):
         return value.to_dict('records')
 
     @classmethod
-    def deserialize(cls, value):
+    def ir_deserialize(cls, value):
         from pandas import DataFrame as pdDFrame
         return pdDFrame(value)
 
@@ -1861,13 +1861,13 @@ class Date(Number):
         self._checkBounds(val)
 
     @classmethod
-    def serialize(cls, value):
+    def ir_serialize(cls, value):
         if not isinstance(value, (dt.datetime, dt.date)): # i.e np.datetime64
             value = value.astype(dt.datetime)
         return value.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @classmethod
-    def deserialize(cls, value):
+    def ir_deserialize(cls, value):
         return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
 
 
@@ -1896,11 +1896,11 @@ class CalendarDate(Number):
         self._checkBounds(val)
 
     @classmethod
-    def serialize(cls, value):
+    def ir_serialize(cls, value):
         return value.strftime("%Y-%m-%d")
 
     @classmethod
-    def deserialize(cls, value):
+    def ir_deserialize(cls, value):
         return dt.datetime.strptime(value, "%Y-%m-%d").date()
 
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1436,8 +1436,8 @@ class Array(ClassSelector):
 
     @classmethod
     def deserialize(cls, value):
-        from numpy import array
-        return array(value)
+        from numpy import asarray
+        return asarray(value)
 
 
 class DataFrame(ClassSelector):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1015,7 +1015,7 @@ class Tuple(Parameter):
 
 
     @classmethod
-    def ir_deserialize(cls, value):
+    def deserialize(cls, value):
         return tuple(value) # As JSON has no tuple representation
 
 
@@ -1431,11 +1431,11 @@ class Array(ClassSelector):
         super(Array,self).__init__(ndarray, allow_None=True, default=default, **params)
 
     @classmethod
-    def ir_serialize(cls, value):
+    def serialize(cls, value):
         return value.tolist()
 
     @classmethod
-    def ir_deserialize(cls, value):
+    def deserialize(cls, value):
         from numpy import array
         return array(value)
 
@@ -1511,11 +1511,11 @@ class DataFrame(ClassSelector):
             self._length_bounds_check(self.rows, len(val), 'Row')
 
     @classmethod
-    def ir_serialize(cls, value):
+    def serialize(cls, value):
         return value.to_dict('records')
 
     @classmethod
-    def ir_deserialize(cls, value):
+    def deserialize(cls, value):
         from pandas import DataFrame as pdDFrame
         return pdDFrame(value)
 
@@ -1861,13 +1861,13 @@ class Date(Number):
         self._checkBounds(val)
 
     @classmethod
-    def ir_serialize(cls, value):
+    def serialize(cls, value):
         if not isinstance(value, (dt.datetime, dt.date)): # i.e np.datetime64
             value = value.astype(dt.datetime)
         return value.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @classmethod
-    def ir_deserialize(cls, value):
+    def deserialize(cls, value):
         return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
 
 
@@ -1896,11 +1896,11 @@ class CalendarDate(Number):
         self._checkBounds(val)
 
     @classmethod
-    def ir_serialize(cls, value):
+    def serialize(cls, value):
         return value.strftime("%Y-%m-%d")
 
     @classmethod
-    def ir_deserialize(cls, value):
+    def deserialize(cls, value):
         return dt.datetime.strptime(value, "%Y-%m-%d").date()
 
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1857,7 +1857,8 @@ class Date(Number):
 
     @classmethod
     def deserialize(cls, value):
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+
 
 class CalendarDate(Number):
     """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1843,6 +1843,9 @@ class Date(Number):
         self._checkBounds(val)
 
     @classmethod
+    def serialize(cls, value):
+        return value.replace(microsecond=0).isoformat()
+    @classmethod
     def deserialize(cls, value):
         return dt.datetime.fromisoformat(value)
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1501,6 +1501,15 @@ class DataFrame(ClassSelector):
         if self.rows is not None:
             self._length_bounds_check(self.rows, len(val), 'Row')
 
+    @classmethod
+    def serialize(cls, value):
+        return value.to_dict('records')
+
+    @classmethod
+    def deserialize(cls, value):
+        from pandas import DataFrame as pdDFrame
+        return pdDFrame(value)
+
 
 class Series(ClassSelector):
     """

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -10,7 +10,6 @@ import inspect
 import random
 import numbers
 import operator
-import json
 from .serializer import JSONSerialization
 
 from collections import defaultdict, namedtuple, OrderedDict

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -734,15 +734,15 @@ class Parameter(object):
         self.per_instance = per_instance
 
 
-    def _serialize(self, value):
+    def serialize(self, value):
         "Given the parameter value, return a Python value suitable for serialization"
         return value
 
-    def _deserialize(self, value):
+    def deserialize(self, value):
         "Given a serializable Python value, return a value that the parameter can be set to"
         return value
 
-    def _schema(self, safe=False):
+    def schema(self, safe=False):
         return self._serializer.parameter_schema(self.__class__.__name__, self, safe=safe)
 
     @property

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1164,7 +1164,7 @@ class Parameters(object):
                 self_or_cls._parameters_state[k] = state.pop(key)
         for k, v in state.items():
             setattr(self, k, v)
-            
+
     def __getitem__(self_, key):
         """
         Returns the class or instance parameter
@@ -1979,7 +1979,7 @@ class ParameterizedMetaclass(type):
             "watchers": [] # Queue of batched watchers
         }
         mcs._param = Parameters(mcs)
-        
+
 
         # All objects (with their names) of type Parameter that are
         # defined in this class

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -10,6 +10,8 @@ import inspect
 import random
 import numbers
 import operator
+import json
+from .serializer import JSONSerialization
 
 from collections import defaultdict, namedtuple, OrderedDict
 from operator import itemgetter,attrgetter
@@ -687,6 +689,8 @@ class Parameter(object):
     # class is created, owner, name, and _internal_name are
     # set.
 
+    _serializer = JSONSerialization
+
     def __init__(self,default=None,doc=None,label=None,precedence=None,  # pylint: disable-msg=R0913
                  instantiate=False,constant=False,readonly=False,
                  pickle_default_value=True, allow_None=False,
@@ -730,6 +734,15 @@ class Parameter(object):
         self.watchers = {}
         self.per_instance = per_instance
 
+
+    def _serialize(self, value):
+        return JSONSerialization.serialize(self.__class__.__name__, value)
+
+    def _deserialize(self, string):
+        return JSONSerialization.deserialize(self.__class__.__name__, string)
+
+    def _schema(self):
+        return JSONSerialization.parameter_schema(self.__class__.__name__, self)
 
     @property
     def label(self):
@@ -1565,6 +1578,14 @@ class Parameters(object):
 
             for obj in sublist:
                 obj.param.set_dynamic_time_fn(time_fn,sublistattr)
+
+    def serialize_parameters(self_):
+        self_or_cls = self_.self_or_cls
+        return Parameter._serializer.serialize_parameters(self_or_cls)
+
+    def schema(self_):
+        self_or_cls = self_.self_or_cls
+        return Parameter._serializer.schema(self_or_cls)
 
     def get_param_values(self_,onlychanged=False):
         """

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -734,11 +734,13 @@ class Parameter(object):
         self.per_instance = per_instance
 
 
-    def serialize(self, value):
+    @classmethod
+    def serialize(cls, value):
         "Given the parameter value, return a Python value suitable for serialization"
         return value
 
-    def deserialize(self, value):
+    @classmethod
+    def deserialize(cls, value):
         "Given a serializable Python value, return a value that the parameter can be set to"
         return value
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -741,12 +741,12 @@ class Parameter(object):
 
 
     @classmethod
-    def serialize(cls, value):
+    def ir_serialize(cls, value):
         "Given the parameter value, return a Python value suitable for serialization"
         return value
 
     @classmethod
-    def deserialize(cls, value):
+    def ir_deserialize(cls, value):
         "Given a serializable Python value, return a value that the parameter can be set to"
         return value
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -741,12 +741,12 @@ class Parameter(object):
 
 
     @classmethod
-    def ir_serialize(cls, value):
+    def serialize(cls, value):
         "Given the parameter value, return a Python value suitable for serialization"
         return value
 
     @classmethod
-    def ir_deserialize(cls, value):
+    def deserialize(cls, value):
         "Given a serializable Python value, return a value that the parameter can be set to"
         return value
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -750,10 +750,11 @@ class Parameter(object):
         "Given a serializable Python value, return a value that the parameter can be set to"
         return value
 
-    def schema(self, safe=False):
+    def schema(self, safe=False, subset=None):
         if self._serializer is None:
             raise ImportError('Cannot import serializer.py needed to generate schema')
-        return self._serializer.parameter_schema(self.__class__.__name__, self, safe=safe)
+        return self._serializer.parameter_schema(self.__class__.__name__, self,
+                                                 safe=safe, subset=subset)
 
     @property
     def label(self):
@@ -1590,13 +1591,13 @@ class Parameters(object):
             for obj in sublist:
                 obj.param.set_dynamic_time_fn(time_fn,sublistattr)
 
-    def serialize_parameters(self_):
+    def serialize_parameters(self_, subset=None):
         self_or_cls = self_.self_or_cls
-        return Parameter._serializer.serialize_parameters(self_or_cls)
+        return Parameter._serializer.serialize_parameters(self_or_cls, subset=subset)
 
-    def schema(self_, safe=False):
+    def schema(self_, safe=False, subset=None):
         self_or_cls = self_.self_or_cls
-        return Parameter._serializer.schema(self_or_cls, safe=safe)
+        return Parameter._serializer.schema(self_or_cls, safe=safe, subset=subset)
 
     def get_param_values(self_,onlychanged=False):
         """

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -735,13 +735,15 @@ class Parameter(object):
 
 
     def _serialize(self, value):
-        return JSONSerialization.serialize(self.__class__.__name__, value)
+        "Given the parameter value, return a Python value suitable for serialization"
+        return value
 
-    def _deserialize(self, string):
-        return JSONSerialization.deserialize(self.__class__.__name__, string)
+    def _deserialize(self, value):
+        "Given a serializable Python value, return a value that the parameter can be set to"
+        return value
 
     def _schema(self, safe=False):
-        return JSONSerialization.parameter_schema(self.__class__.__name__, self, safe=safe)
+        return self._serializer.parameter_schema(self.__class__.__name__, self, safe=safe)
 
     @property
     def label(self):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1596,12 +1596,16 @@ class Parameters(object):
 
     def serialize_parameters(self_, subset=None, mode='json'):
         self_or_cls = self_.self_or_cls
-
         if mode not in Parameter._serializers:
            raise KeyError('Mode %r not in available serialization formats %r'
                           % (mode, list(Parameter._serializers.keys())))
         serializer = Parameter._serializers[mode]
         return serializer.serialize_parameters(self_or_cls, subset=subset)
+
+    def deserialize_parameters(self_, serialization, subset=None, mode='json'):
+       self_or_cls = self_.self_or_cls
+       serializer = Parameter._serializers[mode]
+       return serializer.deserialize_parameters(self_or_cls, serialization, subset=subset)
 
     def schema(self_, safe=False, subset=None, mode='json'):
         self_or_cls = self_.self_or_cls

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -741,8 +741,8 @@ class Parameter(object):
     def _deserialize(self, string):
         return JSONSerialization.deserialize(self.__class__.__name__, string)
 
-    def _schema(self):
-        return JSONSerialization.parameter_schema(self.__class__.__name__, self)
+    def _schema(self, safe=False):
+        return JSONSerialization.parameter_schema(self.__class__.__name__, self, safe=safe)
 
     @property
     def label(self):
@@ -1583,9 +1583,9 @@ class Parameters(object):
         self_or_cls = self_.self_or_cls
         return Parameter._serializer.serialize_parameters(self_or_cls)
 
-    def schema(self_):
+    def schema(self_, safe=False):
         self_or_cls = self_.self_or_cls
-        return Parameter._serializer.schema(self_or_cls)
+        return Parameter._serializer.schema(self_or_cls, safe=safe)
 
     def get_param_values(self_,onlychanged=False):
         """

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -10,7 +10,13 @@ import inspect
 import random
 import numbers
 import operator
-from .serializer import JSONSerialization
+
+# Allow this file to be used standalone if desired, albeit without JSON serialization
+try:
+   from .serializer import JSONSerialization
+except ImportError:
+   JSONSerialization = None
+
 
 from collections import defaultdict, namedtuple, OrderedDict
 from operator import itemgetter,attrgetter
@@ -745,6 +751,8 @@ class Parameter(object):
         return value
 
     def schema(self, safe=False):
+        if self._serializer is None:
+            raise ImportError('Cannot import serializer.py needed to generate schema')
         return self._serializer.parameter_schema(self.__class__.__name__, self, safe=safe)
 
     @property

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -85,9 +85,11 @@ class JSONSerialization(Serialization):
             raise UnserializableException
         dispatch_method = cls._get_method(ptype, 'schema')
         if dispatch_method:
-            return dispatch_method(p, safe=safe)
+            schema = dispatch_method(p, safe=safe)
         else:
-            return { "type": ptype.lower()}
+            schema = { "type": ptype.lower()}
+
+        return JSONNullable(schema) if p.allow_None else schema
 
     # Custom Schemas
 
@@ -110,8 +112,7 @@ class JSONSerialization(Serialization):
             if high is not None:
                 key = 'maximum' if p.inclusive_bounds[0] else 'exclusiveMaximum'
                 schema[key] = high
-
-        return JSONNullable(schema) if p.allow_None else schema
+        return schema
 
     @classmethod
     def integer_schema(cls, p, safe=False):

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -56,7 +56,7 @@ class JSONSerialization(Serialization):
     def schema(cls, pobj, safe=False):
         schema = {}
         for name, p in pobj.param.objects('existing').items():
-            schema[name] = p._schema(safe=safe)
+            schema[name] = p.schema(safe=safe)
             if p.doc:
                 schema[name]["description"] = p.doc.strip()
             if p.label:
@@ -68,7 +68,7 @@ class JSONSerialization(Serialization):
         components = {}
         for name, p in pobj.param.objects('existing').items():
             value = pobj.param.get_value_generator(name)
-            serializable_value = p._serialize(value)
+            serializable_value = p.serialize(value)
             components[name] = json.dumps(serializable_value, cls=ParamJSONEncoder)
 
         contents = ', '.join('"%s":%s' % (name, sval) for name, sval in components.items())

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -106,6 +106,14 @@ class JSONSerialization(Serialization):
     # Custom Schemas
 
     @classmethod
+    def dict_schema(cls, p, safe=False):
+        if safe is True:
+            msg = ('Dict is not guaranteed to be safe for '
+                   'serialization as the key and value types are unknown')
+            raise UnsafeserializableException(msg)
+        return { "type": "object"}
+
+    @classmethod
     def date_schema(cls, p, safe=False):
         return { "type": "string", "format": "date-time"}
 

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -71,6 +71,18 @@ class JSONSerialization(Serialization):
         contents = ', '.join('"%s":%s' % (name, sval) for name, sval in components.items())
         return '{{{contents}}}'.format(contents=contents)
 
+
+    @classmethod
+    def deserialize_parameters(cls, pobj, serialization, subset=None):
+        components = {}
+        for name, value in serialization.items():
+            if subset is not None and name not in subset:
+                continue
+            deserialized = pobj.param[name].deserialize(value)
+            components[name] = deserialized
+
+        return components
+
     # Parameter level methods
 
     @classmethod

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -69,7 +69,7 @@ class JSONSerialization(Serialization):
         for name, p in pobj.param.objects('existing').items():
             value = pobj.param.get_value_generator(name)
             serializable_value = p._serialize(value)
-            components[name] = json.dumps(value, cls=ParamJSONEncoder)
+            components[name] = json.dumps(serializable_value, cls=ParamJSONEncoder)
 
         contents = ', '.join('"%s":%s' % (name, sval) for name, sval in components.items())
         return '{{{contents}}}'.format(contents=contents)

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -48,7 +48,8 @@ class JSONSerialization(Serialization):
 
     unserializable_parameter_types = ['Callable']
 
-    json_schema_literal_types = {int:'integer', float:'number', str:'string'}
+    json_schema_literal_types = {int:'integer', float:'number', str:'string',
+                                 type(None):'null'}
 
 
     @classmethod
@@ -157,3 +158,18 @@ class JSONSerialization(Serialization):
         if p.class_ is not None and p.class_ in cls.json_schema_literal_types:
             schema['items'] = {"type": cls.json_schema_literal_types[p.class_]}
         return schema
+
+    @classmethod
+    def objectselector_schema(cls, p, safe=False):
+        try:
+            allowed_types = [{'type': cls.json_schema_literal_types[type(obj)]}
+                             for obj in p.objects]
+            schema =  { "anyOf": allowed_types}
+            schema['enum'] = p.objects
+            return schema
+        except:
+            if safe is True:
+                msg = ('ObjectSelector cannot be guaranteed to be safe for '
+                       'serialization due to unserializable type in objects')
+                raise UnsafeserializableException(msg)
+            return {}

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -106,6 +106,13 @@ class JSONSerialization(Serialization):
     # Custom Schemas
 
     @classmethod
+    def array_schema(cls, p, safe=False):
+        if safe is True:
+            msg = ('Array is not guaranteed to be safe for '
+                   'serialization as the dtype is unknown')
+        return { "type": "array"}
+
+    @classmethod
     def dict_schema(cls, p, safe=False):
         if safe is True:
             msg = ('Dict is not guaranteed to be safe for '

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -4,7 +4,6 @@ Parameterized objects.
 """
 
 import json
-import datetime as dt
 
 class UnserializableException(Exception):
     pass

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -179,3 +179,46 @@ class JSONSerialization(Serialization):
                 msg = "ListSelector cannot serialize type %s" % type(obj)
                 raise UnserializableException(msg)
         return {'type': 'array', 'items':{'enum':p.objects}}
+
+
+    @classmethod
+    def dataframe_schema(cls, p, safe=False):
+        schema = {'type': 'array'}
+        if safe is True:
+            msg = ('DataFrame is not guaranteed to be safe for '
+                   'serialization as the column dtypes are unknown')
+        if p.columns is None:
+            schema['items'] = {'type': 'object'}
+            return schema
+
+        mincols, maxcols = None, None
+        if isinstance(p.columns, int):
+            mincols, maxcols = p.columns, p.columns
+        elif isinstance(p.columns, tuple):
+            mincols, maxcols = p.columns
+
+        if isinstance(p.columns, int) or isinstance(p.columns, tuple):
+            schema['items'] =  {'type': 'object',
+                                'minItems': mincols,
+                                'maxItems': maxcols}
+
+        if isinstance(p.columns, list) or isinstance(p.columns, set):
+            literal_types = [{'type':el} for el in cls.json_schema_literal_types.values()]
+            allowable_types = {"anyOf": literal_types}
+            properties = {name: allowable_types for name in p.columns}
+            schema['items'] =  {'type': 'object',
+                                'properties' : properties }
+
+
+        minrows, maxrows = None, None
+        if isinstance(p.rows, int):
+            minrows, maxrows = p.rows, p.rows
+        elif isinstance(p.rows, tuple):
+            minrows, maxrows = p.rows
+
+        if minrows is not None:
+            schema['minItems'] = minrows
+        if maxrows is not None:
+            schema['maxItems'] = maxrows
+
+        return schema

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -58,6 +58,8 @@ class JSONSerialization(Serialization):
             schema[name] = p._schema(safe=safe)
             if p.doc:
                 schema[name]["description"] = p.doc.strip()
+            if p.label:
+                schema[name]["title"] = p.label
         return schema
 
     @classmethod

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -65,7 +65,7 @@ class JSONSerialization(Serialization):
             if subset is not None and name not in subset:
                 continue
             value = pobj.param.get_value_generator(name)
-            serializable_value = p.serialize(value)
+            serializable_value = p.ir_serialize(value)
             components[name] = json.dumps(serializable_value)
 
         contents = ', '.join('"%s":%s' % (name, sval) for name, sval in components.items())
@@ -78,7 +78,7 @@ class JSONSerialization(Serialization):
         for name, value in serialization.items():
             if subset is not None and name not in subset:
                 continue
-            deserialized = pobj.param[name].deserialize(value)
+            deserialized = pobj.param[name].ir_deserialize(value)
             components[name] = deserialized
 
         return components

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -32,12 +32,6 @@ class Serialization(object):
         raise NotImplementedError
 
 
-class ParamJSONEncoder(json.JSONEncoder):
-    "Custom encoder used to support more value types than vanilla JSON"
-    def default(self, obj):
-        if isinstance(obj, dt.datetime):
-            return obj.replace(microsecond=0).isoformat()
-        return json.JSONEncoder.default(self, obj)
 
 class JSONSerialization(Serialization):
     """
@@ -69,7 +63,7 @@ class JSONSerialization(Serialization):
         for name, p in pobj.param.objects('existing').items():
             value = pobj.param.get_value_generator(name)
             serializable_value = p.serialize(value)
-            components[name] = json.dumps(serializable_value, cls=ParamJSONEncoder)
+            components[name] = json.dumps(serializable_value)
 
         contents = ', '.join('"%s":%s' % (name, sval) for name, sval in components.items())
         return '{{{contents}}}'.format(contents=contents)

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -4,7 +4,7 @@ Parameterized objects.
 """
 
 import json
-
+import datetime as dt
 
 class UnserializableException(Exception):
     pass
@@ -57,7 +57,6 @@ class JSONSerialization(Serialization):
     @classmethod
     def serialize_parameters(cls, pobj):
         components = {}
-        json_string = ''
         for name, p in pobj.param.objects('existing').items():
             value = pobj.param.get_value_generator(name)
             components[name] = p._serialize(value)
@@ -95,7 +94,7 @@ class JSONSerialization(Serialization):
     def deserialize(cls, ptype, string):
         dispatch_method = cls._get_method(ptype, 'deserialize')
         if dispatch_method:
-            return dispatch_method(value)
+            return dispatch_method(string)
         else:
             return json.loads(string)
 

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -187,6 +187,7 @@ class JSONSerialization(Serialization):
         if safe is True:
             msg = ('DataFrame is not guaranteed to be safe for '
                    'serialization as the column dtypes are unknown')
+            raise UnsafeserializableException(msg)
         if p.columns is None:
             schema['items'] = {'type': 'object'}
             return schema

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -23,11 +23,11 @@ class Serialization(object):
     """
 
     @classmethod
-    def schema(cls, pobj):
+    def schema(cls, pobj, subset=None):
         raise NotImplementedError
 
     @classmethod
-    def serialize_parameters(cls, pobj):
+    def serialize_parameters(cls, pobj, subset=None):
         raise NotImplementedError
 
 
@@ -46,9 +46,11 @@ class JSONSerialization(Serialization):
 
 
     @classmethod
-    def schema(cls, pobj, safe=False):
+    def schema(cls, pobj, safe=False, subset=None):
         schema = {}
         for name, p in pobj.param.objects('existing').items():
+            if subset is not None and name not in subset:
+                continue
             schema[name] = p.schema(safe=safe)
             if p.doc:
                 schema[name]["description"] = p.doc.strip()
@@ -57,9 +59,11 @@ class JSONSerialization(Serialization):
         return schema
 
     @classmethod
-    def serialize_parameters(cls, pobj):
+    def serialize_parameters(cls, pobj, subset=None):
         components = {}
         for name, p in pobj.param.objects('existing').items():
+            if subset is not None and name not in subset:
+                continue
             value = pobj.param.get_value_generator(name)
             serializable_value = p.serialize(value)
             components[name] = json.dumps(serializable_value)
@@ -76,7 +80,7 @@ class JSONSerialization(Serialization):
         return getattr(cls, method_name, None)
 
     @classmethod
-    def parameter_schema(cls, ptype, p, safe=False):
+    def parameter_schema(cls, ptype, p, safe=False, subset=None):
         if ptype in cls.unserializable_parameter_types:
             raise UnserializableException
         dispatch_method = cls._get_method(ptype, 'schema')

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -65,7 +65,7 @@ class JSONSerialization(Serialization):
             if subset is not None and name not in subset:
                 continue
             value = pobj.param.get_value_generator(name)
-            serializable_value = p.ir_serialize(value)
+            serializable_value = p.serialize(value)
             components[name] = json.dumps(serializable_value)
 
         contents = ', '.join('"%s":%s' % (name, sval) for name, sval in components.items())
@@ -78,7 +78,7 @@ class JSONSerialization(Serialization):
         for name, value in serialization.items():
             if subset is not None and name not in subset:
                 continue
-            deserialized = pobj.param[name].ir_deserialize(value)
+            deserialized = pobj.param[name].deserialize(value)
             components[name] = deserialized
 
         return components

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -110,6 +110,7 @@ class JSONSerialization(Serialization):
         if safe is True:
             msg = ('Array is not guaranteed to be safe for '
                    'serialization as the dtype is unknown')
+            raise UnsafeserializableException(msg)
         return { "type": "array"}
 
     @classmethod

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -14,7 +14,23 @@ def JSONNullable(json_type):
     return { "anyOf": [ json_type, { "type": "null"}] }
 
 
-class JSONSerialization(object):
+
+class Serialization(object):
+    """
+    Base class used to implement different types of serialization.
+    """
+
+    @classmethod
+    def schema(cls, pobj):
+        raise NotImplementedError
+
+    @classmethod
+    def serialize_parameters(cls, pobj):
+        raise NotImplementedError
+
+
+
+class JSONSerialization(Serialization):
     """
     Class responsible for specifying JSON serialization, deserialization
     and JSON schemas for Parameters and Parameterized classes and

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -118,6 +118,10 @@ class JSONSerialization(Serialization):
         return { "type": "string", "format": "date-time"}
 
     @classmethod
+    def calendardate_schema(cls, p, safe=False):
+        return { "type": "string", "format": "date"}
+
+    @classmethod
     def tuple_schema(cls, p, safe=False):
         schema = { "type": "array"}
         if p.length is not None:

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -1,0 +1,154 @@
+"""
+Classes used to support string serialization of Parameters and
+Parameterized objects.
+"""
+
+import json
+
+
+class UnserializableException(Exception):
+    pass
+
+def JSONNullable(json_type):
+    "Express a JSON schema type as nullable to easily support Parameters that allow_None"
+    return { "anyOf": [ json_type, { "type": "null"}] }
+
+
+class JSONSerialization(object):
+    """
+    Class responsible for specifying JSON serialization, deserialization
+    and JSON schemas for Parameters and Parameterized classes and
+    objects.
+    """
+
+    unserializable_parameter_types = ['Callable']
+
+    json_schema_literal_types = {int:'integer', float:'number', str:'string'}
+
+
+    @classmethod
+    def schema(cls, pobj):
+        schema = {}
+        for name, p in pobj.param.objects('existing').items():
+            schema[name] = p._schema()
+            if p.doc:
+                schema[name]["description"] = p.doc.strip()
+        return schema
+
+    @classmethod
+    def serialize_parameters(cls, pobj):
+        components = {}
+        json_string = ''
+        for name, p in pobj.param.objects('existing').items():
+            value = pobj.param.get_value_generator(name)
+            components[name] = p._serialize(value)
+
+        contents = ', '.join('"%s":%s' % (name, sval) for name, sval in components.items())
+        return '{{{contents}}}'.format(contents=contents)
+
+    # Parameter level methods
+
+    @classmethod
+    def _get_method(cls, ptype, suffix):
+        "Returns specialized method if available, otherwise None"
+        method_name = ptype.lower()+'_' + suffix
+        return getattr(cls, method_name, None)
+
+    @classmethod
+    def parameter_schema(cls, ptype, p):
+        if ptype in cls.unserializable_parameter_types:
+            raise UnserializableException
+        dispatch_method = cls._get_method(ptype, 'schema')
+        if dispatch_method:
+            return dispatch_method(p)
+        else:
+            return { "type": ptype.lower()}
+
+    @classmethod
+    def serialize(cls, ptype, value):
+        dispatch_method = cls._get_method(ptype, 'serialize')
+        if dispatch_method:
+            return dispatch_method(value)
+        else:
+            return json.dumps(value)
+
+    @classmethod
+    def deserialize(cls, ptype, string):
+        dispatch_method = cls._get_method(ptype, 'deserialize')
+        if dispatch_method:
+            return dispatch_method(value)
+        else:
+            return json.loads(string)
+
+    # Custom Serializers
+
+    @classmethod
+    def date_serialize(cls, value):
+        string = value.replace(microsecond=0).isoformat() # Test *with* microseconds.
+        return json.dumps(string)
+
+    # Custom Deserializers
+
+    @classmethod
+    def date_deserialize(cls, string):
+        return dt.datetime.fromisoformat(string)  # FIX: 3.7+ only
+
+    @classmethod
+    def tuple_deserialize(cls, string):
+        return tuple(json.loads(string))
+
+    # Custom Schemas
+
+    @classmethod
+    def date_schema(cls, p):
+        return { "type": "string", "format": "date-time"}
+
+    @classmethod
+    def tuple_schema(cls, p):
+        return { "type": "array"}
+
+    @classmethod
+    def number_schema(cls, p):
+        schema = { "type": p.__class__.__name__.lower() }
+        if p.bounds is not None:
+            (low, high) = p.bounds
+            if low is not None:
+                key = 'minimum' if p.inclusive_bounds[0] else 'exclusiveMinimum'
+                schema[key] = low
+            if high is not None:
+                key = 'maximum' if p.inclusive_bounds[0] else 'exclusiveMaximum'
+                schema[key] = high
+
+        return JSONNullable(schema) if p.allow_None else schema
+
+    @classmethod
+    def integer_schema(cls, p):
+        return cls.number_schema(p)
+
+    @classmethod
+    def numerictuple_schema(cls, p):
+        return {"type": "array",
+                "additionalItems": { "type": "number" }}
+
+    @classmethod
+    def xycoordinates_schema(cls, p):
+        return  {
+            "type": "array",
+            "items": [
+                {"type": "number"}, {"type": "number"}],
+            "additionalItems": False
+        }
+
+    @classmethod
+    def range_schema(cls, p):
+        return  {
+            "type": "array",
+            "items": [{"type": "number"},{"type": "number"}],
+        }
+
+    @classmethod
+    def list_schema(cls, p):
+        schema =  { "type": "array"}
+        if p.class_ is not None and p.class_ in cls.json_schema_literal_types:
+            schema['items'] = {"type": cls.json_schema_literal_types[p.class_]}
+        return schema

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -24,11 +24,11 @@ class Serialization(object):
 
     @classmethod
     def schema(cls, pobj, subset=None):
-        raise NotImplementedError
+        raise NotImplementedError        # noqa: unimplemented method
 
     @classmethod
     def serialize_parameters(cls, pobj, subset=None):
-        raise NotImplementedError
+        raise NotImplementedError        # noqa: unimplemented method
 
 
 

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -99,7 +99,11 @@ class JSONSerialization(Serialization):
 
     @classmethod
     def tuple_schema(cls, p, safe=False):
-        return { "type": "array"}
+        schema = { "type": "array"}
+        if p.length is not None:
+            schema['minItems'] =  p.length
+            schema['maxItems'] =  p.length
+        return schema
 
     @classmethod
     def number_schema(cls, p, safe=False):
@@ -120,26 +124,17 @@ class JSONSerialization(Serialization):
 
     @classmethod
     def numerictuple_schema(cls, p, safe=False):
-        return {"type": "array",
-                "additionalItems": { "type": "number" }}
+        schema = cls.tuple_schema(p, safe=safe)
+        schema["additionalItems"] = { "type": "number" }
+        return schema
 
     @classmethod
     def xycoordinates_schema(cls, p, safe=False):
-        return  {
-            "type": "array",
-            "items": [
-                {"type": "number"}, {"type": "number"}],
-            "additionalItems": False
-        }
+        return cls.numerictuple_schema(p, safe=safe)
 
     @classmethod
     def range_schema(cls, p, safe=False):
-        # Extend for allow None
-        return  {
-            "type": "array",
-            "items": [{"type": "number"},{"type": "number"}],
-            #"additionalItems": "false"
-        }
+        return cls.numerictuple_schema(p, safe=safe)
 
     @classmethod
     def list_schema(cls, p, safe=False):

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -173,3 +173,16 @@ class JSONSerialization(Serialization):
                        'serialization due to unserializable type in objects')
                 raise UnsafeserializableException(msg)
             return {}
+
+    @classmethod
+    def listselector_schema(cls, p, safe=False):
+        if p.objects is None:
+            if safe is True:
+                msg = ('ListSelector cannot be guaranteed to be safe for '
+                       'serialization as allowed objects unspecified')
+            return {'type': 'array'}
+        for obj in p.objects:
+            if type(obj) not in cls.json_schema_literal_types:
+                msg = "ListSelector cannot serialize type %s" % type(obj)
+                raise UnserializableException(msg)
+        return {'type': 'array', 'items':{'enum':p.objects}}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ extras_require = {
         'nose',
         'flake8',
         'jsonschema',
-        'pandas'
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ extras_require = {
     # (https://github.com/pypa/pip/issues/1197)
     'tests': [
         'nose',
-        'flake8'
+        'flake8',
+        'jsonschema',
+        'pandas'
     ]
 }
 

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -57,6 +57,7 @@ class TestSet(param.Parameterized):
     t = None if pd is None else param.DataFrame(default=pd.DataFrame(
         {'A':[1,2,3], 'B':[1.1,2.2,3.3]}), columns=(1,4), rows=(2,5))
     u = None if pd is None else param.DataFrame(default=df2, columns=['A', 'B'])
+    v = param.Dict({'1':2})
 
 
 test = TestSet(a=29)

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -95,10 +95,7 @@ class TestJSONSerialization(API1TestCase):
             json_loaded = json.loads(serialization)
             deserialized_values = test.param.deserialize_parameters(json_loaded)
             deserialized_value = deserialized_values[param_name]
-            if isinstance(original_value, pd.DataFrame):
-                self.assertEqual(original_value.equals(deserialized_value), True)
-            else:
-                self.assertEqual(original_value, deserialized_value)
+            self.assertEqual(original_value, deserialized_value)
 
 
     def test_class_instance_schemas_match_and_validate_unsafe(self):

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -29,6 +29,7 @@ class TestSet(param.Parameterized):
     l = param.String(default='baz', allow_None=True)
     m = param.ObjectSelector(default=3, objects=[3,'foo'], allow_None=False)
     n = param.ListSelector(default=[1,4,5], objects=[1,2,3,4,5,6])
+    o = param.CalendarDate(default=datetime.date.today())
 
 
 test = TestSet(a=29)

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -13,6 +13,15 @@ try:
 except ImportError:
     validate = None
 
+try:
+    import numpy as np
+    ndarray = np.array([[1,2,3],[4,5,6]])
+except:
+    np = None
+    ndarray =  None
+
+
+
 
 class TestSet(param.Parameterized):
     a = param.Integer(default=5, doc='Example doc', bounds=(2,30), inclusive_bounds=(True, False))
@@ -30,6 +39,7 @@ class TestSet(param.Parameterized):
     m = param.ObjectSelector(default=3, objects=[3,'foo'], allow_None=False)
     n = param.ListSelector(default=[1,4,5], objects=[1,2,3,4,5,6])
     o = param.CalendarDate(default=datetime.date.today())
+    p = param.Array(default=ndarray)
 
 
 test = TestSet(a=29)
@@ -96,7 +106,10 @@ class TestJSONSerialization(API1TestCase):
             json_loaded = json.loads(serialization)
             deserialized_values = test.param.deserialize_parameters(json_loaded)
             deserialized_value = deserialized_values[param_name]
-            self.assertEqual(original_value, deserialized_value)
+            if (np is not None) and isinstance(original_value, np.ndarray):
+                self.assertEqual(np.array_equal(original_value, deserialized_value), True)
+            else:
+                self.assertEqual(original_value, deserialized_value)
 
 
     def test_class_instance_schemas_match_and_validate_unsafe(self):

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -111,7 +111,10 @@ class TestJSONSerialization(API1TestCase):
         validate(instance=serialized, schema=schema)
 
     def test_instance_serialization(self):
+        excluded = test.numpy_params + test.pandas_params
         for param_name in list(test.param):
+            if param_name in excluded:
+                continue
             original_value = getattr(test, param_name)
             serialization = test.param.serialize_parameters(subset=[param_name], mode='json')
             json_loaded = json.loads(serialization)

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -32,6 +32,7 @@ class TestSet(param.Parameterized):
 
     numpy_params = ['p']
     pandas_params = ['q','r','s']
+    always_unsafe = numpy_params + pandas_params
 
     a = param.Integer(default=5, doc='Example doc', bounds=(2,30), inclusive_bounds=(True, False))
     b = param.Number(default=4.3, allow_None=True)
@@ -160,3 +161,11 @@ class TestJSONSerialization(API1TestCase):
 
             class_serialization_val = TestSet.param.serialize_parameters(subset=[param_name])
             validate(instance=class_serialization_val, schema=class_schema)
+
+    def test_class_instance_schemas_match_and_validate_always_unsafe(self):
+        if validate is None:
+            raise SkipTest('jsonschema needed for schema validation testing')
+
+        for param_name in test.always_unsafe:
+            with self.assertRaisesRegexp(param.serializer.UnsafeserializableException,''):
+                test.param.schema(safe=True, subset=[param_name], mode='json')

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -99,6 +99,9 @@ class TestJSONSerialization(API1TestCase):
 
 
     def test_class_instance_schemas_match_and_validate_unsafe(self):
+        if validate is None:
+            raise SkipTest('jsonschema needed for schema validation testing')
+
         for param_name in list(test.param):
             class_schema = TestSet.param.schema(safe=False, subset=[param_name], mode='json')
             instance_schema = test.param.schema(safe=False, subset=[param_name], mode='json')

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -27,32 +27,36 @@ except:
     pd, df1, df2 = None, None, None
 
 
+simple_list = [1]
 
 class TestSet(param.Parameterized):
 
-    numpy_params = ['p']
-    pandas_params = ['q','r','s']
+    numpy_params = ['r']
+    pandas_params = ['s','t','u']
+    conditionally_unsafe = ['f', 'o']
 
     a = param.Integer(default=5, doc='Example doc', bounds=(2,30), inclusive_bounds=(True, False))
     b = param.Number(default=4.3, allow_None=True)
     c = param.String(default='foo')
     d = param.Boolean(default=False)
     e = param.List([1,2,3], class_=int)
-    f = param.Date(default=datetime.datetime.now())
-    g = param.Tuple(default=(1,2,3), length=3)
-    h = param.NumericTuple(default=(1,2,3,4))
-    i = param.XYCoordinates(default=(32.1, 51.5))
-    j = param.Integer(default=1)
-    k = param.Range(default=(1.1,2.3), bounds=(1,3))
-    l = param.String(default='baz', allow_None=True)
-    m = param.ObjectSelector(default=3, objects=[3,'foo'], allow_None=False)
-    n = param.ListSelector(default=[1,4,5], objects=[1,2,3,4,5,6])
-    o = param.CalendarDate(default=datetime.date.today())
-    p = None if np is None else param.Array(default=ndarray)
-    q = None if pd is None else param.DataFrame(default=df1, columns=2)
-    r = None if pd is None else param.DataFrame(default=pd.DataFrame(
+    f = param.List([1,2,3])
+    g = param.Date(default=datetime.datetime.now())
+    h = param.Tuple(default=(1,2,3), length=3)
+    i = param.NumericTuple(default=(1,2,3,4))
+    j = param.XYCoordinates(default=(32.1, 51.5))
+    k = param.Integer(default=1)
+    l = param.Range(default=(1.1,2.3), bounds=(1,3))
+    m = param.String(default='baz', allow_None=True)
+    n = param.ObjectSelector(default=3, objects=[3,'foo'], allow_None=False)
+    o = param.ObjectSelector(default=simple_list, objects=[simple_list], allow_None=False)
+    p = param.ListSelector(default=[1,4,5], objects=[1,2,3,4,5,6])
+    q = param.CalendarDate(default=datetime.date.today())
+    r = None if np is None else param.Array(default=ndarray)
+    s = None if pd is None else param.DataFrame(default=df1, columns=2)
+    t = None if pd is None else param.DataFrame(default=pd.DataFrame(
         {'A':[1,2,3], 'B':[1.1,2.2,3.3]}), columns=(1,4), rows=(2,5))
-    s = None if pd is None else param.DataFrame(default=df2, columns=['A', 'B'])
+    u = None if pd is None else param.DataFrame(default=df2, columns=['A', 'B'])
 
 
 test = TestSet(a=29)
@@ -177,3 +181,8 @@ class TestJSONSerialization(API1TestCase):
             class_serialization_val = TestSet.param.serialize_parameters(subset=[param_name])
             validate(instance=class_serialization_val, schema=class_schema)
 
+
+    def test_conditionally_unsafe(self):
+        for param_name in test.conditionally_unsafe:
+            with self.assertRaisesRegexp(param.serializer.UnsafeserializableException,''):
+                test.param.schema(safe=True, subset=[param_name], mode='json')

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -1,0 +1,125 @@
+"""
+Testing JSON serialization of parameters and the corresponding schemas.
+"""
+
+import json
+import datetime
+import param
+from unittest import SkipTest
+from . import API1TestCase
+
+try:
+    from jsonschema import validate, ValidationError
+except ImportError:
+    validate = None
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
+
+class TestSet(param.Parameterized):
+    a = param.Integer(default=5, doc='Example doc', bounds=(2,30), inclusive_bounds=(True, False))
+    b = param.Number(default=4.3, allow_None=True)
+    c = param.String(default='foo')
+    d = param.Boolean(default=False)
+    e = param.List([1,2,3], class_=int)
+    f = param.Date(default=datetime.datetime.now())
+    g = param.Tuple(default=(1,2,3), length=3)
+    h = param.NumericTuple(default=(1,2,3,4))
+    i = param.XYCoordinates(default=(32.1, 51.5))
+    j = param.Integer(default=1)
+    k = param.Range(default=(1.1,2.3), bounds=(1,3))
+    l = param.String(default='baz', allow_None=True)
+    m = param.ObjectSelector(default=3, objects=[3,'foo'], allow_None=False)
+    n = param.ListSelector(default=[1,4,5], objects=[1,2,3,4,5,6])
+    o = param.DataFrame(default=pd.DataFrame({'A':[1.,2.,3.], 'B':[1.1,2.2,3.3]}), columns=2)
+    p = param.DataFrame(default=pd.DataFrame({'A':[1.,2.,3.], 'B':[1.1,2.2,3.3]}), columns=(1,4), rows=(2,5))
+    q = param.DataFrame(default=pd.DataFrame({'A':[1.1,2.2,3.3],
+                                              'B':[1.1,2.2,3.3]}), columns=['A', 'B'])
+
+test = TestSet(a=29)
+
+
+class TestJSONSerialization(API1TestCase):
+
+    def test_serialize_integer_class(self):
+        serialization = TestSet.param.serialize_parameters(subset=['a'], mode='json')
+        deserialized = json.loads(serialization)
+        self.assertEqual(TestSet.a, 5)
+        self.assertEqual(deserialized, {'a':TestSet.a})
+
+    def test_serialize_integer_instance(self):
+        serialization = test.param.serialize_parameters(subset=['a'], mode='json')
+        deserialized = json.loads(serialization)
+        self.assertEqual(test.a, 29)
+        self.assertEqual(deserialized, {'a':test.a})
+
+    def test_serialize_integer_schema_class(self):
+        if validate is None:
+            raise SkipTest('jsonschema needed for schema validation testing')
+        param_schema = TestSet.param.schema(safe=True, subset=['a'], mode='json')
+        schema = {"type" : "object", "properties" : param_schema}
+        serialized = json.loads(TestSet.param.serialize_parameters(subset=['a']))
+        self.assertEqual({'a':
+                          {'type': 'integer', 'minimum': 2, 'exclusiveMaximum': 30,
+                           'description': 'Example doc', 'title': 'A'}},
+                         param_schema)
+        validate(instance=serialized, schema=schema)
+
+    def test_serialize_integer_schema_class_invalid(self):
+        if validate is None:
+            raise SkipTest('jsonschema needed for schema validation testing')
+        param_schema = TestSet.param.schema(safe=True, subset=['a'], mode='json')
+        schema = {"type" : "object", "properties" : param_schema}
+        serialized = json.loads(TestSet.param.serialize_parameters(subset=['a']))
+        self.assertEqual({'a':
+                          {'type': 'integer', 'minimum': 2, 'exclusiveMaximum': 30,
+                           'description': 'Example doc', 'title': 'A'}},
+                         param_schema)
+
+        exception = "1 is not of type 'object'"
+        with self.assertRaisesRegexp(ValidationError, exception):
+            validate(instance=1, schema=schema)
+
+
+    def test_serialize_integer_schema_instance(self):
+        if validate is None:
+            raise SkipTest('jsonschema needed for schema validation testing')
+        param_schema = test.param.schema(safe=True, subset=['a'], mode='json')
+        schema = {"type" : "object", "properties" : param_schema}
+        serialized = json.loads(test.param.serialize_parameters(subset=['a']))
+        self.assertEqual({'a':
+                          {'type': 'integer', 'minimum': 2, 'exclusiveMaximum': 30,
+                           'description': 'Example doc', 'title': 'A'}},
+                         param_schema)
+        validate(instance=serialized, schema=schema)
+
+
+    def test_instance_serialization(self):
+        param_names = [el for el in test.param if el != 'name']
+        for param_name in param_names:
+            original_value = getattr(test, param_name)
+            serialization = test.param.serialize_parameters(subset=[param_name], mode='json')
+            json_loaded = json.loads(serialization)
+            deserialized_values = test.param.deserialize_parameters(json_loaded)
+            deserialized_value = deserialized_values[param_name]
+            if isinstance(original_value, pd.DataFrame):
+                self.assertEqual(original_value.equals(deserialized_value), True)
+            else:
+                self.assertEqual(original_value, deserialized_value)
+
+
+    def test_class_instance_schemas_match_and_validate_unsafe(self):
+        param_names = [el for el in test.param if el != 'name']
+        for param_name in param_names:
+            class_schema = TestSet.param.schema(safe=False, subset=[param_name], mode='json')
+            instance_schema = test.param.schema(safe=False, subset=[param_name], mode='json')
+            self.assertEqual(class_schema, instance_schema)
+
+            instance_serialization_val = test.param.serialize_parameters(subset=[param_name])
+            validate(instance=instance_serialization_val, schema=class_schema)
+
+            class_serialization_val = TestSet.param.serialize_parameters(subset=[param_name])
+            validate(instance=class_serialization_val, schema=class_schema)

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -13,11 +13,6 @@ try:
 except ImportError:
     validate = None
 
-try:
-    import pandas as pd
-except ImportError:
-    pd = None
-
 
 class TestSet(param.Parameterized):
     a = param.Integer(default=5, doc='Example doc', bounds=(2,30), inclusive_bounds=(True, False))
@@ -35,15 +30,6 @@ class TestSet(param.Parameterized):
     m = param.ObjectSelector(default=3, objects=[3,'foo'], allow_None=False)
     n = param.ListSelector(default=[1,4,5], objects=[1,2,3,4,5,6])
 
-
-df1 = None if (pd is None) else pd.DataFrame({'A':[1,2,3], 'B':[1.1,2.2,3.3]})
-df2 = None if (pd is None) else pd.DataFrame({'A':[1.1,2.2,3.3],
-                                              'B':[1.1,2.2,3.3]})
-
-class PandasSet(param.Parameterized):
-    o = param.DataFrame(default=df1, columns=2, allow_None=True)
-    p = param.DataFrame(default=df1, columns=(1,4), rows=(2,5), allow_None=True)
-    q = param.DataFrame(default=df2, columns=['A', 'B'], allow_None=True)
 
 test = TestSet(a=29)
 

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -98,8 +98,7 @@ class TestJSONSerialization(API1TestCase):
 
 
     def test_instance_serialization(self):
-        param_names = [el for el in test.param if el != 'name']
-        for param_name in param_names:
+        for param_name in list(test.param):
             original_value = getattr(test, param_name)
             serialization = test.param.serialize_parameters(subset=[param_name], mode='json')
             json_loaded = json.loads(serialization)
@@ -112,8 +111,7 @@ class TestJSONSerialization(API1TestCase):
 
 
     def test_class_instance_schemas_match_and_validate_unsafe(self):
-        param_names = [el for el in test.param if el != 'name']
-        for param_name in param_names:
+        for param_name in list(test.param):
             class_schema = TestSet.param.schema(safe=False, subset=[param_name], mode='json')
             instance_schema = test.param.schema(safe=False, subset=[param_name], mode='json')
             self.assertEqual(class_schema, instance_schema)

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -73,7 +73,6 @@ class TestJSONSerialization(API1TestCase):
             raise SkipTest('jsonschema needed for schema validation testing')
         param_schema = TestSet.param.schema(safe=True, subset=['a'], mode='json')
         schema = {"type" : "object", "properties" : param_schema}
-        serialized = json.loads(TestSet.param.serialize_parameters(subset=['a']))
         self.assertEqual({'a':
                           {'type': 'integer', 'minimum': 2, 'exclusiveMaximum': 30,
                            'description': 'Example doc', 'title': 'A'}},

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -34,10 +34,16 @@ class TestSet(param.Parameterized):
     l = param.String(default='baz', allow_None=True)
     m = param.ObjectSelector(default=3, objects=[3,'foo'], allow_None=False)
     n = param.ListSelector(default=[1,4,5], objects=[1,2,3,4,5,6])
-    o = param.DataFrame(default=pd.DataFrame({'A':[1.,2.,3.], 'B':[1.1,2.2,3.3]}), columns=2)
-    p = param.DataFrame(default=pd.DataFrame({'A':[1.,2.,3.], 'B':[1.1,2.2,3.3]}), columns=(1,4), rows=(2,5))
-    q = param.DataFrame(default=pd.DataFrame({'A':[1.1,2.2,3.3],
-                                              'B':[1.1,2.2,3.3]}), columns=['A', 'B'])
+
+
+df1 = None if (pd is None) else pd.DataFrame({'A':[1,2,3], 'B':[1.1,2.2,3.3]})
+df2 = None if (pd is None) else pd.DataFrame({'A':[1.1,2.2,3.3],
+                                              'B':[1.1,2.2,3.3]})
+
+class PandasSet(param.Parameterized):
+    o = param.DataFrame(default=df1, columns=2, allow_None=True)
+    p = param.DataFrame(default=df1, columns=(1,4), rows=(2,5), allow_None=True)
+    q = param.DataFrame(default=df2, columns=['A', 'B'], allow_None=True)
 
 test = TestSet(a=29)
 


### PR DESCRIPTION
This PR outlines another attempt at serializing/deserializing to JSON (for reference see
#153 for earlier attempts at tackling this problem). The design used in this PR aims to try to keep things simpler but also adds the ability to generate [JSON Schemas](https://json-schema.org/) which should help with testing as well as specification of allowable parameter values (e.g this could be used to specify suitable widgets in panel).

This PR is based off the ideas suggested in #382.

### TODO:

- [ ] The main open problem is about finding the appropriate API and JSON (and schema) representation for entire parameterized objects (i.e including the class identity as well as all the parameters).