### PR TITLE
Test suite fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ jobs:
       env: TOX_ENV=py38
 
     - <<: *default
+      python: 3.9-dev
+      env: TOX_ENV=py39
+
+    - <<: *default
       python: 3.6
       env: TOX_ENV=py36
 
@@ -66,6 +70,25 @@ jobs:
 
     - <<: *default
       env: TOX_ENV=with_pandas
+
+    - <<: *default
+      env: TOX_ENV=with_jsonschema
+
+    - <<: *default
+      env: TOX_ENV=with_gmpy
+      addons:
+        apt:
+          packages:
+          - libgmp10
+          - libgmp-dev
+
+    - <<: *default
+      env: TOX_ENV=with_all
+      addons:
+        apt:
+          packages:
+          - libgmp10
+          - libgmp-dev
 
     - <<: *default
       env: TOX_ENV=coverage

--- a/numbergen/__init__.py
+++ b/numbergen/__init__.py
@@ -202,7 +202,7 @@ class Hash(object):
 
         I32 = 4294967296 # Maximum 32 bit unsigned int (i.e. 'I') value
         if isinstance(val, int):
-             numer, denom = val, 1
+            numer, denom = val, 1
         elif isinstance(val, fractions.Fraction):
             numer, denom = val.numerator, val.denominator
         elif hasattr(val, 'numer'):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -221,7 +221,7 @@ def parameterized_class(name, params, bases=Parameterized):
     supplied parameters, inheriting from the specified base(s).
     """
     if not (isinstance(bases, list) or isinstance(bases, tuple)):
-          bases=[bases]
+        bases=[bases]
     return type(name, tuple(bases), params)
 
 
@@ -924,7 +924,7 @@ class Integer(Number):
     """Numeric Parameter required to be an Integer"""
 
     def __init__(self,default=0,**params):
-       Number.__init__(self,default=default,**params)
+        Number.__init__(self,default=default,**params)
 
     def _validate(self, val):
         if callable(val): return
@@ -1250,7 +1250,7 @@ class ObjectSelector(SelectorBase):
         to check each item instead.
         """
         if not (val in self.objects):
-           self.objects.append(val)
+            self.objects.append(val)
 
     def get_range(self):
         """
@@ -2012,7 +2012,7 @@ class DateRange(Range):
 
         start, end = val
         if not end >= start:
-           raise ValueError("DateRange '%s': end datetime %s is before start datetime %s."%(self.name,val[1],val[0]))
+            raise ValueError("DateRange '%s': end datetime %s is before start datetime %s."%(self.name,val[1],val[0]))
 
         # Calling super(DateRange, self)._check(val) would also check
         # values are numeric, which is redundant, so just call
@@ -2034,7 +2034,7 @@ class CalendarDateRange(Range):
 
         start, end = val
         if not end >= start:
-           raise ValueError("CalendarDateRange '%s': end date %s is before start date %s."%(self.name,val[1],val[0]))
+            raise ValueError("CalendarDateRange '%s': end date %s is before start date %s."%(self.name,val[1],val[0]))
 
         # Calling super(CalendarDateRange, self)._check(val) would also check
         # values are numeric, which is redundant, so just call

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -495,7 +495,7 @@ def _params_depended_on(minfo):
 
 def _m_caller(self, n):
     def caller(event):
-       return getattr(self,n)()
+        return getattr(self,n)()
     caller._watcher_name = n
     return caller
 
@@ -754,8 +754,8 @@ class Parameter(object):
         if serializer is None:
             raise ImportError('Cannot import serializer.py needed to generate schema')
         if mode not in  self._serializers:
-           raise KeyError('Mode %r not in available serialization formats %r'
-                          % (mode, list(self._serializers.keys())))
+            raise KeyError('Mode %r not in available serialization formats %r'
+                           % (mode, list(self._serializers.keys())))
         return self._serializers[mode].parameter_schema(self.__class__.__name__, self,
                                                         safe=safe, subset=subset)
 
@@ -1604,29 +1604,29 @@ class Parameters(object):
     def serialize_parameters(self_, subset=None, mode='json'):
         self_or_cls = self_.self_or_cls
         if mode not in Parameter._serializers:
-           raise ValueError('Mode %r not in available serialization formats %r'
-                            % (mode, list(Parameter._serializers.keys())))
+            raise ValueError('Mode %r not in available serialization formats %r'
+                             % (mode, list(Parameter._serializers.keys())))
         serializer = Parameter._serializers[mode]
         return serializer.serialize_parameters(self_or_cls, subset=subset)
 
     def serialize_value(self_, pname, mode='json'):
         self_or_cls = self_.self_or_cls
         if mode not in Parameter._serializers:
-           raise ValueError('Mode %r not in available serialization formats %r'
-                            % (mode, list(Parameter._serializers.keys())))
+            raise ValueError('Mode %r not in available serialization formats %r'
+                             % (mode, list(Parameter._serializers.keys())))
         serializer = Parameter._serializers[mode]
         return serializer.serialize_parameter_value(self_or_cls, pname)
 
     def deserialize_parameters(self_, serialization, subset=None, mode='json'):
-       self_or_cls = self_.self_or_cls
-       serializer = Parameter._serializers[mode]
-       return serializer.deserialize_parameters(self_or_cls, serialization, subset=subset)
+        self_or_cls = self_.self_or_cls
+        serializer = Parameter._serializers[mode]
+        return serializer.deserialize_parameters(self_or_cls, serialization, subset=subset)
 
     def deserialize_value(self_, pname, value, mode='json'):
         self_or_cls = self_.self_or_cls
         if mode not in Parameter._serializers:
-           raise ValueError('Mode %r not in available serialization formats %r'
-                            % (mode, list(Parameter._serializers.keys())))
+            raise ValueError('Mode %r not in available serialization formats %r'
+                             % (mode, list(Parameter._serializers.keys())))
         serializer = Parameter._serializers[mode]
         return serializer.deserialize_parameter_value(self_or_cls, pname, value)
 
@@ -1636,8 +1636,8 @@ class Parameters(object):
         """
         self_or_cls = self_.self_or_cls
         if mode not in Parameter._serializers:
-           raise ValueError('Mode %r not in available serialization formats %r'
-                            % (mode, list(Parameter._serializers.keys())))
+            raise ValueError('Mode %r not in available serialization formats %r'
+                             % (mode, list(Parameter._serializers.keys())))
         serializer = Parameter._serializers[mode]
         return serializer.schema(self_or_cls, safe=safe, subset=subset)
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -494,7 +494,8 @@ def _params_depended_on(minfo):
 
 
 def _m_caller(self, n):
-    caller = lambda event: getattr(self,n)()
+    def caller(event):
+       return getattr(self,n)()
     caller._watcher_name = n
     return caller
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,11 @@ universal = 1
 # TODO tests should not be excluded (one day...)
 include = setup.py param numbergen
 exclude = .git,__pycache__,.tox,.eggs,*.egg,doc,dist,build,_build,tests,.ipynb_checkpoints,run_test.py
-ignore = E1,
+ignore = E114,
+         E116,
+         E126,
+         E128,
+         E129,
          E2,
          E3,
          E4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,23 +2,26 @@
 universal = 1
 
 [flake8]
-# TODO tests (one day)
+# TODO tests should not be excluded (one day...)
 include = setup.py param numbergen
-exclude = .git,__pycache__,.tox,.eggs,*.egg,doc,dist,build,_build,tests
+exclude = .git,__pycache__,.tox,.eggs,*.egg,doc,dist,build,_build,tests,.ipynb_checkpoints,run_test.py
 ignore = E1,
          E2,
          E3,
          E4,
          E5,
+         E731,
          E701,
          E702,
          E703,
-         E704,   
+         E704,
          E722,
          E741,
          E742,
          E743,
-         W503
+         W503,
+         W504,
+         W605
 
 [nosetests]
 verbosity = 2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ extras_require = {
     'tests': [
         'nose',
         'flake8',
-        'jsonschema',
     ]
 }
 

--- a/tests/API0/testtimedependent.py
+++ b/tests/API0/testtimedependent.py
@@ -12,9 +12,12 @@ import fractions
 
 try:
     import gmpy
-except:
-    gmpy = None
-
+except ImportError:
+    import os
+    if os.getenv('PARAM_TEST_GMPY','0') == '1':
+        raise ImportError("PARAM_TEST_GMPY=1 but gmpy not available.")
+    else:
+        gmpy = None
 
 
 class TestTimeClass(unittest.TestCase):

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -13,6 +13,9 @@ from . import API1TestCase
 try:
     from jsonschema import validate, ValidationError
 except ImportError:
+    import os
+    if os.getenv('PARAM_TEST_JSONSCHEMA','0') == '1':
+        raise ImportError("PARAM_TEST_JSONSCHEMA=1 but jsonschema not available.")
     validate = None
 
 try:

--- a/tests/API1/testtimedependent.py
+++ b/tests/API1/testtimedependent.py
@@ -12,9 +12,12 @@ import fractions
 
 try:
     import gmpy
-except:
-    gmpy = None
-
+except ImportError:
+    import os
+    if os.getenv('PARAM_TEST_GMPY','0') == '1':
+        raise ImportError("PARAM_TEST_GMPY=1 but gmpy not available.")
+    else:
+        gmpy = None
 
 
 class TestTimeClass(API1TestCase):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,0 @@
-import sys
-import unittest # noqa
-
-if sys.version_info[0]==2 and sys.version_info[1]<7:
-    del sys.modules['unittest']
-    sys.modules['unittest'] = __import__('unittest2')

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,18 @@
 [tox]
 envlist =
-    py38,py37,py36,py35,py27,pypy,
-    {py27,py37}-flakes,
-    {py27,py37}-with_numpy,
-    {py27,py37}-with_ipython
-    {py27,py37}-with_pandas
+    py39,py38,py37,py36,py35,py27,pypy,
+    py37-flakes,
+    py37-coverage,
+    py37-with_numpy,
+    py37-with_ipython,
+    py37-with_pandas,
+    py37-with_jsonsschema,
+    py37-with_gmpy,
+    py37-with_all
 
 [testenv]
 deps = .[tests]
 commands = nosetests
-
-[testenv:coverage]
-# remove develop install if https://github.com/ioam/param/issues/219
-# implemented
-setdevelop = True
-passenv = TRAVIS TRAVIS_*
-deps = {[testenv]deps}
-       coveralls
-commands = nosetests --with-coverage --cover-package=param
-           coveralls
-# TODO missing numbergen
 
 [testenv:with_numpy]
 deps = {[testenv]deps}
@@ -31,11 +24,43 @@ deps = {[testenv]deps}
        pandas
 setenv = PARAM_TEST_PANDAS = 1
 
-
 [testenv:with_ipython]
 deps = {[testenv]deps}
        ipython
 setenv = PARAM_TEST_IPYTHON = 1
+
+[testenv:with_jsonschema]
+deps = {[testenv]deps}
+       jsonschema
+setenv = PARAM_TEST_JSONSCHEMA = 1
+
+[testenv:with_gmpy]
+deps = {[testenv]deps}
+       gmpy
+setenv = PARAM_TEST_GMPY = 1
+
+[testenv:with_all]
+deps = {[testenv:with_numpy]deps}
+       {[testenv:with_pandas]deps}
+       {[testenv:with_ipython]deps}
+       {[testenv:with_jsonschema]deps}
+       {[testenv:with_gmpy]deps}
+setenv = {[testenv:with_numpy]setenv}
+         {[testenv:with_pandas]setenv}
+         {[testenv:with_ipython]setenv}
+         {[testenv:with_jsonschema]setenv}
+         {[testenv:with_gmpy]setenv}
+
+[testenv:coverage]
+# remove develop install if https://github.com/ioam/param/issues/219
+# implemented
+setdevelop = True
+passenv = TRAVIS TRAVIS_*
+deps = {[testenv:with_all]deps}
+       coveralls
+setenv = {[testenv:with_all]setenv}
+commands = nosetests --with-coverage --cover-package=param --cover-package=numbergen
+           coveralls
 
 [testenv:flakes]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -65,8 +65,3 @@ commands = nosetests --with-coverage --cover-package=param --cover-package=numbe
 [testenv:flakes]
 skip_install = true
 commands = flake8
-
-[flake8]
-ignore = E,W,W605
-include = *.py
-exclude = .git,__pycache__,.tox,.eggs,*.egg,doc,dist,build,_build,.ipynb_checkpoints,run_test.py


### PR DESCRIPTION
* Remove redundant handling for python<2.7 in test suite (we don't support python<2.7).
* Don't use python 2.7 as a primary test environment on travis, use python 3.7. (python 2.7 is still tested.)
* Follow existing pattern for testing with optional components: jsonschema
* Re-enable testing with gmpy present
* Add python 3.9 on travis (3.9 comes out soon).
* All tests are now being run on travis.
* Measure coverage with all optional tests running.
* Add numbergen to modules being checked for coverage.
* Merged duplicate/inconsistent flake8 sections, with a set of rules that lead to no complaints about trivial stuff.
* Replaced a named lambda with a function (because flake8 complained :) I don't have much opinion).
* Fix various indentation issues and add indentation to flake checks (we can at least agree on 4 spaces only, not mixing with 3, I hope...)

Fixes #433 
Fixes #246 
