### PR TITLE
Make copy of watchers dictionary on instance parameters

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1183,7 +1183,7 @@ class Parameters(object):
                 except:
                     raise
                 finally:
-                    p.watchers = watchers
+                    p.watchers = {k: list(v) for k, v in watchers.items()}
                 p.owner = inst
                 inst._instance__params[key] = p
             else:


### PR DESCRIPTION
A horrible bug where instance parameters could potentially share watchers of class parameters causing really strange interactions.