### PR TITLE
Replace nose with pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,7 @@ jobs:
       - name: unit all_deps
         if: (contains(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, 'py'))
         run: tox -e with_all
+      - name: run coveralls
+        env:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: tox -e coveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
         if: (contains(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, 'py'))
         run: tox -e with_all
       - name: run coveralls
+        if: matrix.python-version != '2.7'
         env:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         run: tox -e coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.lock
 .ipynb_checkpoints
 .vscode
+.tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,5 @@ ignore = E114,
 
 [tool:pytest]
 python_files = test*.py
+# Run the doctests found (if any) in the modules of param & numbergen.
+addopts = --doctest-modules param numbergen

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,5 @@ ignore = E114,
          W504,
          W605
 
-[nosetests]
-verbosity = 2
-with-doctest = 1
-nologcapture = 1
+[tool:pytest]
+python_files = test*.py

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
     # pip doesn't support tests_require
     # (https://github.com/pypa/pip/issues/1197)
     'tests': [
-        'nose',
+        'pytest',
         'flake8',
     ],
     'doc': [

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ extras_require = {
     # (https://github.com/pypa/pip/issues/1197)
     'tests': [
         'pytest',
+        'pytest-cov',
         'flake8',
     ],
     'doc': [

--- a/tests/API0/testcompositeparams.py
+++ b/tests/API0/testcompositeparams.py
@@ -92,8 +92,3 @@ class TestCompositeParameters(unittest.TestCase):
         # get_value_generator() should give the objects
         self.assertEqual(ix(), 2)
         self.assertEqual(iy(), 5)
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testdefaults.py
+++ b/tests/API0/testdefaults.py
@@ -4,6 +4,8 @@ Do all subclasses of Parameter supply a valid default?
 
 import unittest
 
+import pytest
+
 from param.parameterized import add_metaclass
 from param import concrete_descendents, Parameter
 
@@ -34,8 +36,7 @@ class TestDefaultsMetaclass(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
-            from nose.exc import SkipTest
-            raise SkipTest
+            pytest.skip()
 
         def add_test(p):
             def test(self):

--- a/tests/API0/testdefaults.py
+++ b/tests/API0/testdefaults.py
@@ -53,8 +53,3 @@ class TestDefaultsMetaclass(type):
 @add_metaclass(TestDefaultsMetaclass)
 class TestDefaults(unittest.TestCase):
     pass
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testdefaults.py
+++ b/tests/API0/testdefaults.py
@@ -32,7 +32,7 @@ except ImportError:
     skip.append('Series')
 
 
-class TestDefaultsMetaclass(type):
+class DefaultsMetaclassTest(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
@@ -51,6 +51,6 @@ class TestDefaultsMetaclass(type):
         return type.__new__(mcs, name, bases, dict_)
 
 
-@add_metaclass(TestDefaultsMetaclass)
+@add_metaclass(DefaultsMetaclassTest)
 class TestDefaults(unittest.TestCase):
     pass

--- a/tests/API0/testdynamicparams.py
+++ b/tests/API0/testdynamicparams.py
@@ -247,12 +247,6 @@ class TestDynamicSharedNumbergen(TestDynamicParameters):
             self.assertNotEqual(call_1, t12.x)
 
 
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
-
-
 # Commented out block in the original doctest version.
 # Maybe these are features originally planned but never implemented
 

--- a/tests/API0/testlistselector.py
+++ b/tests/API0/testlistselector.py
@@ -155,7 +155,3 @@ class TestListSelectorParameters(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             Q.params('r').compute_default()
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testnumbergen.py
+++ b/tests/API0/testnumbergen.py
@@ -33,7 +33,3 @@ class TestUniformRandomOffset(unittest.TestCase):
         for _ in range(_iterations):
             value = gen()
             self.assertTrue(lbound <= value < ubound)
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testnumpy.py
+++ b/tests/API0/testnumpy.py
@@ -33,8 +33,3 @@ class TestNumpy(unittest.TestCase):
 
         z = Z(z=numpy.array([1,2]))
         _is_array_and_equal(z.z,[1,2])
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testobjectselector.py
+++ b/tests/API0/testobjectselector.py
@@ -101,8 +101,3 @@ class TestObjectSelectorParameters(unittest.TestCase):
             pass
         else:
             raise AssertionError("ObjectSelector created without range.")
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testparameterizedobject.py
+++ b/tests/API0/testparameterizedobject.py
@@ -10,18 +10,16 @@ import numbergen
 
 
 import random
-from nose.tools import istest, nottest
-
 
 from param.parameterized import ParamOverrides, shared_parameters
 
-@nottest
 class _SomeRandomNumbers(object):
     def __call__(self):
         return random.random()
 
-@nottest
 class TestPO(param.Parameterized):
+    __test__ = False
+
     inst = param.Parameter(default=[1,2,3],instantiate=True)
     notinst = param.Parameter(default=[1,2,3],instantiate=False)
     const = param.Parameter(default=1,constant=True)
@@ -30,24 +28,24 @@ class TestPO(param.Parameterized):
 
     dyn = param.Dynamic(default=1)
 
-@nottest
 class AnotherTestPO(param.Parameterized):
     instPO = param.Parameter(default=TestPO(),instantiate=True)
     notinstPO = param.Parameter(default=TestPO(),instantiate=False)
 
-@nottest
 class TestAbstractPO(param.Parameterized):
+    __test__ = False
+
     __abstract = True
 
 class _AnotherAbstractPO(param.Parameterized):
     __abstract = True
 
 
-@nottest
 class TestParamInstantiation(AnotherTestPO):
+    __test__ = False
+
     instPO = param.Parameter(default=AnotherTestPO(),instantiate=False)
 
-@istest
 class TestParameterized(unittest.TestCase):
 
     def test_constant_parameter(self):
@@ -160,22 +158,22 @@ class TestParameterized(unittest.TestCase):
 
 from param import parameterized
 
-@nottest
 class some_fn(param.ParameterizedFunction):
-   num_phase = param.Number(18)
-   frequencies = param.List([99])
-   scale = param.Number(0.3)
+    __test__ = False
 
-   def __call__(self,**params_to_override):
-       params = parameterized.ParamOverrides(self,params_to_override)
-       num_phase = params['num_phase']
-       frequencies = params['frequencies']
-       scale = params['scale']
-       return scale,num_phase,frequencies
+    num_phase = param.Number(18)
+    frequencies = param.List([99])
+    scale = param.Number(0.3)
+
+    def __call__(self,**params_to_override):
+        params = parameterized.ParamOverrides(self,params_to_override)
+        num_phase = params['num_phase']
+        frequencies = params['frequencies']
+        scale = params['scale']
+        return scale,num_phase,frequencies
 
 instance = some_fn.instance()
 
-@istest
 class TestParameterizedFunction(unittest.TestCase):
 
     def _basic_tests(self,fn):
@@ -201,12 +199,12 @@ class TestParameterizedFunction(unittest.TestCase):
         self.assertEqual(i(),(0.3,18,[10,20,30]))
 
 
-@nottest
 class TestPO1(param.Parameterized):
+    __test__ = False
+
     x = param.Number(default=numbergen.UniformRandom(lbound=-1,ubound=1,seed=1),bounds=(-1,1))
     y = param.Number(default=1,bounds=(-1,1))
 
-@istest
 class TestNumberParameter(unittest.TestCase):
 
     def test_outside_bounds(self):
@@ -231,7 +229,6 @@ class TestNumberParameter(unittest.TestCase):
             assert False, "Should raise ValueError."
 
 
-@istest
 class TestStringParameter(unittest.TestCase):
 
     def setUp(self):
@@ -256,7 +253,6 @@ class TestStringParameter(unittest.TestCase):
 
 
 
-@istest
 class TestParamOverrides(unittest.TestCase):
 
     def setUp(self):

--- a/tests/API0/testparameterizedobject.py
+++ b/tests/API0/testparameterizedobject.py
@@ -297,9 +297,3 @@ class TestSharedParameters(unittest.TestCase):
     def test_shared_list(self):
         self.assertTrue(self.p1.inst is self.p2.inst)
         self.assertTrue(self.p1.params('inst').default is not self.p2.inst)
-
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testparameterizedrepr.py
+++ b/tests/API0/testparameterizedrepr.py
@@ -159,9 +159,3 @@ class TestParameterizedRepr(unittest.TestCase):
 
         self.assertEqual(obj.pprint(qualify=True),
                          "tests.API0.testparameterizedrepr."+r)
-
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API0/testtimedependent.py
+++ b/tests/API0/testtimedependent.py
@@ -7,7 +7,7 @@ import param
 import numbergen
 import copy
 
-from nose.plugins.skip import SkipTest
+import pytest
 import fractions
 
 try:
@@ -81,16 +81,15 @@ class TestTimeClass(unittest.TestCase):
         self.assertEqual(t(), 1)
         self.assertEqual(t.time_type, fractions.Fraction)
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_init_gmpy(self):
-        if gmpy is None: raise SkipTest
-
         t = param.Time(time_type=gmpy.mpq)
         self.assertEqual(t(), gmpy.mpq(0))
         t.advance(gmpy.mpq(0.25))
         self.assertEqual(t(), gmpy.mpq(1,4))
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_init_gmpy_advanced(self):
-        if gmpy is None: raise SkipTest
         t = param.Time(time_type=gmpy.mpq,
                        timestep=gmpy.mpq(0.25),
                        until=1.5)
@@ -270,12 +269,12 @@ class TestTimeDependentDynamic(unittest.TestCase):
         self.assertEqual(hashfn(pi), hashfn(fractions.Fraction(pi)))
 
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_hashing_integers_gmpy(self):
         """
         Check that hashes for gmpy values at the integers also matches
         those of ints, fractions and strings.
         """
-        if gmpy is None: raise SkipTest
         hashfn = numbergen.Hash("test", input_count=1)
         hash_1 = hashfn(1)
         hash_42 = hashfn(42)
@@ -286,12 +285,12 @@ class TestTimeDependentDynamic(unittest.TestCase):
         self.assertEqual(hash_42, hashfn(gmpy.mpq(42)))
         self.assertEqual(hash_42, hashfn(42))
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_hashing_rationals_gmpy(self):
         """
         Check that hashes of fractions and gmpy mpqs match for some
         reasonable rational numbers.
         """
-        if gmpy is None: raise SkipTest
         pi = "3.141592"
         hashfn = numbergen.Hash("test", input_count=1)
         self.assertEqual(hashfn(0.5), hashfn(gmpy.mpq(0.5)))

--- a/tests/API0/testtimedependent.py
+++ b/tests/API0/testtimedependent.py
@@ -296,10 +296,3 @@ class TestTimeDependentDynamic(unittest.TestCase):
         hashfn = numbergen.Hash("test", input_count=1)
         self.assertEqual(hashfn(0.5), hashfn(gmpy.mpq(0.5)))
         self.assertEqual(hashfn(pi), hashfn(gmpy.mpq(3.141592)))
-
-
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testcompositeparams.py
+++ b/tests/API1/testcompositeparams.py
@@ -93,8 +93,3 @@ class TestCompositeParameters(API1TestCase):
         # get_value_generator() should give the objects
         self.assertEqual(ix(), 2)
         self.assertEqual(iy(), 5)
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testdefaults.py
+++ b/tests/API1/testdefaults.py
@@ -1,6 +1,7 @@
 """
 Do all subclasses of Parameter supply a valid default?
 """
+import pytest
 
 from param.parameterized import add_metaclass
 from param import concrete_descendents, Parameter
@@ -31,8 +32,7 @@ class TestDefaultsMetaclass(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
-            from nose.exc import SkipTest
-            raise SkipTest
+            pytest.skip()
 
         def add_test(p):
             def test(self):

--- a/tests/API1/testdefaults.py
+++ b/tests/API1/testdefaults.py
@@ -28,7 +28,7 @@ except ImportError:
     skip.append('Series')
 
 
-class TestDefaultsMetaclass(type):
+class DefaultsMetaclassTest(type):
     def __new__(mcs, name, bases, dict_):
 
         def test_skip(*args,**kw):
@@ -47,6 +47,6 @@ class TestDefaultsMetaclass(type):
         return type.__new__(mcs, name, bases, dict_)
 
 
-@add_metaclass(TestDefaultsMetaclass)
+@add_metaclass(DefaultsMetaclassTest)
 class TestDefaults(API1TestCase):
     pass

--- a/tests/API1/testdefaults.py
+++ b/tests/API1/testdefaults.py
@@ -50,8 +50,3 @@ class TestDefaultsMetaclass(type):
 @add_metaclass(TestDefaultsMetaclass)
 class TestDefaults(API1TestCase):
     pass
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testdynamicparams.py
+++ b/tests/API1/testdynamicparams.py
@@ -248,12 +248,6 @@ class TestDynamicSharedNumbergen(TestDynamicParameters):
             self.assertNotEqual(call_1, t12.x)
 
 
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()
-
-
 # Commented out block in the original doctest version.
 # Maybe these are features originally planned but never implemented
 

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -39,6 +39,8 @@ simple_list = [1]
 
 class TestSet(param.Parameterized):
 
+    __test__ = False
+
     numpy_params = ['r']
     pandas_params = ['s','t','u']
     conditionally_unsafe = ['f', 'o']

--- a/tests/API1/testlist.py
+++ b/tests/API1/testlist.py
@@ -51,8 +51,3 @@ class TestListParameters(API1TestCase):
             pass
         else:
             raise AssertionError("Object set outside range.")
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testlistselector.py
+++ b/tests/API1/testlistselector.py
@@ -154,7 +154,3 @@ class TestListSelectorParameters(API1TestCase):
 
         with self.assertRaises(TypeError):
             Q.param.params('r').compute_default()
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testnumbergen.py
+++ b/tests/API1/testnumbergen.py
@@ -31,7 +31,3 @@ class TestUniformRandomOffset(API1TestCase):
         for _ in range(_iterations):
             value = gen()
             self.assertTrue(lbound <= value < ubound)
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testnumpy.py
+++ b/tests/API1/testnumpy.py
@@ -41,7 +41,3 @@ class TestNumpy(API1TestCase):
 
         z = Z(z=numpy.array([1,2]))
         _is_array_and_equal(z.z,[1,2])
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testobjectselector.py
+++ b/tests/API1/testobjectselector.py
@@ -133,8 +133,3 @@ class TestObjectSelectorParameters(API1TestCase):
             pass
         else:
             raise AssertionError("ObjectSelector created without range.")
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testpandas.py
+++ b/tests/API1/testpandas.py
@@ -219,7 +219,3 @@ class TestSeries(API1TestCase):
         test = Test()
         test.series = None
         self.assertIs(test.series, None)
-                
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -497,9 +497,3 @@ class TestSharedParameters(API1TestCase):
     def test_shared_list(self):
         self.assertTrue(self.p1.inst is self.p2.inst)
         self.assertTrue(self.p1.param.params('inst').default is not self.p2.inst)
-
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -12,19 +12,17 @@ from .utils import MockLoggingHandler
 
 
 import random
-from nose.tools import istest, nottest
-
 
 from param.parameterized import ParamOverrides, shared_parameters
 from param.parameterized import default_label_formatter, no_instance_params
 
-@nottest
 class _SomeRandomNumbers(object):
     def __call__(self):
         return random.random()
 
-@nottest
 class TestPO(param.Parameterized):
+    __test__ = False
+
     inst = param.Parameter(default=[1,2,3],instantiate=True)
     notinst = param.Parameter(default=[1,2,3],instantiate=False, per_instance=False)
     const = param.Parameter(default=1,constant=True)
@@ -35,32 +33,33 @@ class TestPO(param.Parameterized):
 
     dyn = param.Dynamic(default=1)
 
-@nottest
 class TestPOValidation(param.Parameterized):
+    __test__ = False
+
     value = param.Number(default=2, bounds=(0, 4))
 
-@nottest
 @no_instance_params
 class TestPONoInstance(TestPO):
+    __test__ = False
     pass
 
-@nottest
 class AnotherTestPO(param.Parameterized):
     instPO = param.Parameter(default=TestPO(),instantiate=True)
     notinstPO = param.Parameter(default=TestPO(),instantiate=False)
 
-@nottest
 class TestAbstractPO(param.Parameterized):
+    __test__ = False
+
     __abstract = True
 
 class _AnotherAbstractPO(param.Parameterized):
     __abstract = True
 
-@nottest
 class TestParamInstantiation(AnotherTestPO):
+    __test__ = False
+
     instPO = param.Parameter(default=AnotherTestPO(),instantiate=False)
 
-@istest
 class TestParameterized(API1TestCase):
 
     @classmethod
@@ -340,22 +339,22 @@ class TestParameterized(API1TestCase):
 
 from param import parameterized
 
-@nottest
 class some_fn(param.ParameterizedFunction):
-   num_phase = param.Number(18)
-   frequencies = param.List([99])
-   scale = param.Number(0.3)
+    __test__ = False
 
-   def __call__(self,**params_to_override):
-       params = parameterized.ParamOverrides(self,params_to_override)
-       num_phase = params['num_phase']
-       frequencies = params['frequencies']
-       scale = params['scale']
-       return scale,num_phase,frequencies
+    num_phase = param.Number(18)
+    frequencies = param.List([99])
+    scale = param.Number(0.3)
+
+    def __call__(self,**params_to_override):
+        params = parameterized.ParamOverrides(self,params_to_override)
+        num_phase = params['num_phase']
+        frequencies = params['frequencies']
+        scale = params['scale']
+        return scale,num_phase,frequencies
 
 instance = some_fn.instance()
 
-@istest
 class TestParameterizedFunction(API1TestCase):
 
     def _basic_tests(self,fn):
@@ -381,12 +380,12 @@ class TestParameterizedFunction(API1TestCase):
         self.assertEqual(i(),(0.3,18,[10,20,30]))
 
 
-@nottest
 class TestPO1(param.Parameterized):
+    __test__ = False
+
     x = param.Number(default=numbergen.UniformRandom(lbound=-1,ubound=1,seed=1),bounds=(-1,1))
     y = param.Number(default=1,bounds=(-1,1))
 
-@istest
 class TestNumberParameter(API1TestCase):
 
     def test_outside_bounds(self):
@@ -411,7 +410,6 @@ class TestNumberParameter(API1TestCase):
             assert False, "Should raise ValueError."
 
 
-@istest
 class TestStringParameter(API1TestCase):
 
     def setUp(self):
@@ -435,7 +433,6 @@ class TestStringParameter(API1TestCase):
         assert t.c is None
 
 
-@istest
 class TestParameterizedUtilities(API1TestCase):
 
     def setUp(self):
@@ -455,7 +452,6 @@ class TestParameterizedUtilities(API1TestCase):
     def test_default_label_formatter_overrides(self):
         assert default_label_formatter.instance(overrides={'a': 'b'})('a') == 'b'
 
-@istest
 class TestParamOverrides(API1TestCase):
 
     def setUp(self):

--- a/tests/API1/testparameterizedrepr.py
+++ b/tests/API1/testparameterizedrepr.py
@@ -159,9 +159,3 @@ class TestParameterizedRepr(API1TestCase):
 
         self.assertEqual(obj.pprint(qualify=True),
                          "tests.API1.testparameterizedrepr."+r)
-
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testselector.py
+++ b/tests/API1/testselector.py
@@ -113,8 +113,3 @@ class TestSelectorParameters(API1TestCase):
             pass
         else:
             raise AssertionError("Selector created without range.")
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testtimedependent.py
+++ b/tests/API1/testtimedependent.py
@@ -296,10 +296,3 @@ class TestTimeDependentDynamic(API1TestCase):
         hashfn = numbergen.Hash("test", input_count=1)
         self.assertEqual(hashfn(0.5), hashfn(gmpy.mpq(0.5)))
         self.assertEqual(hashfn(pi), hashfn(gmpy.mpq(3.141592)))
-
-
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tests/API1/testtimedependent.py
+++ b/tests/API1/testtimedependent.py
@@ -7,7 +7,7 @@ import numbergen
 import copy
 
 from . import API1TestCase
-from nose.plugins.skip import SkipTest
+import pytest
 import fractions
 
 try:
@@ -81,16 +81,15 @@ class TestTimeClass(API1TestCase):
         self.assertEqual(t(), 1)
         self.assertEqual(t.time_type, fractions.Fraction)
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_init_gmpy(self):
-        if gmpy is None: raise SkipTest
-
         t = param.Time(time_type=gmpy.mpq)
         self.assertEqual(t(), gmpy.mpq(0))
         t.advance(gmpy.mpq(0.25))
         self.assertEqual(t(), gmpy.mpq(1,4))
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_init_gmpy_advanced(self):
-        if gmpy is None: raise SkipTest
         t = param.Time(time_type=gmpy.mpq,
                        timestep=gmpy.mpq(0.25),
                        until=1.5)
@@ -270,12 +269,12 @@ class TestTimeDependentDynamic(API1TestCase):
         self.assertEqual(hashfn(pi), hashfn(fractions.Fraction(pi)))
 
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_hashing_integers_gmpy(self):
         """
         Check that hashes for gmpy values at the integers also matches
         those of ints, fractions and strings.
         """
-        if gmpy is None: raise SkipTest
         hashfn = numbergen.Hash("test", input_count=1)
         hash_1 = hashfn(1)
         hash_42 = hashfn(42)
@@ -286,12 +285,12 @@ class TestTimeDependentDynamic(API1TestCase):
         self.assertEqual(hash_42, hashfn(gmpy.mpq(42)))
         self.assertEqual(hash_42, hashfn(42))
 
+    @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_hashing_rationals_gmpy(self):
         """
         Check that hashes of fractions and gmpy mpqs match for some
         reasonable rational numbers.
         """
-        if gmpy is None: raise SkipTest
         pi = "3.141592"
         hashfn = numbergen.Hash("test", input_count=1)
         self.assertEqual(hashfn(0.5), hashfn(gmpy.mpq(0.5)))

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -776,8 +776,3 @@ class TestTrigger(API1TestCase):
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 0)
         self.assertEqual(args[1].type, 'triggered')
-
-
-if __name__ == "__main__":
-    import nose
-    nose.runmodule()

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 
 [testenv]
 deps = .[tests]
-commands = nosetests
+commands = pytest
 
 [testenv:with_numpy]
 deps = {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 
 [testenv]
 deps = .[tests]
-commands = pytest
+commands = pytest tests
 
 [testenv:with_numpy]
 deps = {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 
 [testenv]
 deps = .[tests]
-commands = pytest tests
+commands = pytest tests --cov=numbergen --cov=param --cov-append
 
 [testenv:with_numpy]
 deps = {[testenv]deps}
@@ -53,16 +53,11 @@ setenv = {[testenv:with_numpy]setenv}
          {[testenv:with_jsonschema]setenv}
          {[testenv:with_gmpy]setenv}
 
-[testenv:coverage]
-# remove develop install if https://github.com/ioam/param/issues/219
-# implemented
-setdevelop = True
-passenv = TRAVIS TRAVIS_*
-deps = {[testenv:with_all]deps}
-       coveralls
-setenv = {[testenv:with_all]setenv}
-commands = nosetests --with-coverage --cover-package=param --cover-package=numbergen
-           coveralls
+[testenv:coveralls]
+passenv = GITHUB_*
+skip_install = true
+deps = coveralls
+commands = coveralls
 
 [testenv:flakes]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ setenv = {[testenv:with_numpy]setenv}
 passenv = GITHUB_*
 skip_install = true
 deps = coveralls
-commands = coveralls
+commands = coveralls --service=github
 
 [testenv:flakes]
 skip_install = true


### PR DESCRIPTION
In line with what was done partially in #423, the goal of this PR is to replace nose by pytest:

* [x] Minimal changes required to switch to pytest and get the CI green
* [x] Fix coverage

When this is done, some optional tasks could be tackled such as fixing the warnings already spotted in #423, switching to fixtures when relevant...