### PR TITLE
Fixed Path to allow folders, as already documented

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1628,45 +1628,39 @@ class resolve_path(ParameterizedFunction):
         Prepended to a non-relative path, in order, until a file is
         found.""")
 
-    path_to_file = Boolean(default=True, pickle_default_value=False, doc="""
+    path_to_file = Boolean(default=True, pickle_default_value=False,
+                           allow_None=True, doc="""
         String specifying whether the path refers to a 'File' or a 'Folder'.""")
 
     def __call__(self, path, **params):
         p = ParamOverrides(self, params)
-
         path = os.path.normpath(path)
+        ftype = "File" if p.path_to_file is True \
+            else "Folder" if p.path_to_file is False else "Path"
 
+        if not p.search_paths:
+            p.search_paths = [os.getcwd()]
+            
         if os.path.isabs(path):
-            if p.path_to_file:
-                if os.path.isfile(path):
-                    return path
-                else:
-                    raise IOError("File '%s' not found." %path)
-            elif not p.path_to_file:
-                if os.path.isdir(path):
-                    return path
-                else:
-                    raise IOError("Folder '%s' not found." %path)
-            else:
-                raise IOError("Type '%s' not recognised." %p.path_type)
+            if ((p.path_to_file is None  and os.path.exists(path)) or
+                (p.path_to_file is True  and os.path.isfile(path)) or
+                (p.path_to_file is False and os.path.isdir( path))):
+                return path
+            raise IOError("%s '%s' not found." % (ftype,path))
 
         else:
             paths_tried = []
             for prefix in p.search_paths:
                 try_path = os.path.join(os.path.normpath(prefix), path)
 
-                if p.path_to_file:
-                    if os.path.isfile(try_path):
-                        return try_path
-                elif not p.path_to_file:
-                    if os.path.isdir(try_path):
-                        return try_path
-                else:
-                    raise IOError("Type '%s' not recognised." %p.path_type)
+                if ((p.path_to_file is None  and os.path.exists(try_path)) or
+                    (p.path_to_file is True  and os.path.isfile(try_path)) or
+                    (p.path_to_file is False and os.path.isdir( try_path))):
+                    return try_path
 
                 paths_tried.append(try_path)
 
-            raise IOError(os.path.split(path)[1] + " was not found in the following place(s): " + str(paths_tried) + ".")
+            raise IOError(ftype + " " + os.path.split(path)[1] + " was not found in the following place(s): " + str(paths_tried) + ".")
 
 
 class normalize_path(ParameterizedFunction):
@@ -1725,20 +1719,17 @@ class Path(Parameter):
         super(Path,self).__init__(default,**params)
 
     def _resolve(self, path):
-        if self.search_paths:
-            return resolve_path(path, search_paths=self.search_paths)
-        else:
-            return resolve_path(path)
+        return resolve_path(path, path_to_file=None, search_paths=self.search_paths)
 
     def _validate(self, val):
         if val is None:
             if not self.allow_None:
-                Parameterized(name="%s.%s"%(self.owner.name,self.name)).warning('None is not allowed')
+                Parameterized(name="%s.%s"%(self.owner.name,self.name)).param.warning('None is not allowed')
         else:
             try:
                 self._resolve(val)
             except IOError as e:
-                Parameterized(name="%s.%s"%(self.owner.name,self.name)).warning('%s',e.args[0])
+                Parameterized(name="%s.%s"%(self.owner.name,self.name)).param.warning('%s',e.args[0])
 
     def __get__(self, obj, objtype):
         """
@@ -1776,10 +1767,7 @@ class Filename(Path):
     """
 
     def _resolve(self, path):
-        if self.search_paths:
-            return resolve_path(path, path_to_file=True, search_paths=self.search_paths)
-        else:
-            return resolve_path(path, path_to_file=True)
+        return resolve_path(path, path_to_file=True, search_paths=self.search_paths)
 
 
 class Foldername(Path):
@@ -1800,10 +1788,7 @@ class Foldername(Path):
     """
 
     def _resolve(self, path):
-        if self.search_paths:
-            return resolve_path(path, path_to_file=False, search_paths=self.search_paths)
-        else:
-            return resolve_path(path, path_to_file=False)
+        return resolve_path(path, path_to_file=False, search_paths=self.search_paths)
 
 
 
@@ -1959,7 +1944,7 @@ class CalendarDate(Number):
 class Color(Parameter):
     """
     Color parameter defined as a hex RGB string with an optional #
-    prefix.
+    prefix or (optionally) as a CSS3 color name.
     """
 
     # CSS3 color specification https://www.w3.org/TR/css-color-3/#svg-color

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1640,7 +1640,7 @@ class resolve_path(ParameterizedFunction):
 
         if not p.search_paths:
             p.search_paths = [os.getcwd()]
-            
+
         if os.path.isabs(path):
             if ((p.path_to_file is None  and os.path.exists(path)) or
                 (p.path_to_file is True  and os.path.isfile(path)) or


### PR DESCRIPTION
Path is documented as accepting both files and folders (directories), but it was only accepting files.  Fixed to make Path check only that the path exists, not whether it is a file or folder. Also simplified the logic overall. Marked API since the behavior has apparently never matched the documented API; now it should match the previously documented API.