### PR TITLE
Added Dependencies_and_Watchers user guide

### DIFF
--- a/doc/user_guide/index.md
+++ b/doc/user_guide/index.md
@@ -1,17 +1,17 @@
 # User Guide
 
-This user guide provides detailed information about how to use Param, assuming you have worked through the Getting Started guide. Sections marked TODO are still in development as of 7/2021.
+This user guide provides detailed information about how to use Param, assuming you have worked through the Getting Started guide.
 
 - [Simplifying Codebases](./Simplifying_Codebases): How Param allows you to eliminate boilerplate and unsafe code 
 - [Parameters](./Parameters): Using parameters (Class vs. instance parameters, setting defaults, etc.)
 - [Parameter Types](./Parameter_Types): Predefined Parameter classes available for your use
-- Dependencies and Watchers: Expressing relationships between parameters and parameters or code, and triggering events (TODO)
+- [Dependencies and Watchers](./Dependencies_and_Watchers): Expressing relationships between parameters and parameters or code, and triggering events
 - [Serialization and Persistence](./Serialization_and_Persistence): Saving the state of a Parameterized object to a text, script, or pickle file
 - [Outputs](./Outputs): Output types and connecting output to Parameter inputs
 - [Logging and Messages](./Logging_and_Messages): Logging, messaging, warning, and raising errors on Parameterized objects
 - [ParameterizedFunctions](./ParameterizedFunctions): Parameterized function objects, for configurable callables
 - [Dynamic Parameters](./Dynamic_Parameters): Using dynamic parameter values with and without Numbergen
-- [How Param works](How_Param_Works): Internal details, for Param developers and power users
+- [How Param Works](./How_Param_Works): Internal details, for Param developers and power users
 
 ```{toctree}
 ---
@@ -22,7 +22,11 @@ Overview <index>
 Simplifying Codebases <Simplifying_Codebases>
 Parameters <Parameters>
 Parameter Types <Parameter_Types>
+Dependencies and Watchers <Dependencies_and_Watchers>
+Serialization and Persistence <Serialization_and_Persistence>
+Outputs <Outputs>
 Logging and Messages <Logging_and_Messages>
 ParameterizedFunctions <ParameterizedFunctions>
+Dynamic Parameters <Dynamic_Parameters>
 How Param Works <How_Param_Works>
 ```

--- a/examples/user_guide/Dependencies_and_Watchers.ipynb
+++ b/examples/user_guide/Dependencies_and_Watchers.ipynb
@@ -32,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58661e91",
+   "id": "e8166ebf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f14d35a5",
+   "id": "d308a16d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c2101bd",
+   "id": "9cab7a1b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "299991bf",
+   "id": "7f7f48f2",
    "metadata": {},
    "source": [
     "Here we have created an object `d` of type `D` with a unique ID like `D00003`. `d` has various parameters, including one nested Parameterized object in its parameter `n`. In this class, the nested parameter is set to our earlier object `c`, using `instantiate=False` to ensure that the value is precisely the same earlier object, not a copy of it. You can verify that it is the same object by comparing e.g. `name='C00002'` in the repr for the subobject in `d` to the name in the repr for `c` in the previous section; both should be e.g. `C00002`.\n",
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0576bcb2",
+   "id": "010df800",
    "metadata": {},
    "source": [
     "Here we can see that method `cb1` will be invoked for any value changes in `d`'s parameters `x` or `s`, for any value changes in `c`'s parameter `country`, and a change in the `constant` slot of `s`. These dependency relationships correspond to the specification `@param.depends('x', 's', 'n.country', 's:constant', watch=True)` above.\n",
@@ -182,12 +182,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.x=5"
+    "d.x = 5"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "813c7067",
+   "id": "32c4a1e8",
    "metadata": {},
    "source": [
     "`cb3` and `cb4` are also invoked, because `cb3` depends on `x` as well, plus `cb4` depends on `cb3`, inheriting all of `cb3`'s dependencies.\n",
@@ -198,16 +198,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "629cb096",
+   "id": "70cc0df5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "c.country='Togo'"
+    "c.country = 'Togo'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b3cedd68",
+   "id": "9d30e14d",
    "metadata": {},
    "source": [
     "As you can see, `cb2` is also invoked, because `cb2` depends on _all_ parameters of the subobject in `n`. \n",
@@ -222,12 +222,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c.continent='Asia'"
+    "c.continent = 'Asia'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "17251553",
+   "id": "ec313bd1",
    "metadata": {},
    "source": [
     "Changing metadata works just the same as changing values. Because `cb1` depends on the `constant` slot of `s`, it is invoked when that slot changes:"
@@ -236,11 +236,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf14070c",
+   "id": "a5b002ee",
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.param.s.constant=True"
+    "d.param.s.constant = True"
    ]
   },
   {
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65a5a8e5",
+   "id": "84bb8ce9",
    "metadata": {},
    "source": [
     "You could run this code manually:"
@@ -287,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcd4632c",
+   "id": "03a9ff10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1267f28d",
+   "id": "35d0fca4",
    "metadata": {},
    "source": [
     "### `@param.depends` with function objects\n",
@@ -394,22 +394,22 @@
     "def g(country, i):\n",
     "    print(f\"g country={country} i={i}\")\n",
     "\n",
-    "c.country='Japan'"
+    "c.country = 'Japan'"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b166d745",
+   "id": "3347781e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.i=6"
+    "d.i = 6"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1dd59c3f",
+   "id": "160556c9",
    "metadata": {},
    "source": [
     "Here you can see that in addition to the classmethods starting with `cb` previously set up to depend on the country, setting `c`'s `country` parameter or `d`'s `i` parameter now also invokes function `g`, passing in the current values of the parameters it depends on whenever the function gets invoked. `g` can then make a side effect happen such as updating any other data structure it can access that needs to be changed when `country` or `i` changes. \n",
@@ -422,7 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3557e982",
+   "id": "6755aa4d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "371c2a5b",
+   "id": "75f6586e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22f09fa4",
+   "id": "23517811",
    "metadata": {},
    "source": [
     "Here, we have set up three Watchers, each invoking a method on `P` when either `a` or `b` changes. The first Watcher invokes `run_a1` when `a` changes, and in turn `run_a1` changes `b`. Since `queued=True` for `run_a1`, `run_b` is not invoked while `run_a1` executes, but only later once both `run_a1` and `run_a2` have completed (since both Watchers were triggered by the original event `p.a=1`). \n",
@@ -493,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6bfb4b5",
+   "id": "f1792f63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +504,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d0dbaef",
+   "id": "4d6c35ef",
    "metadata": {},
    "source": [
     "## Using dependencies and watchers\n",
@@ -546,7 +546,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecb4e66b",
+   "id": "e421fba8",
    "metadata": {},
    "source": [
     "Here, even though `p.a` is changed four times, each of the watchers of `a` is executed only once, with the final value. One of those events then changes `b`, so `b`'s watcher is also executed once.\n",
@@ -557,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8b126be",
+   "id": "60ef3dfd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,6 +567,24 @@
     "    p.a = 3\n",
     "    p.a = 1\n",
     "    p.a = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bba6ca3",
+   "metadata": {},
+   "source": [
+    "If all you need to do is set a batch of parameters, you can use `.set_param` instead of `batch_call_watchers`, which has the same underlying batching mechanism:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f619f53e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.param.set_param(a=9,b=2)"
    ]
   },
   {
@@ -593,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04bd8a67",
+   "id": "53711778",
    "metadata": {},
    "source": [
     "(Notice that none of the callbacks is invoked, despite all the Watchers on `p.a` and `p.b`.)"
@@ -601,7 +619,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd987890",
+   "id": "ed7fa863",
    "metadata": {},
    "source": [
     "### `.param.trigger`\n",
@@ -614,7 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46be57ca",
+   "id": "c9ea4285",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +641,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c128f4b",
+   "id": "7acd308a",
    "metadata": {},
    "source": [
     "But if you explicitly trigger parameter `b` on `p`, `run_b` will be invoked, even though the value of `b` is not changing:"
@@ -632,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db0eb5f8",
+   "id": "9f9ade0e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "deacc3cd",
+   "id": "1da921f7",
    "metadata": {},
    "source": [
     "If you trigger `a`, the usual series of chained events will be triggered, including changing `b`:"
@@ -650,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9667d7ea",
+   "id": "d21f9443",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -659,7 +677,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b605755",
+   "id": "33b2f04e",
    "metadata": {},
    "source": [
     "### `Event` Parameter\n",
@@ -672,7 +690,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70a2937e",
+   "id": "06b87f25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,13 +702,13 @@
     "        print(f'e=={self.e}')\n",
     "        \n",
     "q = Q()\n",
-    "q.e=True"
+    "q.e = True"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62919cfe",
+   "id": "9a441f1b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4d11da7",
+   "id": "49084aac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57ac5634",
+   "id": "80c0a749",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -765,7 +783,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4eb77da",
+   "id": "b5f36579",
    "metadata": {},
    "source": [
     "When you execute the above cell, you will normally get `[]`, indicating that there are not yet any results available. \n",
@@ -792,7 +810,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8addc3fa",
+   "id": "063fb4ad",
    "metadata": {},
    "source": [
     "This `while` loop iterates until all results are available, printing a count of results so far each time through the loop. Processing is done during the `asyncio.sleep` call, which returns control to the IOLoop for that length of time, and then the `while` loop checks to see if processing is done yet. Once it's done, the list of URLs downloaded is displayed, and you can see from the ordering (unlikely to be sequential) that the downloading was done asynchronously. You can find out more about programming asynchronously in the [asyncio](https://docs.python.org/3/library/asyncio.html) docs."
@@ -800,7 +818,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09f80473",
+   "id": "719dd5b0",
    "metadata": {},
    "source": [
     "### Applying these techniques to your own code\n",

--- a/examples/user_guide/Dependencies_and_Watchers.ipynb
+++ b/examples/user_guide/Dependencies_and_Watchers.ipynb
@@ -1,0 +1,820 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ff410233",
+   "metadata": {},
+   "source": [
+    "# Dependencies and Watchers\n",
+    "\n",
+    "As outlined in the [Dynamic Parameters](Dynamic_Parameters.ipynb) guide, Param can be used in multiple ways, including as a static set of typed attributes, dynamic attributes that are computed when they are read (`param.Dynamic` parameters, a \"pull\" or \"get\" model), and using explicitly expressed chains of actions driven by events at the Parameter level (a \"push\" or \"set\" model described in this notebook). \n",
+    "\n",
+    "Unlike Dynamic Parameters, which calculate values when parameters are _accessed_, the dependency and watcher interface allows events to be triggered when parameters are _set_. With this interface, parameters and methods can declare that they should be updated or invoked when a given parameter is modified, spawning a cascading series of events that update settings to be consistent, adapt values as appropriate for a change, or invoke computations such as updating a displayed object when a value is modified. This approach is well suited to a GUI interface, where a user interacts with a single widget at a time but other widgets or displays need to be updated in response. The\n",
+    "[Dynamic Parameters](Dynamic_Parameters.ipynb) approach, in contrast, is well suited when Parameters update either on read or in response to a global clock or counter, such as in a simulation or machine-learning iteration.\n",
+    "\n",
+    "This user guide is structured as three main sections:\n",
+    "\n",
+    "- [Dependencies](#Dependencies): High-level dependency declaration via the `@param.depends()` decorator\n",
+    "- [Watchers](#Watchers): Low-level watching mechanism via `.param.watch()`.\n",
+    "- [Using dependencies and watchers](#Using-dependencies-and-watchers): Utilities and tools for working with events created using either dependencies or watchers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35b949ab",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "\n",
+    "Param's `depends` decorator allows a programmer to express that a given computation \"depends\" on a certain set of parameters. For instance, if you have parameters whose values are interlinked, it's easy to express that relationship with `depends`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58661e91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import param\n",
+    "\n",
+    "class C(param.Parameterized):\n",
+    "    _countries = {'Africa': ['Ghana', 'Togo', 'South Africa'],\n",
+    "                  'Asia'  : ['China', 'Thailand', 'Japan', 'Singapore'],\n",
+    "                  'Europe': ['Austria', 'Bulgaria', 'Greece', 'Switzerland']}\n",
+    "    \n",
+    "    continent = param.Selector(list(_countries.keys()), default='Asia')\n",
+    "    country = param.Selector(_countries['Asia'])\n",
+    "    \n",
+    "    @param.depends('continent', watch=True)\n",
+    "    def _update_countries(self):\n",
+    "        countries = self._countries[self.continent]\n",
+    "        self.param['country'].objects = countries\n",
+    "        if self.country not in countries:\n",
+    "            self.country = countries[0]\n",
+    "\n",
+    "c = C()\n",
+    "c.country, c.param.country.objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c411e0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.continent='Africa'\n",
+    "c.country, c.param.country.objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f14d35a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d67210d0",
+   "metadata": {},
+   "source": [
+    "As you can see, here Param updates the allowed and current values for `country` whenever someone changes the `continent` parameter. This code relies on the dependency mechanism to make sure these parameters are kept appropriately synchronized:\n",
+    "\n",
+    "1. First, we set up the default (initial) values of those two parameters to be consistent ('Asia' for the continent, plus the first Asian country in the list). For the country parameter we could have called `self._update_countries()` to give it a value in the constructor, but declaring the defaults at the class level like this ensures the defaults are clearly visible and easily changeable by a user as class attributes if desired. \n",
+    "2. Next, if someone chooses a different continent, the list of countries allowed needs to be updated, so we wrote a method `_update_countries()` that (a) looks up the countries allowed for the current continent, (b) sets that list as the allowed objects for the `country` parameter, and (c) selects the first such country as the default country.\n",
+    "3. Finally, we expressed that the `_update_countries()` method depends on the `continent` parameter. We specified `watch=True`) to direct Param to invoke this method immediately, whenever the value of `continent` changes. We'll see [examples of watch=False](#watch=False-dependencies) later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a15d05f6",
+   "metadata": {},
+   "source": [
+    "### Dependency specs\n",
+    "\n",
+    "The example above expressed a dependency of `_update_countries` on this object's `continent` parameter. A wide range of such dependency relationships can be specified:\n",
+    "\n",
+    "1. **Multiple dependencies**: Here we had only one parameter in the dependency list, but you can supply any number of dependencies (`@param.depends('continent', 'country', watch=True)`).\n",
+    "2. **Dependencies on nested parameters**: Parameters specified can either be on this class, or on nested Parameterized objects of this class. Parameters on this class are specified as the attribute name as a simple string (like `'continent'`). Nested parameters are specified as a dot-separated string (like `'handler.strategy.i'`, if this object has a parameter `handler`, whose value is an object `strategy`, which itself has a parameter `i`). If you want to depend on some arbitrary parameter elsewhere in Python, just create an `instantiate=False` (and typically read-only) parameter on this class to hold it, then here you can specify the path to it on _this_ object.\n",
+    "3. **Dependencies on metadata**: By default, dependencies are tied to a parameter's current value, but dependencies can also be on any of the declared metadata about the parameter (e.g. a method could depend on `country:constant`, triggering when someone changes whether that parameter is constant, or on `country:objects` (triggering when the objects list is replaced (not just changed in place as in appending). The available metadata is listed in the `__slots__` attribute of a Parameter object (e.g. \n",
+    "`p.param.continent.__slots__`). \n",
+    "4. **Dependencies on any nested param**: If you want to depend on _all_ the parameters of a nested object `n`, your method can depend on `'n.param'` (where parameter `n` has been set to a Parameterized object).\n",
+    "5. **Dependencies on a method name**: Often you will want to break up computation into multiple chunks, some of which are useful on their own and some which require other computations to have been done as prerequisites. In this case, your method can declare a dependency on another method (as a string name), which means that it will now watch everything that method watches, and will then get invoked after that method is invoked.\n",
+    "\n",
+    "We can see examples of all these dependency specifications in class `D` below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c2101bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class D(param.Parameterized):\n",
+    "    x = param.Number(7)\n",
+    "    s = param.String(\"never\")\n",
+    "    i = param.Integer(-5)\n",
+    "    o = param.Selector(['red', 'green', 'blue'])\n",
+    "    n = param.ClassSelector(param.Parameterized, c, instantiate=False)                    \n",
+    "    \n",
+    "    @param.depends('x', 's', 'n.country', 's:constant', watch=True)\n",
+    "    def cb1(self):\n",
+    "        print(f\"cb1 x={self.x} s={self.s} \"\n",
+    "              f\"param.s.constant={self.param.s.constant} n.country={self.n.country}\")\n",
+    "\n",
+    "    @param.depends('n.param', watch=True)\n",
+    "    def cb2(self):\n",
+    "        print(f\"cb2 n={self.n}\")\n",
+    "\n",
+    "    @param.depends('x', 'i', watch=True)\n",
+    "    def cb3(self):\n",
+    "        print(f\"cb3 x={self.x} i={self.i}\")\n",
+    "\n",
+    "    @param.depends('cb3', watch=True)\n",
+    "    def cb4(self):\n",
+    "        print(f\"cb4 x={self.x} i={self.i}\")\n",
+    "\n",
+    "d = D()\n",
+    "d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "299991bf",
+   "metadata": {},
+   "source": [
+    "Here we have created an object `d` of type `D` with a unique ID like `D00003`. `d` has various parameters, including one nested Parameterized object in its parameter `n`. In this class, the nested parameter is set to our earlier object `c`, using `instantiate=False` to ensure that the value is precisely the same earlier object, not a copy of it. You can verify that it is the same object by comparing e.g. `name='C00002'` in the repr for the subobject in `d` to the name in the repr for `c` in the previous section; both should be e.g. `C00002`.\n",
+    "\n",
+    "Dependencies are stored declaratively so that they are accessible for other libraries to inspect and use. E.g. we can now examine the dependencies for the decorated callback method `cb1`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25c01683",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dependencies = d.param.params_depended_on('cb1')\n",
+    "[f\"{o.inst.name}.{o.pobj.name}:{o.what}\" for o in dependencies]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0576bcb2",
+   "metadata": {},
+   "source": [
+    "Here we can see that method `cb1` will be invoked for any value changes in `d`'s parameters `x` or `s`, for any value changes in `c`'s parameter `country`, and a change in the `constant` slot of `s`. These dependency relationships correspond to the specification `@param.depends('x', 's', 'n.country', 's:constant', watch=True)` above.\n",
+    "\n",
+    "Now, if we change `x`, we can see that Param invokes `cb1`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "346330d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d.x=5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "813c7067",
+   "metadata": {},
+   "source": [
+    "`cb3` and `cb4` are also invoked, because `cb3` depends on `x` as well, plus `cb4` depends on `cb3`, inheriting all of `cb3`'s dependencies.\n",
+    "\n",
+    "If we now change `c.country`, `cb1` will be invoked since `cb1` depends on `n.country`, and `n` is currently set to `c`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "629cb096",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.country='Togo'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3cedd68",
+   "metadata": {},
+   "source": [
+    "As you can see, `cb2` is also invoked, because `cb2` depends on _all_ parameters of the subobject in `n`. \n",
+    "\n",
+    "`continent` is also a parameter on `c`, so `cb2` will also be invoked if you change `c.continent`. Note that changing `c.continent` itself invokes `c._update_countries()`, so in that case `cb2` actually gets invoked _twice_ (once for each parameter changed on `c`), along with `cb1` (watching `n.country`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb90ae09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.continent='Asia'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17251553",
+   "metadata": {},
+   "source": [
+    "Changing metadata works just the same as changing values. Because `cb1` depends on the `constant` slot of `s`, it is invoked when that slot changes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf14070c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d.param.s.constant=True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf0ec14c",
+   "metadata": {},
+   "source": [
+    "### `watch=False` dependencies\n",
+    "\n",
+    "The previous examples all supplied `watch=True`, indicating that Param itself should watch for changes in the dependency and invoke that method when a dependent parameter is set. If `watch=False` (the default), `@param.depends` declares that such a dependency exists, but does not automatically invoke it. `watch=False` is useful for setting up code for a separate library like [Panel](https://panel.holoviz.org) or [HoloViews](https://holoviews.org) to use, indicating which parameters the external library should watch so that it knows when to invoke the decorated method. Typically, you'll want to use `watch=False` when that external library needs to do something with the return value of the method (a functional approach), and use `watch=True` when the function is [side-effecty](https://en.wikipedia.org/wiki/Side_effect_(computer_science)), i.e. having an effect just from running it, and not normally returning a value.\n",
+    "\n",
+    "For instance, consider this Param class with methods that return values to display:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b49c2c9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Mul(param.Parameterized):\n",
+    "    a = param.Number(5,  bounds=(-100, 100))\n",
+    "    b = param.Number(-2, bounds=(-100, 100))\n",
+    "\n",
+    "    @param.depends('a', 'b')\n",
+    "    def view(self):\n",
+    "        return str(self.a*self.b)\n",
+    "\n",
+    "    def view2(self):\n",
+    "        return str(self.a*self.b)\n",
+    "\n",
+    "prod = Mul(name='Multiplier')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65a5a8e5",
+   "metadata": {},
+   "source": [
+    "You could run this code manually:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcd4632c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prod.a = 7\n",
+    "prod.b = 10\n",
+    "prod.view()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9742061e",
+   "metadata": {},
+   "source": [
+    "Or you could pass the parameters and the `view` method to Panel, and let Panel invoke it as needed by following the dependency chain:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6aeb74b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a42092fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(prod.param, prod.view)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fab0784",
+   "metadata": {},
+   "source": [
+    "Panel creates widgets for the parameters, runs the `view` method with the default values of those parameters, and displays the result. As long as you have a live Python process running (not just a static HTML export of this page as on param.holoviz.org), Panel will then watch for changes in those parameters due to the widgets and will re-execute the `view` method to update the output whenever one of those parameters changes. Using the dependency declarations, Panel is able to do all this without ever having to be told separately which parameters there are or what dependency relationships there are. \n",
+    "\n",
+    "How does that work? A library like Panel can simply ask Param what dependency relationships have been declared for the method passed to it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cb94354",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[o.name for o in prod.param.params_depended_on('view')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2724ef69",
+   "metadata": {},
+   "source": [
+    "Note that in this particular case the `depends` decorator could have been omitted, because Param conservatively assumes that any method _could_ read the value of any parameter, and thus if it has no other declaration from the user, the dependencies are assumed to include _all_ parameters (including `name`, even though it is constant):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f1222e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[o.name for o in prod.param.params_depended_on('view2')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28606c81",
+   "metadata": {},
+   "source": [
+    "Conversely, if you want to declare that a given method does not depend on any parameters at all, you can use `@param.depends()`. \n",
+    "\n",
+    "Be sure not to set `watch=True` for dependencies for any method you pass to an external library like Panel to handle, or else that method will get invoked _twice_, once by Param itself (discarding the output) and once by the external library (using the output). Typically you will want `watch=True` for a side-effecty function or method (typically not returning a value), and `watch=False` (the default) for a function or method with a return value, and you'll need an external library to do something with that return value."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1267f28d",
+   "metadata": {},
+   "source": [
+    "### `@param.depends` with function objects\n",
+    "\n",
+    "The `depends` decorator can also be used with bare functions, in which case the specification should be an actual Parameter object, not a string. The function will be called with the parameter(s)'s value(s) as positional arguments:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64e8cf07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@param.depends(c.param.country, d.param.i, watch=True)\n",
+    "def g(country, i):\n",
+    "    print(f\"g country={country} i={i}\")\n",
+    "\n",
+    "c.country='Japan'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b166d745",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d.i=6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1dd59c3f",
+   "metadata": {},
+   "source": [
+    "Here you can see that in addition to the classmethods starting with `cb` previously set up to depend on the country, setting `c`'s `country` parameter or `d`'s `i` parameter now also invokes function `g`, passing in the current values of the parameters it depends on whenever the function gets invoked. `g` can then make a side effect happen such as updating any other data structure it can access that needs to be changed when `country` or `i` changes. \n",
+    "\n",
+    "Using `@param.depends(..., watch=False)` with a function allows providing bound standalone functions to an external library for display, just as in the `.view` method above.\n",
+    "\n",
+    "Of course, you can still invoke `g` with your own explicit arguments, which does not invoke any watching mechanisms:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3557e982",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g('USA', 7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2618e1f",
+   "metadata": {},
+   "source": [
+    "## Watchers\n",
+    "\n",
+    "The `depends` decorator is built on Param's lower-level `.param.watch` interface, registering the decorated method or function as a `Watcher` object associated with those parameter(s). If you're building or using a complex library like Panel, you can use the low-level Parameter watching interface to set up arbitrary chains of watchers to respond to parameter value or metadata setting:\n",
+    "\n",
+    "- `obj.param.watch(fn, parameter_names, what='value', onlychanged=True, queued=False)`: <br>Create and register a `Watcher` that will invoke the given callback `fn` when the `what` item (`value` or one of the Parameter's slots) is set (or more specifically, changed, if `onlychanged=True`). If `queued=True`, delays calling any events triggered during this callback's execution until all processing of the current events has been completed (breadth-first Event processing rather than the default depth-first processing). The `fn` will be invoked with one or more `Event` objects that have been triggered, as positional arguments. Returns a `Watcher` object, e.g. for use in `unwatch`.\n",
+    "- `obj.param.watch_values(fn, parameter_names, what='value', onlychanged=True, queued=False)`: <br>Easier-to-use version of `obj.param.watch` specific to watching for changes in parameter values. Same as `watch`, but hard-codes `what='value'` and invokes the callback `fn` using keyword arguments _param_name_=_new_value_ rather than with a positional-argument list of `Event` objects. \n",
+    "- `obj.param.unwatch(watcher)`: <br>Remove the given `Watcher` (typically obtained as the return value from `watch` or `watch_values`) from those registered on this `obj`.\n",
+    "\n",
+    "To see how to use `watch` and `watch_values`, let's make a class with parameters `a` and `b` and various watchers with corresponding callback methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "371c2a5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def e(e):\n",
+    "    return f\"(event: {e.name} changed from {e.old} to {e.new})\"\n",
+    "\n",
+    "class P(param.Parameterized):\n",
+    "    a = param.Integer(default=0)\n",
+    "    b = param.Integer(default=0)\n",
+    "    \n",
+    "    def __init__(self, **params):\n",
+    "        super().__init__(**params)\n",
+    "        self.param.watch(self.run_a1, ['a'], queued=True)\n",
+    "        self.param.watch(self.run_a2, ['a'])\n",
+    "        self.param.watch(self.run_b,  ['b'])\n",
+    "\n",
+    "    def run_a1(self, event):\n",
+    "        self.b += 1\n",
+    "        print('a1', self.a, e(event))\n",
+    "\n",
+    "    def run_a2(self, event):\n",
+    "        print('a2', self.a, e(event))\n",
+    "\n",
+    "    def run_b(self, event):\n",
+    "        print('b', self.b, e(event))\n",
+    "        \n",
+    "p = P()\n",
+    "\n",
+    "p.a = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22f09fa4",
+   "metadata": {},
+   "source": [
+    "Here, we have set up three Watchers, each invoking a method on `P` when either `a` or `b` changes. The first Watcher invokes `run_a1` when `a` changes, and in turn `run_a1` changes `b`. Since `queued=True` for `run_a1`, `run_b` is not invoked while `run_a1` executes, but only later once both `run_a1` and `run_a2` have completed (since both Watchers were triggered by the original event `p.a=1`). \n",
+    "\n",
+    "Here we're using data from the `Event` objects given to each callback to see what's changed; try `help(param.parameterized.Event)` for details of what is in these objects (and similarly try the help for `Watcher` (returned by `watch`) or `PInfo` (returned by `.param.params_depended_on`))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6bfb4b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#help(param.parameterized.Event)\n",
+    "#help(param.parameterized.Watcher)\n",
+    "#help(param.parameterized.PInfo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d0dbaef",
+   "metadata": {},
+   "source": [
+    "## Using dependencies and watchers\n",
+    "\n",
+    "Whether you use the `watch` or the `depends` approach, Param will store a set of `Watcher` objects on each `Parameterized` object that let it manage and process `Event`s. Param provides various context managers, methods, and Parameters that help you work with Watchers and Events:\n",
+    "\n",
+    "- [`batch_call_watchers`](#batch_call_watchers): context manager accumulating and eliding multiple Events to be applied on exit from the context \n",
+    "- [`discard_events`](#discard_events): context manager silently discarding events generated while in the context\n",
+    "- [`.param.trigger`](#.param.trigger): method to force creation of an Event for this Parameter's Watchers without a corresponding change to the Parameter\n",
+    "- [Event Parameter](#Event-Parameter): Special Parameter type providing triggerable transient Events (like a momentary push button)\n",
+    "- [Async executor](#Async-executor): Support for asynchronous processing of Events, e.g. for interfacing to external servers\n",
+    "\n",
+    "Each of these will be described in the following sections."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86823025",
+   "metadata": {},
+   "source": [
+    "### `batch_call_watchers`\n",
+    "\n",
+    "Context manager that accumulates parameter changes on the supplied object and dispatches them all at once when the context is exited, to allow multiple changes to a given parameter to be accumulated and short-circuited, rather than prompting serial changes from a batch of parameter setting:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "898288b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with param.parameterized.batch_call_watchers(p):\n",
+    "    p.a = 2\n",
+    "    p.a = 3\n",
+    "    p.a = 1\n",
+    "    p.a = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecb4e66b",
+   "metadata": {},
+   "source": [
+    "Here, even though `p.a` is changed four times, each of the watchers of `a` is executed only once, with the final value. One of those events then changes `b`, so `b`'s watcher is also executed once.\n",
+    "\n",
+    "If we set `b` explicitly, `b`'s watcher will be invoked twice, once for the explicit setting of `b`, and once because of the code `self.b += 1`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8b126be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with param.parameterized.batch_call_watchers(p):\n",
+    "    p.a = 2\n",
+    "    p.b = 8\n",
+    "    p.a = 3\n",
+    "    p.a = 1\n",
+    "    p.a = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54868160",
+   "metadata": {},
+   "source": [
+    "###  `discard_events`\n",
+    "\n",
+    "Context manager that discards any events within its scope that are triggered on the supplied parameterized object. Useful for making silent changes to dependent parameters, e.g. in a setup phase. If your dependencies are meant to ensure consistency between parameters, be careful that your manual changes in this context don't put the object into an inconsistent state!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd655822",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with param.parameterized.discard_events(p):\n",
+    "    p.a = 2\n",
+    "    p.b = 9"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04bd8a67",
+   "metadata": {},
+   "source": [
+    "(Notice that none of the callbacks is invoked, despite all the Watchers on `p.a` and `p.b`.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd987890",
+   "metadata": {},
+   "source": [
+    "### `.param.trigger`\n",
+    "\n",
+    "Usually, a Watcher will be invoked only when a parameter is set (and only if it is changed, by default). What if you want to trigger a Watcher in other cases? For instance, if a parameter value is a mutable container like a list and you add or change an item in that container, Param's `set` method will never be invoked, because in Python the container itself is not changed when the contents are changed. In such cases, you can trigger a watcher explicitly, using `.param.trigger(*param_names)`. Triggering does not affect parameter values, apart from the special parameters of type Event (see [below](#Event-Parameter:)).\n",
+    "\n",
+    "For instance, if you set `p.b` to the value it already has, no callback will normally be invoked:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46be57ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.b = p.b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c128f4b",
+   "metadata": {},
+   "source": [
+    "But if you explicitly trigger parameter `b` on `p`, `run_b` will be invoked, even though the value of `b` is not changing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db0eb5f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.param.trigger('b')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deacc3cd",
+   "metadata": {},
+   "source": [
+    "If you trigger `a`, the usual series of chained events will be triggered, including changing `b`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9667d7ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.param.trigger('a')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b605755",
+   "metadata": {},
+   "source": [
+    "### `Event` Parameter\n",
+    "\n",
+    "An Event Parameter is a special Parameter type whose value is intimately linked to the triggering of events for Watchers to consume. Event has a Boolean value, which when set to `True` triggers the associated watchers (as any Parameter does) but then is automatically set back to `False`. \n",
+    "\n",
+    "Conversely, if events are triggered directly on a `param.Event` via `.trigger`, the value is transiently set to True (so that it's clear which of many parameters being watched may have changed), then restored to False when the triggering completes. An Event parameter is thus like a momentary switch or pushbutton with a transient True value that normally serves only to launch some other action (e.g. via a `param.depends` decorator or a watcher), rather than encapsulating the action itself as `param.Action` does. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70a2937e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Q(param.Parameterized):\n",
+    "    e = param.Event()\n",
+    "    \n",
+    "    @param.depends('e', watch=True)\n",
+    "    def callback(self):\n",
+    "        print(f'e=={self.e}')\n",
+    "        \n",
+    "q = Q()\n",
+    "q.e=True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62919cfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q.e"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4d11da7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q.param.trigger('e')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57ac5634",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q.e"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "822c7365",
+   "metadata": {},
+   "source": [
+    "### Async executor\n",
+    "\n",
+    "Param's events and callbacks described above are all synchronous, happening in a clearly defined order where the processing of each function blocks all other processing until it is completed. Watchers can also be used with the Python [asyncio](https://docs.python.org/3/library/asyncio.html) library to operate asynchronously. To do this, you can define `param.parameterized.async_executor` with an asynchronous executor that allows using coroutines and other asynchronous functions as `.param.watch` callbacks. These callbacks will be scheduled on the event loop from Tornado or asyncio. \n",
+    "\n",
+    "As an example, you can use the Tornado IOLoop underlying this Jupyter Notebook by putting events on the event loop and watching for results to accumulate:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c090d656",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import param, asyncio, aiohttp\n",
+    "from tornado.ioloop import IOLoop\n",
+    "\n",
+    "param.parameterized.async_executor = IOLoop.current().add_callback\n",
+    "\n",
+    "class Downloader(param.Parameterized):\n",
+    "    url = param.String()\n",
+    "    results = param.List()\n",
+    "    \n",
+    "    def __init__(self, **params):\n",
+    "        super().__init__(**params)\n",
+    "        self.param.watch(self.fetch, ['url'])\n",
+    "\n",
+    "    async def fetch(self, event):\n",
+    "        async with aiohttp.ClientSession() as session:\n",
+    "            async with session.get(event.new) as response:\n",
+    "                img = await response.read()\n",
+    "                self.results.append((event.new, img))\n",
+    "\n",
+    "f = Downloader()\n",
+    "n = 7\n",
+    "for index in range(n):\n",
+    "    f.url = f\"https://picsum.photos/800/300?image={index}\"\n",
+    "\n",
+    "f.results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4eb77da",
+   "metadata": {},
+   "source": [
+    "When you execute the above cell, you will normally get `[]`, indicating that there are not yet any results available. \n",
+    "\n",
+    "What the code does is to request 10 different images from an image site by repeatedly setting the `url` parameter of `Downloader` to a new URL. Each time the `url` parameter is modified, because of the `self.param.watch` call, the `self.fetch` callback is invoked. Because it is marked `async` and uses `await` internally, the method call returns without waiting for results to be available. Once the `await`ed results are available, the method continues with its execution and a tuple (_image_name_, _image_data_) is added to the `results` parameter.\n",
+    "\n",
+    "If you need to have all the results available (and have an internet connection!), you can wait for them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9320b248",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Waiting: \", end=\"\")\n",
+    "while len(f.results)<n:\n",
+    "    print(f\"{len(f.results)} \", end=\"\")\n",
+    "    await asyncio.sleep(0.05)\n",
+    "    \n",
+    "[t[0] for t in f.results]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8addc3fa",
+   "metadata": {},
+   "source": [
+    "This `while` loop iterates until all results are available, printing a count of results so far each time through the loop. Processing is done during the `asyncio.sleep` call, which returns control to the IOLoop for that length of time, and then the `while` loop checks to see if processing is done yet. Once it's done, the list of URLs downloaded is displayed, and you can see from the ordering (unlikely to be sequential) that the downloading was done asynchronously. You can find out more about programming asynchronously in the [asyncio](https://docs.python.org/3/library/asyncio.html) docs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09f80473",
+   "metadata": {},
+   "source": [
+    "### Applying these techniques to your own code\n",
+    "\n",
+    "As you can see, there is extensive support for watching for events on Parameters, whether you use the low-level Watcher interface or the high-level `@param.depends` interface. As usual when multiple APIs are provided, it's a good idea to start with the high-level interface, and only drop down to the low-level watching approach if you need the additional power and control and are able to accept the corresponding complexity. The asynchronous approach is then only needed for very specific applications where you want your code to be decoupled from an external system. Most people can simply use `@param.depends` to cover all their needs for interaction between Parameters and for computation that depends on Parameters."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/user_guide/Dependencies_and_Watchers.ipynb
+++ b/examples/user_guide/Dependencies_and_Watchers.ipynb
@@ -724,7 +724,7 @@
    "source": [
     "### Async executor\n",
     "\n",
-    "Param's events and callbacks described above are all synchronous, happening in a clearly defined order where the processing of each function blocks all other processing until it is completed. Watchers can also be used with the Python [asyncio](https://docs.python.org/3/library/asyncio.html) library to operate asynchronously. To do this, you can define `param.parameterized.async_executor` with an asynchronous executor that allows using coroutines and other asynchronous functions as `.param.watch` callbacks. These callbacks will be scheduled on the event loop from Tornado or asyncio. \n",
+    "Param's events and callbacks described above are all synchronous, happening in a clearly defined order where the processing of each function blocks all other processing until it is completed. Watchers can also be used with the Python3 asyncio [`async`/`await`](https://docs.python.org/3/library/asyncio-task.html) support to operate asynchronously. To do this, you can define `param.parameterized.async_executor` with an asynchronous executor that schedules tasks on an event loop from e.g. Tornado or the [asyncio](https://docs.python.org/3/library/asyncio.html) library, which will allow you to use coroutines and other asynchronous functions as `.param.watch` callbacks.\n",
     "\n",
     "As an example, you can use the Tornado IOLoop underlying this Jupyter Notebook by putting events on the event loop and watching for results to accumulate:"
    ]

--- a/examples/user_guide/Parameters.ipynb
+++ b/examples/user_guide/Parameters.ipynb
@@ -799,7 +799,7 @@
     "- `.param.get_value_generator(name)`: Returns the underlying value-generating callable for this parameter, or the underlying static value if none\n",
     "- `.param.force_new_dynamic_value(name)`: For a Dynamic parameter, generate a new value and return it\n",
     "- `.param.inspect_value(name)`: For a Dynamic parameter, return the current value of the named attribute without modifying it.\n",
-    "- `.param.params_depended_on(self_,name)`: A list of all parameters that the indicated parameter depends on\n",
+    "- `.param.params_depended_on(self_,name)`: A list of PInfo objects characterizing all parameters and/or metadata that the indicated method (provided by name) depends on\n",
     "- `.param.defaults()`: Dictionary {parameter_name:parameter.default} for all non-constant parameters\n",
     "- `.param.print_param_values()`: Print out the values for all this object's parameters."
    ]

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -116,7 +116,7 @@ def _batch_call_watchers(parameterized, enable=True, run=True):
             parameterized.param._batch_call_watchers()
 
 batch_watch = _batch_call_watchers # PARAM2_DEPRECATION: Remove this compatibility alias for param 2.0 and later.
-            
+
 @contextmanager
 def batch_call_watchers(parameterized):
     """
@@ -546,15 +546,15 @@ def _m_caller(self, n):
 
 
 def _add_doc(obj, docstring):
-   """Add a docstring to a namedtuple, if on python3 where that's allowed"""
-   if sys.version_info[0]>2:
-       obj.__doc__ = docstring
+    """Add a docstring to a namedtuple, if on python3 where that's allowed"""
+    if sys.version_info[0]>2:
+        obj.__doc__ = docstring
 
 
 PInfo = namedtuple("PInfo", "inst cls name pobj what"); _add_doc(PInfo,
     """
     Object describing something being watched about a Parameter.
-    `inst`: Parameterized instance owning the Parameter, or None 
+    `inst`: Parameterized instance owning the Parameter, or None
     `cls`: Parameterized class owning the Parameter
     `name`: Name of the Parameter being watched
     `pobj`: Parameter object being watched
@@ -575,28 +575,28 @@ Event = namedtuple("Event", "what name obj cls old new type"); _add_doc(Event,
     Object representing an event that triggers a Watcher
     `what`: What is being watched on the Parameter (either value or a slot name)
     `name`: Name of the Parameter that was set or triggered
-    `obj`: Parameterized instance owning the watched Parameter, or None 
+    `obj`: Parameterized instance owning the watched Parameter, or None
     `cls`: Parameterized class owning the watched Parameter
     `old`: Previous value of the item being watched
     `new`: New value of the item being watched
-    `type`: `triggered` if this event was triggered explicitly), 
-            `changed` if the item was set and watching for `onlychanged`, 
-            `set` if the item was set, or 
+    `type`: `triggered` if this event was triggered explicitly),
+            `changed` if the item was set and watching for `onlychanged`,
+            `set` if the item was set, or
             None if type not yet known
     """)
 
 Watcher = namedtuple("Watcher", "inst cls fn mode onlychanged parameter_names what queued"); _add_doc(Watcher,
     """
-    Object declaring a callback function to invoke when an Event is triggered on a watched item 
-    `inst`: Parameterized instance owning the watched Parameter, or None 
+    Object declaring a callback function to invoke when an Event is triggered on a watched item
+    `inst`: Parameterized instance owning the watched Parameter, or None
     `cls`: Parameterized class owning the watched Parameter
     `fn`: Callback function to invoke when triggered by a watched Parameter
-    `mode`: 'args' for param.watch (call `fn` with PInfo object positional args), or 
+    `mode`: 'args' for param.watch (call `fn` with PInfo object positional args), or
             'kwargs' for param.watch_values (call `fn` with <param_name>:<new_value> keywords)
     `onlychanged`: If True, only trigger for actual changes, not setting to the current value
     `parameter_names`: List of Parameters to watch, by name
     `what`: What to watch on the Parameters (either 'value' or a slot name)
-    `queued`: Immediately invoke callbacks triggered during processing of an Event (if False), or 
+    `queued`: Immediately invoke callbacks triggered during processing of an Event (if False), or
             queue them up for processing later, after this event has been handled (if True)
     """)
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -100,13 +100,11 @@ def logging_level(level):
 
 
 @contextmanager
-def batch_watch(parameterized, enable=True, run=True):
+def _batch_call_watchers(parameterized, enable=True, run=True):
     """
-    Context manager to batch watcher events on a parameterized object.
-    The context manager will queue any events triggered by setting a
-    parameter on the supplied parameterized object and dispatch them
-    all at once when the context manager exits. If run=False the
-    queued events are not dispatched and should be processed manually.
+    Internal version of batch_call_watchers, adding control over queueing and running.
+    Only actually batches events if enable=True; otherwise a no-op. Only actually
+    calls the accumulated watchers on exit if run=True; otherwise they remain queued.
     """
     BATCH_WATCH = parameterized.param._BATCH_WATCH
     parameterized.param._BATCH_WATCH = enable or parameterized.param._BATCH_WATCH
@@ -115,6 +113,26 @@ def batch_watch(parameterized, enable=True, run=True):
     finally:
         parameterized.param._BATCH_WATCH = BATCH_WATCH
         if run and not BATCH_WATCH:
+            parameterized.param._batch_call_watchers()
+
+batch_watch = _batch_call_watchers # PARAM2_DEPRECATION: Remove this compatibility alias for param 2.0 and later.
+            
+@contextmanager
+def batch_call_watchers(parameterized):
+    """
+    Context manager to batch events to provide to Watchers on a
+    parameterized object.  This context manager queues any events
+    triggered by setting a parameter on the supplied parameterized
+    object, saving them up to dispatch them all at once when the
+    context manager exits.
+    """
+    BATCH_WATCH = parameterized.param._BATCH_WATCH
+    parameterized.param._BATCH_WATCH = True
+    try:
+        yield
+    finally:
+        parameterized.param._BATCH_WATCH = BATCH_WATCH
+        if not BATCH_WATCH:
             parameterized.param._batch_call_watchers()
 
 
@@ -527,10 +545,61 @@ def _m_caller(self, n):
     return caller
 
 
-PInfo = namedtuple("PInfo","inst cls name pobj what")
-MInfo = namedtuple("MInfo","inst cls name method")
-Event = namedtuple("Event","what name obj cls old new type")
-Watcher = namedtuple("Watcher","inst cls fn mode onlychanged parameter_names what queued")
+def _add_doc(obj, docstring):
+   """Add a docstring to a namedtuple, if on python3 where that's allowed"""
+   if sys.version_info[0]>2:
+       obj.__doc__ = docstring
+
+
+PInfo = namedtuple("PInfo", "inst cls name pobj what"); _add_doc(PInfo,
+    """
+    Object describing something being watched about a Parameter.
+    `inst`: Parameterized instance owning the Parameter, or None 
+    `cls`: Parameterized class owning the Parameter
+    `name`: Name of the Parameter being watched
+    `pobj`: Parameter object being watched
+    `what`: What is being watched on the Parameter (either 'value' or a slot name)
+    """)
+
+MInfo = namedtuple("MInfo", "inst cls name method"); _add_doc(MInfo,
+    """
+    Object describing a Parameterized method being watched.
+    `inst`: Parameterized instance owning the method, or None
+    `cls`: Parameterized class owning the method
+    `name`: Name of the method being watched
+    `method`: bound method of the object being watched
+    """)
+
+Event = namedtuple("Event", "what name obj cls old new type"); _add_doc(Event,
+    """
+    Object representing an event that triggers a Watcher
+    `what`: What is being watched on the Parameter (either value or a slot name)
+    `name`: Name of the Parameter that was set or triggered
+    `obj`: Parameterized instance owning the watched Parameter, or None 
+    `cls`: Parameterized class owning the watched Parameter
+    `old`: Previous value of the item being watched
+    `new`: New value of the item being watched
+    `type`: `triggered` if this event was triggered explicitly), 
+            `changed` if the item was set and watching for `onlychanged`, 
+            `set` if the item was set, or 
+            None if type not yet known
+    """)
+
+Watcher = namedtuple("Watcher", "inst cls fn mode onlychanged parameter_names what queued"); _add_doc(Watcher,
+    """
+    Object declaring a callback function to invoke when an Event is triggered on a watched item 
+    `inst`: Parameterized instance owning the watched Parameter, or None 
+    `cls`: Parameterized class owning the watched Parameter
+    `fn`: Callback function to invoke when triggered by a watched Parameter
+    `mode`: 'args' for param.watch (call `fn` with PInfo object positional args), or 
+            'kwargs' for param.watch_values (call `fn` with <param_name>:<new_value> keywords)
+    `onlychanged`: If True, only trigger for actual changes, not setting to the current value
+    `parameter_names`: List of Parameters to watch, by name
+    `what`: What to watch on the Parameters (either 'value' or a slot name)
+    `queued`: Immediately invoke callbacks triggered during processing of an Event (if False), or 
+            queue them up for processing later, after this event has been handled (if True)
+    """)
+
 
 class ParameterMetaclass(type):
     """
@@ -1633,7 +1702,7 @@ class Parameters(object):
 
     def _call_watcher(self_, watcher, event):
         """
-        Invoke the given the watcher appropriately given a Event object.
+        Invoke the given watcher appropriately given an Event object.
         """
         if self_.self_or_cls.param._TRIGGER:
             pass
@@ -1646,7 +1715,7 @@ class Parameters(object):
                 self_._watchers.append(watcher)
         else:
             event = self_._update_event_type(watcher, event, self_.self_or_cls.param._TRIGGER)
-            with batch_watch(self_.self_or_cls, enable=watcher.queued, run=False):
+            with _batch_call_watchers(self_.self_or_cls, enable=watcher.queued, run=False):
                 self_._execute_watcher(watcher, (event,))
 
     def _batch_call_watchers(self_):
@@ -1666,7 +1735,7 @@ class Parameters(object):
                                                    self_.self_or_cls.param._TRIGGER)
                           for name in watcher.parameter_names
                           if (name, watcher.what) in event_dict]
-                with batch_watch(self_.self_or_cls, enable=watcher.queued, run=False):
+                with _batch_call_watchers(self_.self_or_cls, enable=watcher.queued, run=False):
                     self_._execute_watcher(watcher, events)
 
     def set_dynamic_time_fn(self_,time_fn,sublistattr=None):
@@ -1861,7 +1930,11 @@ class Parameters(object):
         return value
 
 
-    def params_depended_on(self_,name):
+    def params_depended_on(self_, name):
+        """
+        Given the name of a method, returns a PInfo object for each dependency
+        of this method. See help(PInfo) for the contents of these objects.
+        """
         return _params_depended_on(MInfo(cls=self_.cls,inst=self_.self,name=name,method=getattr(self_.self_or_cls,name)))
 
 
@@ -1924,7 +1997,7 @@ class Parameters(object):
         return [info]
 
 
-    def _watch(self_, action, watcher, what='value', operation='add'): #'add' | 'remove'
+    def _watch(self_, action, watcher, what='value'):
         parameter_names = watcher.parameter_names
         for parameter_name in parameter_names:
             if parameter_name not in self_.cls.param:
@@ -1945,7 +2018,37 @@ class Parameters(object):
                     watchers[what] = []
                 getattr(watchers[what], action)(watcher)
 
-    def watch(self_,fn,parameter_names, what='value', onlychanged=True, queued=False):
+    def watch(self_, fn, parameter_names, what='value', onlychanged=True, queued=False):
+        """
+        Register the given callback function `fn` to be invoked for
+        events on the indicated parameters.
+
+        `what`: What to watch on each parameter; either the value (by
+        default) or else the indicated slot (e.g. 'constant').
+
+        `onlychanged`: By default, only invokes the function when the
+        watched item changes, but if `onlychanged=False` also invokes
+        it when the `what` item is set to its current value again.
+
+        `queued`: By default, additional watcher events generated
+        inside the callback fn are dispatched immediately, effectively
+        doing depth-first processing of Watcher events. However, in
+        certain scenarios, it is helpful to wait to dispatch such
+        downstream events until all events that triggered this watcher
+        have been processed. In such cases setting `queued=True` on
+        this Watcher will queue up new downstream events generated
+        during `fn` until `fn` completes and all other watchers
+        invoked by that same event have finished executing),
+        effectively doing breadth-first processing of Watcher events.
+
+        When the `fn` is called, it will be provided the relevant
+        Event objects as positional arguments, which allows it to
+        determine which of the possible triggering events occurred.
+
+        Returns a Watcher object.
+
+        See help(Watcher) and help(Event) for the contents of those objects.
+        """
         parameter_names = tuple(parameter_names) if isinstance(parameter_names, list) else (parameter_names,)
         watcher = Watcher(inst=self_.self, cls=self_.cls, fn=fn, mode='args',
                           onlychanged=onlychanged, parameter_names=parameter_names,
@@ -1955,7 +2058,7 @@ class Parameters(object):
 
     def unwatch(self_,watcher):
         """
-        Unwatch watchers set either with watch or watch_values.
+        Remove the given Watcher object (from `watch` or `watch_values`) from this object's list.
         """
         try:
             self_._watch('remove',watcher)
@@ -1964,10 +2067,17 @@ class Parameters(object):
 
 
     def watch_values(self_, fn, parameter_names, what='value', onlychanged=True, queued=False):
+        """
+        Easier-to-use version of `watch` specific to watching for changes in parameter values.
+
+        Only allows `what` to be 'value', and invokes the callback `fn` using keyword
+        arguments <param_name>=<new_value> rather than with a list of Event objects.
+        """
+        assert(what=='value')
         parameter_names = tuple(parameter_names) if isinstance(parameter_names, list) else (parameter_names,)
         watcher = Watcher(inst=self_.self, cls=self_.cls, fn=fn,
                           mode='kwargs', onlychanged=onlychanged,
-                          parameter_names=parameter_names, what='value',
+                          parameter_names=parameter_names, what=what,
                           queued=queued)
         self_._watch('append', watcher, what)
         return watcher
@@ -2734,7 +2844,7 @@ class Parameterized(object):
         return "<%s %s>" % (self.__class__.__name__,self.name)
 
 
-    # deprecated as of Param 1.12; use self.pprint instead
+    # PARAM2_DEPRECATION: Remove this compatibility alias for param 2.0 and later; use self.pprint instead
     def script_repr(self,imports=[],prefix="    "):
         """
         Deprecated variant of __repr__ designed for generating a runnable script.

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ extras_require = {
         'nbconvert <6.0',
         'graphviz',
         'myst_nb ==0.12.2'
+        'aiohttp',
+        'panel',
     ]
 }
 


### PR DESCRIPTION
Merging this will make the Param User Guide complete for the first time in history!  Still needs some polish and possible reorganization, but the docs at least now cover (or are intended to cover) all of the public API and functionality of param.

This PR includes some minor changes to Param itself that should not affect backwards compatibility:

1. The context manager `param.parameterized.batch_watch` accepted two optional arguments (`enable` and `run`) that shouldn't be part of the public API as they are difficult to explain and shouldn't be needed by end users. Because the name was confusing (it doesn't watch things in batch, it batches up events created when calling watchers), created a new public API version called `param.parameterized.batch_call_watchers`, accepting only the single required parameterized argument. `batch_watch` is kept as an alias for what is now called `_batch_call_watchers` internally, but that alias should be removed in a later Param version.
2. The `_watch` method was accepting an argument `operation` that appears never to have been implemented or used internally. Since that's a private API, simply removed it from the argument list.
3. The namedtuples PInfo, MInfo, Watcher, and Event all now have docstrings (Python3 only).

The rest of the PR is to add the guide and fix up the index to declare the User Guide complete. The new guide currently requires aiohttp and panel for that notebook to run, so those have been added to the docs requirements in setup.py, but I'm not 100% certain that it's appropriate to require those for every build.

@philippjfr and @jlstevens , please verify my changes to parameterized.py and then actually check out this PR to work through the Dependencies_and_Watchers notebook cell by cell, trying to see if you can spot any errors or omissions.