### PR TITLE
Fix .abstract for classes named with leading underscore(s)

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2087,9 +2087,9 @@ class ParameterizedMetaclass(type):
         # _ParameterizedMetaclass__abstract before running, but
         # the actual class object will have an attribute
         # _ClassName__abstract.  So, we have to mangle it ourselves at
-        # runtime.
+        # runtime. Mangling follows description in https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references
         try:
-            return getattr(mcs,'_%s__abstract'%mcs.__name__)
+            return getattr(mcs,'_%s__abstract'%mcs.__name__.lstrip("_"))
         except AttributeError:
             return False
 

--- a/tests/API0/testparameterizedobject.py
+++ b/tests/API0/testparameterizedobject.py
@@ -39,6 +39,10 @@ class AnotherTestPO(param.Parameterized):
 class TestAbstractPO(param.Parameterized):
     __abstract = True
 
+class _AnotherAbstractPO(param.Parameterized):
+    __abstract = True
+
+
 @nottest
 class TestParamInstantiation(AnotherTestPO):
     instPO = param.Parameter(default=AnotherTestPO(),instantiate=False)
@@ -118,6 +122,7 @@ class TestParameterized(unittest.TestCase):
     def test_abstract_class(self):
         """Check that a class declared abstract actually shows up as abstract."""
         self.assertEqual(TestAbstractPO.abstract,True)
+        self.assertEqual(_AnotherAbstractPO.abstract,True)
         self.assertEqual(TestPO.abstract,False)
 
 

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -53,6 +53,9 @@ class AnotherTestPO(param.Parameterized):
 class TestAbstractPO(param.Parameterized):
     __abstract = True
 
+class _AnotherAbstractPO(param.Parameterized):
+    __abstract = True
+
 @nottest
 class TestParamInstantiation(AnotherTestPO):
     instPO = param.Parameter(default=AnotherTestPO(),instantiate=False)
@@ -140,6 +143,7 @@ class TestParameterized(API1TestCase):
     def test_abstract_class(self):
         """Check that a class declared abstract actually shows up as abstract."""
         self.assertEqual(TestAbstractPO.abstract,True)
+        self.assertEqual(_AnotherAbstractPO.abstract,True)
         self.assertEqual(TestPO.abstract,False)
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+In 2018, we moved most of `Parameterized` onto a `param` namespace
+object, expecting this to be the public API of param 2.0, and cleaning
+up the namespace of user classes.
+
+The new API has been in use for a while within holoviz projects, but
+we're still changing it. Meanwhile, the previous API remains
+available.
+
+The original API's tests were copied into an `API0` subdirectory,
+while tests in `API1` use the new API.
+
+(Probably not ideal to just copy everything, and cleaning up would be
+great, but this explains the two directories you see here.)


### PR DESCRIPTION
Fix the (longstanding) assumption in param's abstract class mechanism that abstract classes don't start with a leading underscore.

> Any identifier of the form __spam (at least two leading underscores, at most one trailing underscore) is textually replaced with _classname__spam, where classname is the current class name with leading underscore(s) stripped. This mangling is done without regard to the syntactic position of the identifier, as long as it occurs within the definition of a class.

(https://docs.python.org/2/tutorial/classes.html)

https://github.com/holoviz/param/blob/301b9617e84f3578364393d5ae30c452d1c19cd0/param/parameterized.py#L2074-L2094

(i.e. param does not do the same thing as python)

(originally from https://github.com/holoviz/param/pull/423#issuecomment-694526493)

Also added note about API0 and API1 tests (although not going so far as to say when you should be adding to one or the other or both, just noting the current duplication...)