### PR TITLE
add commit message build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ stages:
   - name: conda_package
     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: website_dev
-    if: (tag =~ ^v(\d+|\.)+[a-z]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
+    if: (tag =~ ^v(\d+|\.)+[a|b|rc]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
   - name: website_release
-    if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website) OR (commit_message =~ /^.*(website_release).*$/)
+    if: (tag =~ ^v(\d+|\.)+\d+$) OR (tag = website_release) OR (commit_message =~ /^.*(website_release).*$/)
 
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ stages:
   - name: conda_package
     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: website_dev
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$ OR tag = website_dev
+    if: (tag =~ ^v(\d+|\.)+[a-z]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
   - name: website_release
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ OR tag = website
+    if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website) OR (commit_message =~ /^.*(website_release).*$/)
 
 
 jobs:


### PR DESCRIPTION
This adds support for building dev and release websites with commit messages containing `website_dev` and `website_release` respectively, and building building from tags using `website_release` and `website_dev`, as well as tags of the format `v1.3.1a4` for dev, and `v1.3.1A4` for release.