### PR TITLE
Fixed version regexp

### DIFF
--- a/param/version.py
+++ b/param/version.py
@@ -191,7 +191,7 @@ class Version(object):
                     except: pass
             if output is None:
                 output = run_cmd([cmd, 'describe', '--long', '--match',
-                                  "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
+                                  "v[0-9]*[.][0-9]*[.][0-9]*", '--dirty'],
                                  cwd=os.path.dirname(self.fpath))
             if as_string: return output
         except Exception as e1:


### PR DESCRIPTION
Previous regexp would have matched "vim" and "vis" and "van" as valid version strings, which surely they are not. Presumably also needs fixing on autover.