### PR TITLE
Ensure Parameterized.param.objects works with uninitialized object

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1469,7 +1469,7 @@ class Parameters(object):
 
         if instance and self_.self is not None:
             if instance == 'existing':
-                if self_.self._instance__params:
+                if getattr(self_.self, 'initialized', False) and self_.self._instance__params:
                     return dict(pdict, **self_.self._instance__params)
                 return pdict
             else:


### PR DESCRIPTION
Only use `_instance_params` when the class has been initialized.