### PR TITLE
bug-fix in discard_events

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -140,7 +140,8 @@ def discard_events(parameterized):
     """
     batch_watch = parameterized.param._BATCH_WATCH
     parameterized.param._BATCH_WATCH = True
-    watchers, events = parameterized.param._watchers, parameterized.param._events
+    watchers = copy.copy(parameterized.param._watchers)
+    events = copy.copy(parameterized.param._events)
     try:
         yield
     except:


### PR DESCRIPTION
`watchers` and `events` need to be copied before being memorized, otherwise they are mere references to `parameterized.param._watchers` and `parameterized.param._events` and the `finally` block has no effect (i.e. does not ignore new events that have accumulated during the scope of the context manager)