### PR TITLE
Copy docs workflow from panel

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,26 +21,55 @@ jobs:
       DESC: "Documentation build"
     steps:
       - uses: actions/checkout@v2
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow -f
+        with:
+          fetch-depth: "100"
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python-version }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow -f
       - name: Set output
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: graphviz
         run: sudo apt install libgraphviz-dev
-      - name: env setup
+      - name: conda setup
         run: |
-          python -m pip install pip==21.0.0
-          python -m pip install nbsite --pre
-          python -m pip install -e .[doc] --use-feature=fast-deps --use-deprecated=legacy-resolver
+          conda config --set always_yes True
+          conda install -c pyviz "pyctdev>=0.5"
+          doit ecosystem_setup
+          doit env_create ${{ env.CHANS_DEV}} --python=3.7
+      - name: doit develop_install
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          conda list
+          doit develop_install ${{ env.CHANS_DEV}} -o doc -o examples
+          pip install sphinxcontrib-napoleon
+          pip install idom pydata_sphinx_theme
+      - name: generate rst
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          nbsite generate-rst --org holoviz --project-name param
+      - name: refmanual
+        run: |
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          python nbsite_generate_modules.py param -d ./doc/api -n param -e tests
       - name: build docs
         run: |
-          mkdir doc/Reference_Manual && nbsite_generate_modules.py param -d ./doc/Reference_Manual -n param -e tests
-          cp examples/user_guide/*.ipynb doc/user_guide/
-          python -m nbsite build --examples-assets='' --org holoviz --project-name param
+          eval "$(conda shell.bash hook)"
+          conda activate test-environment
+          nbsite build --what=html --output=builtdocs --org holoviz --project-name param
+          cp -r ./param/dist ./builtdocs/param_dist
+      - name: git status
+        run: |
+          git status
+          git diff
       - name: Deploy dev
         uses: peaceiris/actions-gh-pages@v3
         if: (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc'))

--- a/doc/index.md
+++ b/doc/index.md
@@ -4,6 +4,11 @@
 
 Are you a Python programmer? If so, you need Param, and check out our <a href="https://youtu.be/KP9bRmzinaY">5-minute intro video</a> to see why!
 
+<div align="right" style="margin-right:10% margin-left:10%;">
+    <iframe width="100%" height="400" src="https://www.youtube.com/embed/KP9bRmzinaY" title="Param: Python Parameters" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <a href="https://tinyurl.com/parampromo">(Download notebook)</a>
+</div>
+
 Param is a library for handling all the user-modifiable parameters, arguments, and attributes that control your code. It provides automatic, robust error-checking while dramatically reducing boilerplate code, letting you focus on what you want your code to do rather than on checking for all the possible ways users could supply inappropriate values to a function or class.
 
 Param lets you program declaratively in Python, stating facts about each of your parameters up front. Once you have done that, Param can handle the rest (type checking, range validation, documentation, serialization, and more!). 

--- a/doc/index.md
+++ b/doc/index.md
@@ -23,7 +23,7 @@ Getting Started <getting_started>
 User Guide <user_guide/index>
 Comparisons <comparisons>
 Roadmap <roadmap>
-API <reference>
+API <api>
 Github Source <https://github.com/holoviz/param>
 About <about>
 ```

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -13,7 +13,7 @@ Param subpackages
 
 `parameterized`_
  Parameter, Parameterized, and other core classes and methods
-`__init__`_
+`param`_
  Optional predefined parameter types like Number, Selector, etc.
 `ipython`_
  Optional help functions tailored for Jupyter and IPython
@@ -28,13 +28,13 @@ Param subpackages
    :hidden:
 
    parameterized <param.parameterized>
-   __init__ <param.__init__>
+   param <param>
    ipython <param.ipython>
    serializer <param.serializer>
    version <param.version>
 
 .. _parameterized: param.parameterized.html
-.. ___init__: param.__init__.html
+.. _param: param.html
 .. _ipython: param.ipython.html
 .. _serializer: param.serializer.html
 .. _version: param.version.html


### PR DESCRIPTION
Speculative attempt to use Panel's doc build configuration to see if it will get the reference manual building on a separate page per module, as Panel's does.