### PR TITLE
Fix conda build

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - numbergen
   commands:
     # https://github.com/ioam/param/issues/219  
-    - nosetests tests
+    - pytest tests
 
 about:
   home: {{ sdata['url'] }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
     - param
     - numbergen
   commands:
-    # https://github.com/ioam/param/issues/219  
+    # https://github.com/holoviz/param/issues/219  
     - pytest tests
 
 about:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,5 +28,3 @@ ignore = E114,
 
 [tool:pytest]
 python_files = test*.py
-# Run the doctests found (if any) in the modules of param & numbergen.
-addopts = --doctest-modules param numbergen

--- a/tests/API1/testtimedependent.py
+++ b/tests/API1/testtimedependent.py
@@ -81,6 +81,26 @@ class TestTimeClass(API1TestCase):
         self.assertEqual(t(), 1)
         self.assertEqual(t.time_type, fractions.Fraction)
 
+    def test_time_integration(self):
+        # This used to part a doctest of param.Time, moved
+        # here not to have any doctest to run.
+        time = param.Time(until=20, timestep=1)
+        self.assertEqual(time(), 0)
+        self.assertEqual(time(5), 5)
+        time += 5
+        self.assertEqual(time(), 10)
+        with time as t:
+            self.assertEqual(t(), 10)
+            self.assertEqual(
+                [val for val in t],
+                [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+            )
+            self.assertEqual(t(), 20)
+            'Time after iteration: %s' % t()
+            t += 2
+            self.assertEqual(t(), 22)
+        self.assertEqual(time(), 10)
+
     @pytest.mark.skipif(gmpy is None, reason="gmpy is not installed")
     def test_time_init_gmpy(self):
         t = param.Time(time_type=gmpy.mpq)

--- a/tests/API1/testtimedependent.py
+++ b/tests/API1/testtimedependent.py
@@ -82,7 +82,7 @@ class TestTimeClass(API1TestCase):
         self.assertEqual(t.time_type, fractions.Fraction)
 
     def test_time_integration(self):
-        # This used to part a doctest of param.Time, moved
+        # This used to be a doctest of param.Time; moved
         # here not to have any doctest to run.
         time = param.Time(until=20, timestep=1)
         self.assertEqual(time(), 0)


### PR DESCRIPTION
`nose` was still expected by `conda build` to run the test suite, which couldn't work at all since it was replaced recently by pytest.

Part of this PR I've also decided to move the last doctest (param.Time) to a unit test. Why? Because conda build failed by simply replacing `nosetests tests` by `pytest tests`. It executes this from a folder that only includes the subfolder `tests`, and the command that was set to tell pytest to look for doctest to execute required the subfolders param and numberben to be also there (pytest tests param numbergen --doc-modules).

There may have been a way to configure pytest to cover this case but I thought it was just simpler to remove that last doctest. This makes even more sense now since param has some nice docs :)

Note that I've not removed the docstest code from the docstring, since it is still useful docs in itself. It's just no longer executed by pytest.