### PR TITLE
Fix all_equal() and hence get_param_values(onlychanged=True)

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1645,9 +1645,9 @@ class Parameters(object):
         only return values that are not equal to the default value
         (onlychanged has no effect when called on a class).
 
-        If suppress_auto_name is True, then auto-generated instance 
-        names will not be shown. Probably, though, this should be called 
-        suppress_name and should suppress the name if True (no matter 
+        If suppress_auto_name is True, then auto-generated instance
+        names will not be shown. Probably, though, this should be called
+        suppress_name and should suppress the name if True (no matter
         what the name is).
         """
         self_or_cls = self_.self_or_cls
@@ -1659,7 +1659,7 @@ class Parameters(object):
         for name, val in self_or_cls.param.objects('existing').items():
             value = self_or_cls.param.get_value_generator(name)
             if name=='name' and suppress_auto_name and _is_auto_name(self_.cls.__name__,value):
-                continue            
+                continue
             # (this is pointless for cls)
             if not onlychanged or not all_equal(value, val.default):
                 vals.append((name, value))

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1646,9 +1646,9 @@ class Parameters(object):
         (onlychanged has no effect when called on a class).
 
         If suppress_auto_name is True, then an auto-generated instance
-        name will never be included if onlychanged is True. Probably, 
-        though, this should be called suppress_name and should 
-        suppress the name if True (no matter what the name is, or 
+        name will never be included if onlychanged is True. Probably,
+        though, this should be called suppress_name and should
+        suppress the name if True (no matter what the name is, or
         what onlychanged is set to).
         """
         self_or_cls = self_.self_or_cls

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1645,10 +1645,11 @@ class Parameters(object):
         only return values that are not equal to the default value
         (onlychanged has no effect when called on a class).
 
-        If suppress_auto_name is True, then auto-generated instance
-        names will not be shown. Probably, though, this should be called
-        suppress_name and should suppress the name if True (no matter
-        what the name is).
+        If suppress_auto_name is True, then an auto-generated instance
+        name will never be included if onlychanged is True. Probably, 
+        though, this should be called suppress_name and should 
+        suppress the name if True (no matter what the name is, or 
+        what onlychanged is set to).
         """
         self_or_cls = self_.self_or_cls
         # CEB: we'd actually like to know whether a value has been
@@ -1658,7 +1659,7 @@ class Parameters(object):
         vals = []
         for name, val in self_or_cls.param.objects('existing').items():
             value = self_or_cls.param.get_value_generator(name)
-            if name=='name' and suppress_auto_name and _is_auto_name(self_.cls.__name__,value):
+            if name=='name' and onlychanged and suppress_auto_name and _is_auto_name(self_.cls.__name__,value):
                 continue
             # (this is pointless for cls)
             if not onlychanged or not all_equal(value, val.default):

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -13,6 +13,7 @@ from .utils import MockLoggingHandler
 
 import random
 from nose.tools import istest, nottest
+from nose.plugins.skip import SkipTest
 
 
 from param.parameterized import ParamOverrides, shared_parameters

--- a/tests/API1/testparameterizedrepr.py
+++ b/tests/API1/testparameterizedrepr.py
@@ -5,6 +5,8 @@ Unit test for the repr and pprint of parameterized objects.
 import param
 from . import API1TestCase
 
+from nose.plugins.skip import SkipTest
+
 
 class TestParameterizedRepr(API1TestCase):
 
@@ -71,6 +73,11 @@ class TestParameterizedRepr(API1TestCase):
                 super(E, self).__init__(**params)
 
         self.E = E
+
+        class A2(param.Parameterized):
+            arr = param.Parameter()
+
+        self.A2 = A2
 
 
     def testparameterizedrepr(self):
@@ -160,6 +167,22 @@ class TestParameterizedRepr(API1TestCase):
         self.assertEqual(obj.pprint(qualify=True),
                          "tests.API1.testparameterizedrepr."+r)
 
+    def test_nparray(self):
+        try:
+            import numpy as np
+        except ImportError:
+            raise SkipTest
+
+        obj = self.A2()
+        a = [[1,2],[3,4]]
+        import numpy as np
+        obj.arr = np.array(a)
+        obj.pprint()
+        self.A2.arr = a
+        obj.arr = a
+        obj.pprint()
+        obj.arr = np.array(a)
+        obj.pprint() # involves comparison of two arrays
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`all_equal()` is pretty broken, so replace it with `Comparator.is_equal()`.

Fixes #179 
Incorporates #180 

But, some issues...

To do:
* [ ] decide on "different definitions of equality"
* [ ] decide on how/when to suppress `name` parameter from `get_param_values()`
* [ ] add a test (if necessary, depending what is decided)

## Different definitions of equality

I'd like everything to be deciding equality the same way. However, it's probably tricky. You can't always have full equality checks everywhere (e.g. could be too expensive). 

`Comparator.is_equal()` does not (by default) handle numpy arrays or `param.Time`(*), both of which are (meant to be) handled by `all_equal()`.

1. Drop those from `all_equal()` (i.e. make it like default of `Comparator.is_equal()`)?

2. Or support those during `all_equal()`, i.e. retain all_equal's existing intended behavior, but comparisons done with Comparator (outside of all_equal) would by default behave differently.

3. Or make `Comparator.is_equal()` handle numpy arrays and param.Time by default. (I'm not quite sure how it's supposed to work on skimming it, but it looks like Comparator is designed to allow comparisons without explicit imports, but even if not seems likely it could be made to work).

(*) Has `_infinitely_iterable` attribute

I'm not too sure. I prefer 1 or 3. When I think of param in the past, I think 3 is what I'd like. But I suspect there's a good reason the default of Comparator is not to handle various cases (performance?).

## Retaining get_param_values(onlychanged=True) behavior of not showing auto-generated name

As noted in #179, a side effect of the incorrect all_equal() function is that it suppresses a parameterized's name from appearing in the result of `get_param_values(onlychanged=True)` if the name was auto-generated. I've added `suppress_auto_name` to `get_param_values()`, defaulting to True, so that if onlychanged=True is requested, an auto-generated name is not included.

But I feel like there are often times when you don't want the name in the parameters you're dealing with, so I'd prefer suppress_auto_name to be respected whether or not onlychanged is True.

I haven't thought about it a lot. Whether to have this option and what it does might depend a bit on the outcome of the api discussions.