### PR TITLE
Extend ObjectSelector to store a single obj dict

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -137,7 +137,7 @@ def named_obj(obj, objtoname=None):
     else:
         k = as_unicode(obj)
     return k,obj
-            
+
 
 def named_objs(objlist, namesdict=None):
     """
@@ -156,7 +156,7 @@ def named_objs(objlist, namesdict=None):
     else:
         objtoname = None if namesdict is None else \
             {hashable(v): k for k, v in namesdict.items()}
-        
+
         objs = OrderedDict()
         for obj in objlist:
             objs[named_obj(obj, objtoname)] = obj
@@ -1291,8 +1291,8 @@ class Selector(ObjectSelector):
     argument which sufficient in many common use cases.
     """
     def __init__(self,objects=None, default=None, instantiate=False,
-                  compute_default_fn=None, check_on_set=None,
-                  allow_None=None,**params):
+                 compute_default_fn=None, check_on_set=None,
+                 allow_None=None,**params):
 
         if default is None:
             if objects is not None and len(objects)>0 and \
@@ -1301,10 +1301,10 @@ class Selector(ObjectSelector):
                                    "dictionaries prior to Python 3.6 not being "
                                    "ordered; should use an ordered dict or "
                                    "supply an explicit default value.")
-                
+
             objects = named_objs(objects)
             default = named_obj_default(objects)
-        
+
         super(Selector,self).__init__(default=default, objects=objects,
                                       instantiate=instantiate,
                                       compute_default_fn=compute_default_fn,
@@ -1824,7 +1824,7 @@ class ListSelector(ObjectSelector):
             self.default = self.compute_default_fn()
             for o in self.default:
                 self._ensure_value_is_in_objects(o)
-                    
+
     def _validate(self, val):
         for o in val:
             super(ListSelector, self)._validate(o)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1871,7 +1871,7 @@ class MultiFileSelector(ListSelector):
         self.objects = named_objs(sorted(glob.glob(self.path)))
         if self.default and all([o in self.objects.values() for o in self.default]):
             return
-        self.default = self.objects.values()
+        self.default = list(self.objects.values())
 
     def get_range(self):
         return abbreviate_paths(self.path,super(MultiFileSelector, self).get_range())

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -230,9 +230,9 @@ class JSONSerialization(Serialization):
     def objectselector_schema(cls, p, safe=False):
         try:
             allowed_types = [{'type': cls.json_schema_literal_types[type(obj)]}
-                             for obj in p.objects]
+                             for obj in p.objects.values()]
             schema =  { "anyOf": allowed_types}
-            schema['enum'] = p.objects
+            schema['enum'] = list(p.objects.values())
             return schema
         except:
             if safe is True:

--- a/tests/API0/testlistselector.py
+++ b/tests/API0/testlistselector.py
@@ -147,7 +147,7 @@ class TestListSelectorParameters(unittest.TestCase):
         self.assertEqual(Q.r, None)
         Q.params('r').compute_default()
         self.assertEqual(Q.r, [1,2,3])
-        self.assertEqual(Q.params('r').objects, [1,2,3])
+        self.assertEqual(Q.params('r').objects.values(), [1,2,3])
 
     def test_bad_compute_default(self):
         class Q(param.Parameterized):

--- a/tests/API0/testlistselector.py
+++ b/tests/API0/testlistselector.py
@@ -147,7 +147,7 @@ class TestListSelectorParameters(unittest.TestCase):
         self.assertEqual(Q.r, None)
         Q.params('r').compute_default()
         self.assertEqual(Q.r, [1,2,3])
-        self.assertEqual(Q.params('r').objects.values(), [1,2,3])
+        self.assertEqual(list(Q.params('r').objects.values()), [1,2,3])
 
     def test_bad_compute_default(self):
         class Q(param.Parameterized):

--- a/tests/API1/testlistselector.py
+++ b/tests/API1/testlistselector.py
@@ -146,7 +146,7 @@ class TestListSelectorParameters(API1TestCase):
         self.assertEqual(Q.r, None)
         Q.param.params('r').compute_default()
         self.assertEqual(Q.r, [1,2,3])
-        self.assertEqual(Q.param.params('r').objects, [1,2,3])
+        self.assertEqual(Q.param.params('r').objects.values(), [1,2,3])
 
     def test_bad_compute_default(self):
         class Q(param.Parameterized):

--- a/tests/API1/testlistselector.py
+++ b/tests/API1/testlistselector.py
@@ -146,7 +146,7 @@ class TestListSelectorParameters(API1TestCase):
         self.assertEqual(Q.r, None)
         Q.param.params('r').compute_default()
         self.assertEqual(Q.r, [1,2,3])
-        self.assertEqual(Q.param.params('r').objects.values(), [1,2,3])
+        self.assertEqual(list(Q.param.params('r').objects.values()), [1,2,3])
 
     def test_bad_compute_default(self):
         class Q(param.Parameterized):


### PR DESCRIPTION
Alternative to https://github.com/holoviz/param/pull/440.  This version stores the objects for ObjectSelector and its subclasses as a string->obj dictionary in all cases, which makes the logic cleaner and easier but may not be able to be made backwards compatible.