### PR TITLE
Fix bug setting attributes before class is initialized

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1164,7 +1164,7 @@ class Parameter(object):
         self._post_setter(obj, val)
 
         if obj is not None:
-            if not obj.initialized:
+            if not getattr(obj, 'initialized', False):
                 return
             obj.param._update_deps(self.name)
 


### PR DESCRIPTION
This was causing some issues setting attributes in a Parameterized constructor