### PR TITLE
ListSelector restricted to list type objects

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1862,6 +1862,9 @@ class ListSelector(Selector):
     def _validate(self, val):
         if (val is None and self.allow_None):
             return
+        if not isinstance(val, list):
+            raise ValueError("ListSelector parameter %r only takes list "
+                             "types, not %r." % (self.name, val))
         for o in val:
             super(ListSelector, self)._validate(o)
 

--- a/tests/API0/testlistselector.py
+++ b/tests/API0/testlistselector.py
@@ -53,7 +53,7 @@ class TestListSelectorParameters(unittest.TestCase):
         p.g = [7]
         try:
             p.g = None
-        except TypeError:
+        except ValueError:
             pass
         else:
             raise AssertionError("Object set outside range.")
@@ -110,12 +110,12 @@ class TestListSelectorParameters(unittest.TestCase):
     ### new tests (not copied from testobjectselector)
 
     def test_bad_default(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             class Q(param.Parameterized):
                 r = param.ListSelector(default=6,check_on_set=True)
 
     def test_implied_check_on_set(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             class Q(param.Parameterized):
                 r = param.ListSelector(default=7,objects=[7,8])
 
@@ -135,7 +135,7 @@ class TestListSelectorParameters(unittest.TestCase):
         class Q(param.Parameterized):
             r = param.ListSelector(default=6,check_on_set=False)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             Q.r = 6
     ##########################
 

--- a/tests/API1/testlistselector.py
+++ b/tests/API1/testlistselector.py
@@ -52,7 +52,7 @@ class TestListSelectorParameters(API1TestCase):
         p.g = [7]
         try:
             p.g = None
-        except TypeError:
+        except ValueError:
             pass
         else:
             raise AssertionError("Object set outside range.")
@@ -109,12 +109,12 @@ class TestListSelectorParameters(API1TestCase):
     ### new tests (not copied from testobjectselector)
 
     def test_bad_default(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             class Q(param.Parameterized):
                 r = param.ListSelector(default=6,check_on_set=True)
 
     def test_implied_check_on_set(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             class Q(param.Parameterized):
                 r = param.ListSelector(default=7,objects=[7,8])
 
@@ -134,7 +134,7 @@ class TestListSelectorParameters(API1TestCase):
         class Q(param.Parameterized):
             r = param.ListSelector(default=6,check_on_set=False)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             Q.r = 6
     ##########################
 
@@ -154,3 +154,16 @@ class TestListSelectorParameters(API1TestCase):
 
         with self.assertRaises(TypeError):
             Q.param.params('r').compute_default()
+
+    def test_initialization_bad_iterable(self):
+        with self.assertRaises(ValueError):
+            class Q(param.Parameterized):
+                j = param.ListSelector('ab', ['a', 'b', 'c', 'd'])
+
+    def test_set_bad_iterable(self):
+        class Q(param.Parameterized):
+            r = param.ListSelector(objects=['a', 'b', 'c', 'd'])
+
+        q = Q()
+        with self.assertRaises(ValueError):
+            q.r = 'ab'


### PR DESCRIPTION
Fixes #527 

I chose to raise a `ValueError` when the type is not a list since raising `ValueError` seems to be what param does in this case. The tests used to catch `TypeError`s in some occasions because param was trying to iterate over non iterables.