### PR TITLE
Avoid clashing class_ slot in List parameter

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1364,7 +1364,7 @@ class List(Parameter):
     def __init__(self,default=[],class_=None,item_type=None,instantiate=True,
                  bounds=(0,None),**params):
         self.item_type = item_type or class_
-        self.class_ = class_
+        self.class_ = item_type or class_
         self.bounds = bounds
         Parameter.__init__(self,default=default,instantiate=instantiate,
                            **params)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1359,11 +1359,11 @@ class List(Parameter):
     items in the list are checked to be of that type.
     """
 
-    __slots__ = ['bounds', 'list_class']
+    __slots__ = ['bounds', 'item_type']
 
     def __init__(self,default=[],class_=None,instantiate=True,
                  bounds=(0,None),**params):
-        self.list_class = class_
+        self.item_type = class_
         self.bounds = bounds
         Parameter.__init__(self,default=default,instantiate=instantiate,
                            **params)
@@ -1396,9 +1396,9 @@ class List(Parameter):
         self._check_type(val)
 
     def _check_type(self,val):
-        if self.list_class is not None:
+        if self.item_type is not None:
             for v in val:
-                assert isinstance(v,self.list_class),repr(self.name)+": "+repr(v)+" is not an instance of " + repr(self.list_class) + "."
+                assert isinstance(v,self.item_type),repr(self.name)+": "+repr(v)+" is not an instance of " + repr(self.item_type) + "."
 
 
 class HookList(List):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1363,7 +1363,7 @@ class List(Parameter):
 
     def __init__(self,default=[],class_=None,item_type=None,instantiate=True,
                  bounds=(0,None),**params):
-        self.item_type = class_ or item_type
+        self.item_type = item_type or class_
         self.bounds = bounds
         Parameter.__init__(self,default=default,instantiate=instantiate,
                            **params)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1364,7 +1364,7 @@ class List(Parameter):
     def __init__(self,default=[],class_=None,item_type=None,instantiate=True,
                  bounds=(0,None),**params):
         self.item_type = item_type or class_
-        self.class_ = item_type or class_
+        self.class_ = self.item_type
         self.bounds = bounds
         Parameter.__init__(self,default=default,instantiate=instantiate,
                            **params)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1361,9 +1361,9 @@ class List(Parameter):
 
     __slots__ = ['bounds', 'item_type']
 
-    def __init__(self,default=[],class_=None,instantiate=True,
+    def __init__(self,default=[],class_=None,item_type=None,instantiate=True,
                  bounds=(0,None),**params):
-        self.item_type = class_
+        self.item_type = class_ or item_type
         self.bounds = bounds
         Parameter.__init__(self,default=default,instantiate=instantiate,
                            **params)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1359,11 +1359,11 @@ class List(Parameter):
     items in the list are checked to be of that type.
     """
 
-    __slots__ = ['class_','bounds']
+    __slots__ = ['bounds', 'list_class']
 
     def __init__(self,default=[],class_=None,instantiate=True,
                  bounds=(0,None),**params):
-        self.class_ = class_
+        self.list_class = class_
         self.bounds = bounds
         Parameter.__init__(self,default=default,instantiate=instantiate,
                            **params)
@@ -1396,9 +1396,9 @@ class List(Parameter):
         self._check_type(val)
 
     def _check_type(self,val):
-        if self.class_ is not None:
+        if self.list_class is not None:
             for v in val:
-                assert isinstance(v,self.class_),repr(self.name)+": "+repr(v)+" is not an instance of " + repr(self.class_) + "."
+                assert isinstance(v,self.list_class),repr(self.name)+": "+repr(v)+" is not an instance of " + repr(self.list_class) + "."
 
 
 class HookList(List):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1359,11 +1359,12 @@ class List(Parameter):
     items in the list are checked to be of that type.
     """
 
-    __slots__ = ['bounds', 'item_type']
+    __slots__ = ['bounds', 'item_type', 'class_']
 
     def __init__(self,default=[],class_=None,item_type=None,instantiate=True,
                  bounds=(0,None),**params):
         self.item_type = item_type or class_
+        self.class_ = class_
         self.bounds = bounds
         Parameter.__init__(self,default=default,instantiate=instantiate,
                            **params)

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -218,12 +218,12 @@ class JSONSerialization(Serialization):
     @classmethod
     def list_schema(cls, p, safe=False):
         schema =  { "type": "array"}
-        if safe is True and p.class_ is None:
+        if safe is True and p.list_class is None:
             msg = ('List without a class specified cannot be guaranteed '
                    'to be safe for serialization')
             raise UnsafeserializableException(msg)
-        if p.class_ is not None and p.class_ in cls.json_schema_literal_types:
-            schema['items'] = {"type": cls.json_schema_literal_types[p.class_]}
+        if p.list_class is not None and p.list_class in cls.json_schema_literal_types:
+            schema['items'] = {"type": cls.json_schema_literal_types[p.list_class]}
         return schema
 
     @classmethod

--- a/param/serializer.py
+++ b/param/serializer.py
@@ -218,12 +218,12 @@ class JSONSerialization(Serialization):
     @classmethod
     def list_schema(cls, p, safe=False):
         schema =  { "type": "array"}
-        if safe is True and p.list_class is None:
+        if safe is True and p.item_type is None:
             msg = ('List without a class specified cannot be guaranteed '
                    'to be safe for serialization')
             raise UnsafeserializableException(msg)
-        if p.list_class is not None and p.list_class in cls.json_schema_literal_types:
-            schema['items'] = {"type": cls.json_schema_literal_types[p.list_class]}
+        if p.item_type is not None and p.item_type in cls.json_schema_literal_types:
+            schema['items'] = {"type": cls.json_schema_literal_types[p.item_type]}
         return schema
 
     @classmethod


### PR DESCRIPTION
Here is one way to address https://github.com/holoviz/param/issues/455, namely to make sure the `List` parameter does not use the same `class_` slot as `ClassSelector` (I called it `list_class` for now instead).

Generally, I'm not sure why parameters inherit previous slot values at all (when they have a value of None) tbh...
