### PR TITLE
Add project links to setup to add links to pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup_args = dict(
     tests_require=extras_require['tests'],
     project_urls={
         "Documentation": "https://param.holoviz.org/",
-        "Releases": "https://param.holoviz.org/historical_release_notes.html",
-        "Bug Tracker": "https://github.com/ioam/param/issues",
+        "Releases": "https://github.com/holoviz/param/releases",
+        "Bug Tracker": "https://github.com/holoviz/param/issues",
         "Source Code": "https://github.com/holoviz/param",
         "Panel Examples": "https://panel.holoviz.org/user_guide/Param.html",
     },

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,12 @@ setup_args = dict(
     install_requires=[],
     extras_require=extras_require,
     tests_require=extras_require['tests'],
+    project_urls={
+        "Documentation": "https://param.holoviz.org/",
+        "Releases": "https://param.holoviz.org/historical_release_notes.html",
+        "Bug Tracker": "https://github.com/ioam/param/issues",
+        "Source Code": "https://github.com/holoviz/param",
+    },
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup_args = dict(
         "Releases": "https://param.holoviz.org/historical_release_notes.html",
         "Bug Tracker": "https://github.com/ioam/param/issues",
         "Source Code": "https://github.com/holoviz/param",
+        "Panel Examples": "https://panel.holoviz.org/user_guide/Param.html",
     },
     classifiers=[
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
This pull request adds description links to the setup.py using the `project_urls` key. 
* [An example setup for mflow](https://github.com/mlflow/mlflow/pull/2431/files)
* This PR adds more entries the project link on pypi see [mlflow](https://pypi.org/project/mlflow/)

In the descriptive links I've placed canonical things like Documentation, Releases, and Bug Tracker. I propose adding panel docs as complements to the param docs.

closes #418 