### PR TITLE
Fix serialization of Tuple

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1015,6 +1015,10 @@ class Tuple(Parameter):
 
 
     @classmethod
+    def serialize(cls, value):
+        return list(value) # As JSON has no tuple representation
+
+    @classmethod
     def deserialize(cls, value):
         return tuple(value) # As JSON has no tuple representation
 


### PR DESCRIPTION
Serialization must be symmetric otherwise things break (e.g. URL syncing which makes use of param serialization is broken without this).