### PR TITLE
Added support for setting ObjectSelector.objects

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1208,8 +1208,9 @@ class ObjectSelector(SelectorBase):
             self._objects = list(value.values())
         else:
             self._objects = value
-            # Special case to allow names and objects to be set separately in any order
-            if self.names is not None and len(self.names) != len(value):
+            # Delete stale names mapping, if it doesn't cover the new object list
+            if len(value)==0 or (self.names is not None and 
+                                 not all([o in value for o in self.names.values()])):
                 self.names = None
 
     # CBNOTE: if the list of objects is changed, the current value for


### PR DESCRIPTION
Addresses https://github.com/holoviz/param/issues/398 and possibly https://github.com/holoviz/param/issues/331 .

ObjectSelector was originally designed only to store a list of objects, which works fine if the objects are strings or have a .name attribute, but otherwise a GUI needs to work with names for the objects, and has to get them somewhere.  To support this case, ObjectSelector was previously extended to accept a dict of name,obj pairs as the `objects` argument to the constructor, but then extracted only the objects and stored it in `self.objects`, while storing the mapping in `self.names` (a lookup table that needs to be mappable both ways for GUI purposes, to give the label from the current value or the new value from a new label). This worked, but caused problems for anyone who wanted to dynamically adjust the objects after the Parameter was constructed.

With this PR, the behavior is the same if a user sets .objects after construction as it is during construction; in both cases the object values are extracted (now storing in ._objects) and the names mapping is stored in `self.names`.  This way a user can update the objects list whenever they like by passing a new dictionary.

It also supports cases where people have done a manual workaround like
```
        self.param.x.names = new_opts
        self.param.x.objects = list(new_opts.values())
```
by keeping the old names if a list is provided and the old names are compatible (have the same length).  This special case could be removed now, but it would affect people who had used the previously required workaround.

Note that this PR does _not_ address people trying to do `self.param.x.objects.append(...)`.  Anyone have ideas about whether that could be made to work?

