### PR TITLE
Group depends for watched deps within a class

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2481,9 +2481,9 @@ class Parameterized(object):
                 # instantiation of Parameterized with watched deps. Will
                 # probably store expanded deps on class - see metaclass
                 # 'dependers'.
-                grouped = defaultdict(list)                
+                grouped = defaultdict(list)
                 for dep in self.param.params_depended_on(n):
-                    grouped[(id(dep.inst),id(dep.cls),dep.what)].append(dep)                    
+                    grouped[(id(dep.inst),id(dep.cls),dep.what)].append(dep)
                 for group in grouped.values():
                     # TODO: can't remember why not just pass m (rather than _m_caller) here
                     (dep.inst or dep.cls).param.watch(_m_caller(self, n), [dep.name for dep in group], dep.what, queued=queued)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2486,7 +2486,8 @@ class Parameterized(object):
                     grouped[(id(dep.inst),id(dep.cls),dep.what)].append(dep)
                 for group in grouped.values():
                     # TODO: can't remember why not just pass m (rather than _m_caller) here
-                    (dep.inst or dep.cls).param.watch(_m_caller(self, n), [dep.name for dep in group], dep.what, queued=queued)
+                    gdep = group[0] # Need to grab representative dep from this group
+                    (gdep.inst or gdep.cls).param.watch(_m_caller(self, n), [d.name for d in group], gdep.what, queued=queued)
 
         self.initialized = True
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -494,7 +494,7 @@ def _params_depended_on(minfo):
 
 
 def _m_caller(self, n):
-    def caller(event):
+    def caller(*events):
         return getattr(self,n)()
     caller._watcher_name = n
     return caller
@@ -2481,9 +2481,12 @@ class Parameterized(object):
                 # instantiation of Parameterized with watched deps. Will
                 # probably store expanded deps on class - see metaclass
                 # 'dependers'.
-                for p in self.param.params_depended_on(n):
+                grouped = defaultdict(list)                
+                for dep in self.param.params_depended_on(n):
+                    grouped[(id(dep.inst),id(dep.cls),dep.what)].append(dep)                    
+                for group in grouped.values():
                     # TODO: can't remember why not just pass m (rather than _m_caller) here
-                    (p.inst or p.cls).param.watch(_m_caller(self, n), p.name, p.what, queued=queued)
+                    (dep.inst or dep.cls).param.watch(_m_caller(self, n), [dep.name for dep in group], dep.what, queued=queued)
 
         self.initialized = True
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -364,7 +364,7 @@ def depends(func, *dependencies, **kw):
                              'or function is not supported when referencing '
                              'parameters by name.')
 
-    if not string_specs and watch:
+    if not string_specs and watch: # string_specs case handled elsewhere (later), in Parameterized.__init__
         def cb(*events):
             args = (getattr(dep.owner, dep.name) for dep in dependencies)
             dep_kwargs = {n: getattr(dep.owner, dep.name) for n, dep in kw.items()}


### PR DESCRIPTION
Supposed to fix #415...but let's see if the existing test suite passes first...

I probably need a review from @philippjfr at this point before I go further, as 1. I'm a bit out of practice ;) and 2. seemingly if I ever try to inspect anything param-ish using pdb, I get `Fatal Python error: Cannot recover from stack overflow` and a core dump :( (no doubt related to the ever recurring repr problems).

To do:

* [ ] add tests