### PR TITLE
Fixed List validation

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1095,6 +1095,9 @@ class Composite(Parameter):
     in the order specified.  Likewise, setting the parameter takes a
     sequence of values and sets the value of the constituent
     attributes.
+
+    This Parameter type has not been tested with watchers and 
+    dependencies, and may not support them properly.
     """
 
     __slots__ = ['attribs', 'objtype']
@@ -1361,8 +1364,12 @@ class List(Parameter):
     Parameter whose value is a list of objects, usually of a specified type.
 
     The bounds allow a minimum and/or maximum length of
-    list to be enforced.  If the class is non-None, all
+    list to be enforced.  If the item_type is non-None, all
     items in the list are checked to be of that type.
+
+    `class_` is accepted as an alias for `item_type`, but is 
+    deprecated due to conflict with how the `class_` slot is
+    used in Selector classes.
     """
 
     __slots__ = ['bounds', 'item_type', 'class_']
@@ -1376,6 +1383,15 @@ class List(Parameter):
                            **params)
         self._validate(default)
 
+    def _validate(self, val):
+        """
+        Checks that the value is numeric and that it is within the hard
+        bounds; if not, an exception is raised.
+        """
+        self._validate_value(val, self.allow_None)
+        self._validate_bounds(val, self.bounds)
+        self._validate_item_type(val, self.item_type)
+        
     def _validate_bounds(self, val, bounds):
         "Checks that the list is of the right length and has the right contents."
         if bounds is None:

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1096,7 +1096,7 @@ class Composite(Parameter):
     sequence of values and sets the value of the constituent
     attributes.
 
-    This Parameter type has not been tested with watchers and 
+    This Parameter type has not been tested with watchers and
     dependencies, and may not support them properly.
     """
 
@@ -1367,7 +1367,7 @@ class List(Parameter):
     list to be enforced.  If the item_type is non-None, all
     items in the list are checked to be of that type.
 
-    `class_` is accepted as an alias for `item_type`, but is 
+    `class_` is accepted as an alias for `item_type`, but is
     deprecated due to conflict with how the `class_` slot is
     used in Selector classes.
     """
@@ -1391,7 +1391,7 @@ class List(Parameter):
         self._validate_value(val, self.allow_None)
         self._validate_bounds(val, self.bounds)
         self._validate_item_type(val, self.item_type)
-        
+
     def _validate_bounds(self, val, bounds):
         "Checks that the list is of the right length and has the right contents."
         if bounds is None:

--- a/tests/API1/testlist.py
+++ b/tests/API1/testlist.py
@@ -1,0 +1,58 @@
+import param
+from . import API1TestCase
+# TODO: I copied the tests from testobjectselector, although I
+# struggled to understand some of them. Both files should be reviewed
+# and cleaned up together.
+
+# TODO: tests copied from testobjectselector could use assertRaises
+# context manager (and could be updated in testobjectselector too).
+
+class TestListParameters(API1TestCase):
+
+    def setUp(self):
+        super(TestListParameters, self).setUp()
+        class P(param.Parameterized):
+            e = param.List([5,6,7], item_type=int)
+            l = param.List(["red","green","blue"], item_type=str, bounds=(0,10))
+
+        self.P = P
+
+    def test_default_None(self):
+        class Q(param.Parameterized):
+            r = param.List(default=[])  #  Also check None)
+
+    def test_set_object_constructor(self):
+        p = self.P(e=[6])
+        self.assertEqual(p.e, [6])
+
+    def test_set_object_outside_bounds(self):
+        p = self.P()
+        try:
+            p.l=[6]*11
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Object set outside range.")
+
+    def test_set_object_wrong_type(self):
+        p = self.P()
+        try:
+            p.e=['s']
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("Object allowed of wrong type.")
+
+    def test_set_object_not_None(self):
+        p = self.P(e=[6])
+        try:
+            p.e = None
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Object set outside range.")
+
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule()


### PR DESCRIPTION
Fixed validation for List parameters, which was broken in https://github.com/holoviz/param/commit/bf3d324ddaa597a64585177662e0d9e6287a2ece because the new `_validate_bounds()` and `_validate_item_type()` methods weren't called by the default implementation of `_validate()`. Closes #491. 