### PR TITLE
Ensure the color class applies allow_none

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1910,7 +1910,7 @@ class Color(Parameter):
     prefix.
     """
 
-    def __init__(self, default=None, allow_None=False, **kwargs):
+    def __init__(self, default=None, **kwargs):
         super(Color, self).__init__(default=default, **kwargs)
         self._validate(default)
 


### PR DESCRIPTION
closes #303 by removing the allow_none parameter from the function signature.