### PR TITLE
Remove dependency on nose (no explicit dependency on pytest)

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -974,7 +974,7 @@ class String(Parameter):
       class IPAddress(String):
         '''IPv4 address as a string (dotted decimal notation)'''
        def __init__(self, default="0.0.0.0", allow_None=False, **kwargs):
-           ip_regex = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+           ip_regex = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
            super(IPAddress, self).__init__(default=default, regex=ip_regex, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ extras_require = {
     # pip doesn't support tests_require
     # (https://github.com/pypa/pip/issues/1197)
     'tests': [
-        'nose',
         'flake8',
         'jsonschema',
     ]

--- a/tests/API0/testclassselector.py
+++ b/tests/API0/testclassselector.py
@@ -26,7 +26,7 @@ class TestClassSelectorParameters(unittest.TestCase):
 
     def test_single_class_instance_error(self):
         exception = "Parameter 'e' value must be an instance of int, not 'a'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(e='a')
 
     def test_single_class_type_constructor(self):
@@ -35,7 +35,7 @@ class TestClassSelectorParameters(unittest.TestCase):
 
     def test_single_class_type_error(self):
         exception = "Parameter 'str' must be a subclass of Number, not 'type'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(f=str)
 
     def test_multiple_class_instance_constructor1(self):
@@ -47,8 +47,8 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.g, 'A')
 
     def test_multiple_class_instance_error(self):
-        exception = "Parameter 'g' value must be an instance of \(int, str\), not '3.0'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Parameter 'g' value must be an instance of \(int, str\), not '3.0'"
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(g=3.0)
 
     def test_multiple_class_type_constructor1(self):
@@ -60,6 +60,6 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.h, str)
 
     def test_multiple_class_type_error(self):
-        exception = "Parameter 'float' must be a subclass of \(int, str\), not 'type'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Parameter 'float' must be a subclass of \(int, str\), not 'type'"
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(h=float)

--- a/tests/API0/testcompositeparams.py
+++ b/tests/API0/testcompositeparams.py
@@ -94,6 +94,4 @@ class TestCompositeParameters(unittest.TestCase):
         self.assertEqual(iy(), 5)
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API0/testdefaults.py
+++ b/tests/API0/testdefaults.py
@@ -30,7 +30,7 @@ except ImportError:
     skip.append('Series')
 
 
-class _TestDefaultsMetaclass(type):
+class MyTestDefaultsMetaclass(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
@@ -50,6 +50,6 @@ class _TestDefaultsMetaclass(type):
         return type.__new__(mcs, name, bases, dict_)
 
 
-@add_metaclass(_TestDefaultsMetaclass)
+@add_metaclass(MyTestDefaultsMetaclass)
 class TestDefaults(unittest.TestCase):
     pass

--- a/tests/API0/testdefaults.py
+++ b/tests/API0/testdefaults.py
@@ -30,11 +30,11 @@ except ImportError:
     skip.append('Series')
 
 
-class TestDefaultsMetaclass(type):
+class _TestDefaultsMetaclass(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
-            from nose.exc import SkipTest
+            from unittest import SkipTest
             raise SkipTest
 
         def add_test(p):
@@ -50,11 +50,6 @@ class TestDefaultsMetaclass(type):
         return type.__new__(mcs, name, bases, dict_)
 
 
-@add_metaclass(TestDefaultsMetaclass)
+@add_metaclass(_TestDefaultsMetaclass)
 class TestDefaults(unittest.TestCase):
     pass
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testdynamicparams.py
+++ b/tests/API0/testdynamicparams.py
@@ -248,9 +248,7 @@ class TestDynamicSharedNumbergen(TestDynamicParameters):
 
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+
 
 
 # Commented out block in the original doctest version.

--- a/tests/API0/testipythonmagic.py
+++ b/tests/API0/testipythonmagic.py
@@ -43,8 +43,8 @@ class TestParamPager(unittest.TestCase):
     def test_parameterized_class(self):
         page_string = self.pager(self.TestClass)
         # Remove params automatic numbered names
-        page_string = re.sub('TestClass(\d+)', 'TestClass', page_string)
-        ref_string = re.sub('TestClass(\d+)', 'TestClass', test1_repr)
+        page_string = re.sub(r'TestClass(\d+)', 'TestClass', page_string)
+        ref_string = re.sub(r'TestClass(\d+)', 'TestClass', test1_repr)
 
         try:
             self.assertEqual(page_string, ref_string)
@@ -56,8 +56,8 @@ class TestParamPager(unittest.TestCase):
     def test_parameterized_instance(self):
         page_string = self.pager(self.TestClass())
         # Remove params automatic numbered names
-        page_string = re.sub('TestClass(\d+)', 'TestClass', page_string)
-        ref_string = re.sub('TestClass(\d+)', 'TestClass', test2_repr)
+        page_string = re.sub(r'TestClass(\d+)', 'TestClass', page_string)
+        ref_string = re.sub(r'TestClass(\d+)', 'TestClass', test2_repr)
 
         try:
             self.assertEqual(page_string, ref_string)

--- a/tests/API0/testlistselector.py
+++ b/tests/API0/testlistselector.py
@@ -156,6 +156,4 @@ class TestListSelectorParameters(unittest.TestCase):
         with self.assertRaises(TypeError):
             Q.params('r').compute_default()
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API0/testnumbergen.py
+++ b/tests/API0/testnumbergen.py
@@ -34,6 +34,4 @@ class TestUniformRandomOffset(unittest.TestCase):
             value = gen()
             self.assertTrue(lbound <= value < ubound)
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API0/testnumpy.py
+++ b/tests/API0/testnumpy.py
@@ -35,6 +35,4 @@ class TestNumpy(unittest.TestCase):
         _is_array_and_equal(z.z,[1,2])
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API0/testobjectselector.py
+++ b/tests/API0/testobjectselector.py
@@ -23,7 +23,7 @@ class TestObjectSelectorParameters(unittest.TestCase):
             g = param.ObjectSelector(default=None,objects=[7,8])
             i = param.ObjectSelector(default=7,objects=[9],check_on_set=False)
             d = param.ObjectSelector(default=opts['B'],objects=opts)
-            
+
         self.P = P
 
     def test_set_object_constructor(self):
@@ -103,6 +103,4 @@ class TestObjectSelectorParameters(unittest.TestCase):
             raise AssertionError("ObjectSelector created without range.")
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API0/testparameterizedrepr.py
+++ b/tests/API0/testparameterizedrepr.py
@@ -162,6 +162,4 @@ class TestParameterizedRepr(unittest.TestCase):
 
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API0/teststringparam.py
+++ b/tests/API0/teststringparam.py
@@ -7,7 +7,7 @@ import unittest
 import param
 
 
-ip_regex = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+ip_regex = r'^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
 
 class TestStringParameters(unittest.TestCase):
 
@@ -25,7 +25,7 @@ class TestStringParameters(unittest.TestCase):
         a = A()
 
         exception = "String 's' only takes a string value."
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 
     def test_default_none(self):
@@ -44,13 +44,13 @@ class TestStringParameters(unittest.TestCase):
         a = A()
 
         exception = "String 's': '123.123.0.256' does not match regex"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = '123.123.0.256'
 
     def test_regex_incorrect_default(self):
 
         exception = "String 'None': '' does not match regex"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             class A(param.Parameterized):
                 s = param.String(regex=ip_regex)  # default value '' does not match regular expression
 

--- a/tests/API0/testtimedependent.py
+++ b/tests/API0/testtimedependent.py
@@ -7,7 +7,7 @@ import param
 import numbergen
 import copy
 
-from nose.plugins.skip import SkipTest
+from unittest import SkipTest
 import fractions
 
 try:
@@ -297,6 +297,4 @@ class TestTimeDependentDynamic(unittest.TestCase):
 
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testclassselector.py
+++ b/tests/API1/testclassselector.py
@@ -27,7 +27,7 @@ class TestClassSelectorParameters(API1TestCase):
 
     def test_single_class_instance_error(self):
         exception = "Parameter 'e' value must be an instance of int, not 'a'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(e='a')
 
     def test_single_class_type_constructor(self):
@@ -36,7 +36,7 @@ class TestClassSelectorParameters(API1TestCase):
 
     def test_single_class_type_error(self):
         exception = "Parameter 'str' must be a subclass of Number, not 'type'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(f=str)
 
     def test_multiple_class_instance_constructor1(self):
@@ -48,8 +48,8 @@ class TestClassSelectorParameters(API1TestCase):
         self.assertEqual(p.g, 'A')
 
     def test_multiple_class_instance_error(self):
-        exception = "Parameter 'g' value must be an instance of \(int, str\), not '3.0'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Parameter 'g' value must be an instance of \(int, str\), not '3.0'"
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(g=3.0)
 
     def test_multiple_class_type_constructor1(self):
@@ -67,8 +67,8 @@ class TestClassSelectorParameters(API1TestCase):
         self.assertIn('str', classes)
 
     def test_multiple_class_type_error(self):
-        exception = "Parameter 'float' must be a subclass of \(int, str\), not 'type'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Parameter 'float' must be a subclass of \(int, str\), not 'type'"
+        with self.assertRaisesRegex(ValueError, exception):
             self.P(h=float)
 
 
@@ -93,5 +93,5 @@ class TestDictParameters(API1TestCase):
 
         test = Test()
         exception = "Parameter 'items' value must be an instance of dict, not '3'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             test.items = 3

--- a/tests/API1/testcompositeparams.py
+++ b/tests/API1/testcompositeparams.py
@@ -95,6 +95,4 @@ class TestCompositeParameters(API1TestCase):
         self.assertEqual(iy(), 5)
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testdefaults.py
+++ b/tests/API1/testdefaults.py
@@ -27,11 +27,11 @@ except ImportError:
     skip.append('Series')
 
 
-class TestDefaultsMetaclass(type):
+class _TestDefaultsMetaclass(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
-            from nose.exc import SkipTest
+            from unittest import SkipTest
             raise SkipTest
 
         def add_test(p):
@@ -47,11 +47,6 @@ class TestDefaultsMetaclass(type):
         return type.__new__(mcs, name, bases, dict_)
 
 
-@add_metaclass(TestDefaultsMetaclass)
+@add_metaclass(_TestDefaultsMetaclass)
 class TestDefaults(API1TestCase):
     pass
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testdefaults.py
+++ b/tests/API1/testdefaults.py
@@ -27,7 +27,7 @@ except ImportError:
     skip.append('Series')
 
 
-class _TestDefaultsMetaclass(type):
+class MyTestDefaultsMetaclass(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
@@ -47,6 +47,6 @@ class _TestDefaultsMetaclass(type):
         return type.__new__(mcs, name, bases, dict_)
 
 
-@add_metaclass(_TestDefaultsMetaclass)
+@add_metaclass(MyTestDefaultsMetaclass)
 class TestDefaults(API1TestCase):
     pass

--- a/tests/API1/testdynamicparams.py
+++ b/tests/API1/testdynamicparams.py
@@ -249,9 +249,7 @@ class TestDynamicSharedNumbergen(TestDynamicParameters):
 
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+
 
 
 # Commented out block in the original doctest version.

--- a/tests/API1/testipythonmagic.py
+++ b/tests/API1/testipythonmagic.py
@@ -43,8 +43,8 @@ class TestParamPager(API1TestCase):
     def test_parameterized_class(self):
         page_string = self.pager(self.TestClass)
         # Remove params automatic numbered names
-        page_string = re.sub('TestClass(\d+)', 'TestClass', page_string)
-        ref_string = re.sub('TestClass(\d+)', 'TestClass', test1_repr)
+        page_string = re.sub(r'TestClass(\d+)', 'TestClass', page_string)
+        ref_string = re.sub(r'TestClass(\d+)', 'TestClass', test1_repr)
 
         try:
             self.assertEqual(page_string, ref_string)
@@ -56,8 +56,8 @@ class TestParamPager(API1TestCase):
     def test_parameterized_instance(self):
         page_string = self.pager(self.TestClass())
         # Remove params automatic numbered names
-        page_string = re.sub('TestClass(\d+)', 'TestClass', page_string)
-        ref_string = re.sub('TestClass(\d+)', 'TestClass', test2_repr)
+        page_string = re.sub(r'TestClass(\d+)', 'TestClass', page_string)
+        ref_string = re.sub(r'TestClass(\d+)', 'TestClass', test2_repr)
 
         try:
             self.assertEqual(page_string, ref_string)

--- a/tests/API1/testlistselector.py
+++ b/tests/API1/testlistselector.py
@@ -155,6 +155,4 @@ class TestListSelectorParameters(API1TestCase):
         with self.assertRaises(TypeError):
             Q.param.params('r').compute_default()
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testnumbergen.py
+++ b/tests/API1/testnumbergen.py
@@ -32,6 +32,4 @@ class TestUniformRandomOffset(API1TestCase):
             value = gen()
             self.assertTrue(lbound <= value < ubound)
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testnumberparameter.py
+++ b/tests/API1/testnumberparameter.py
@@ -35,20 +35,20 @@ class TestNumberParameters(API1TestCase):
 
     def test_step_invalid_type_number_parameter(self):
         exception = "Step parameter can only be None or a numeric value"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             param.Number(step='invalid value')
 
     def test_step_invalid_type_integer_parameter(self):
         exception = "Step parameter can only be None or an integer value"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             param.Integer(step=3.4)
 
     def test_step_invalid_type_datetime_parameter(self):
         exception = "Step parameter can only be None, a datetime or datetime type"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             param.Date(dt.datetime(2017,2,27), step=3.2)
 
     def test_step_invalid_type_date_parameter(self):
         exception = "Step parameter can only be None or a date type"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             param.CalendarDate(dt.date(2017,2,27), step=3.2)

--- a/tests/API1/testnumpy.py
+++ b/tests/API1/testnumpy.py
@@ -42,6 +42,4 @@ class TestNumpy(API1TestCase):
         z = Z(z=numpy.array([1,2]))
         _is_array_and_equal(z.z,[1,2])
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testobjectselector.py
+++ b/tests/API1/testobjectselector.py
@@ -115,6 +115,4 @@ class TestObjectSelectorParameters(API1TestCase):
             raise AssertionError("ObjectSelector created without range.")
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testpandas.py
+++ b/tests/API1/testpandas.py
@@ -31,7 +31,7 @@ class TestDataFrame(API1TestCase):
 
         test = Test()
         exception = "Parameter 'df' value must be an instance of DataFrame, not '3'"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             test.df = 3
 
     def test_dataframe_unordered_column_set_valid(self):
@@ -50,8 +50,8 @@ class TestDataFrame(API1TestCase):
 
         test = Test()
         self.assertEquals(test.param.params('df').ordered, False)
-        exception = "Provided DataFrame columns \['b', 'a', 'c'\] does not contain required columns \['a', 'd'\]"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Provided DataFrame columns \['b', 'a', 'c'\] does not contain required columns \['a', 'd'\]"
+        with self.assertRaisesRegex(ValueError, exception):
             test.df = invalid_df
 
     def test_dataframe_ordered_column_list_valid(self):
@@ -70,8 +70,8 @@ class TestDataFrame(API1TestCase):
         test = Test()
         self.assertEquals(test.param.params('df').ordered, True)
 
-        exception = "Provided DataFrame columns \['a', 'b', 'd'\] must exactly match \['b', 'a', 'd'\]"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Provided DataFrame columns \['a', 'b', 'd'\] must exactly match \['b', 'a', 'd'\]"
+        with self.assertRaisesRegex(ValueError, exception):
             test.df = invalid_df
 
 
@@ -90,7 +90,7 @@ class TestDataFrame(API1TestCase):
         self.assertEquals(test.param.params('df').ordered, None)
 
         exception = "Column length 2 does not match declared bounds of 3"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             test.df = invalid_df
 
 
@@ -103,8 +103,8 @@ class TestDataFrame(API1TestCase):
 
         invalid_df = pandas.DataFrame({'a':[1,2], 'b':[2,3], 'c':[4,5]}, columns=['b', 'a', 'c'])
 
-        exception = "Columns length 3 does not match declared bounds of \(None, 2\)"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Columns length 3 does not match declared bounds of \(None, 2\)"
+        with self.assertRaisesRegex(ValueError, exception):
             class Test(param.Parameterized):
                 df = param.DataFrame(default=invalid_df, columns=(None,2))
 
@@ -121,7 +121,7 @@ class TestDataFrame(API1TestCase):
 
         test = Test()
         exception = "Row length 3 does not match declared bounds of 2"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             test.df = invalid_df
 
     def test_dataframe_unordered_row_tuple_valid(self):
@@ -133,8 +133,8 @@ class TestDataFrame(API1TestCase):
 
         invalid_df = pandas.DataFrame({'a':[1,2], 'b':[2,3], 'c':[4,5]}, columns=['b', 'a', 'c'])
 
-        exception = "Row length 2 does not match declared bounds of \(5, 7\)"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Row length 2 does not match declared bounds of \(5, 7\)"
+        with self.assertRaisesRegex(ValueError, exception):
             class Test(param.Parameterized):
                 df = param.DataFrame(default=invalid_df, rows=(5,7))
 
@@ -159,7 +159,7 @@ class TestSeries(API1TestCase):
 
         test = Test()
         exception = "Row length 3 does not match declared bounds of 2"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             test.series = invalid_series
 
     def test_series_unordered_row_tuple_valid(self):
@@ -171,11 +171,7 @@ class TestSeries(API1TestCase):
 
         invalid_series = pandas.Series([1,2])
 
-        exception = "Row length 2 does not match declared bounds of \(5, 7\)"
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = r"Row length 2 does not match declared bounds of \(5, 7\)"
+        with self.assertRaisesRegex(ValueError, exception):
             class Test(param.Parameterized):
                 series = param.Series(default=invalid_series, rows=(5,7))
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testparameterizedrepr.py
+++ b/tests/API1/testparameterizedrepr.py
@@ -162,6 +162,4 @@ class TestParameterizedRepr(API1TestCase):
 
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testselector.py
+++ b/tests/API1/testselector.py
@@ -115,6 +115,4 @@ class TestSelectorParameters(API1TestCase):
             raise AssertionError("Selector created without range.")
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/teststringparam.py
+++ b/tests/API1/teststringparam.py
@@ -6,7 +6,7 @@ from . import API1TestCase
 import param
 
 
-ip_regex = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+ip_regex = r'^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
 
 class TestStringParameters(API1TestCase):
 
@@ -24,7 +24,7 @@ class TestStringParameters(API1TestCase):
         a = A()
 
         exception = "String 's' only takes a string value."
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 
     def test_default_none(self):
@@ -42,15 +42,13 @@ class TestStringParameters(API1TestCase):
 
         a = A()
 
-        exception = "String 's': '123.123.0.256' does not match regex"  
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = "String 's': '123.123.0.256' does not match regex"
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = '123.123.0.256'
 
     def test_regex_incorrect_default(self):
 
         exception = "String 'None': '' does not match regex"
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             class A(param.Parameterized):
                 s = param.String(regex=ip_regex)  # default value '' does not match regular expression
-
-

--- a/tests/API1/testtimedependent.py
+++ b/tests/API1/testtimedependent.py
@@ -7,7 +7,7 @@ import numbergen
 import copy
 
 from . import API1TestCase
-from nose.plugins.skip import SkipTest
+from unittest import SkipTest
 import fractions
 
 try:
@@ -297,6 +297,4 @@ class TestTimeDependentDynamic(API1TestCase):
 
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -748,6 +748,4 @@ class TestTrigger(API1TestCase):
         self.assertEqual(args[1].type, 'triggered')
 
 
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
+

--- a/tests/API1/utils.py
+++ b/tests/API1/utils.py
@@ -1,3 +1,4 @@
+import random
 import logging
 
 class MockLoggingHandler(logging.Handler):
@@ -75,3 +76,8 @@ class MockLoggingHandler(logging.Handler):
             raise AssertionError(msg.format(method=self.param_methods[level],
                                             last_line=repr(last_line[0]),
                                             substring=repr(substring)))
+
+
+class SomeRandomNumbers(object):
+    def __call__(self):
+        return random.random()


### PR DESCRIPTION
Also, clear up a lot of warning and removing deprecated constructs.

Still remaining:

* Failing test methods test_abstract_class in
  tests/API1/testparameterizedobject.py and
  tests/API0/testparameterizedobject.py with:
```
=================================== FAILURES ===================================
____________________ TestParameterized.test_abstract_class _____________________

self = <tests.API0.testparameterizedobject.TestParameterized testMethod=test_abstract_class>

    def test_abstract_class(self):
        """Check that a class declared abstract actually shows up as abstract."""
>       self.assertEqual(_TestAbstractPO.abstract,True)
E       AssertionError: False != True

tests/API0/testparameterizedobject.py:117: AssertionError
____________________ TestParameterized.test_abstract_class _____________________

self = <tests.API1.testparameterizedobject.TestParameterized testMethod=test_abstract_class>

    def test_abstract_class(self):
        """Check that a class declared abstract actually shows up as abstract."""
>       self.assertEqual(_TestAbstractPO.abstract, True)
E       AssertionError: False != True

tests/API1/testparameterizedobject.py:134: AssertionError
```
* still unresolved use of deprecated method inspect.getargspec() on the
  line 2446 of param/parameterized.py.