### PR TITLE
Cleaned up old comments and alerts

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -832,7 +832,7 @@ class Number(Dynamic):
 
         As documented in https://github.com/holoviz/param/issues/80,
         currently does not respect exclusive bounds, which would
-        strictly require setting to one less for integer values or 
+        strictly require setting to one less for integer values or
         an epsilon less for floats.
         """
         # Values outside the bounds are silently cropped to

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1,10 +1,10 @@
 """
 Generic support for objects with full-featured Parameters and
-messaging. 
+messaging.
 
 This file comes from the Param library (https://github.com/holoviz/param)
 but can be taken out of the param module and used on its own if desired,
-either alone (providing basic Parameter support) or with param's 
+either alone (providing basic Parameter support) or with param's
 __init__.py (providing specialized Parameter types).
 """
 
@@ -1548,7 +1548,7 @@ class Parameters(object):
         """
         self = self_.param.self
         ## Deepcopy all 'instantiate=True' parameters
-        # (building a set of names first to avoid redundantly 
+        # (building a set of names first to avoid redundantly
         # instantiating a later-overridden parent class's parameter)
         params_to_instantiate = {}
         for class_ in classlist(type(self)):
@@ -3139,7 +3139,7 @@ class Parameterized(object):
         if imports is None:
             imports = [] # would have been simpler to use a set from the start
         imports[:] = list(set(imports))
-        
+
         # Generate import statement
         mod = self.__module__
         bits = mod.split('.')
@@ -3210,7 +3210,7 @@ class Parameterized(object):
     # dynamic parameters set on a class can't have state saved. This
     # is because, to do this, state_push() would need to be a
     # @bothmethod, but that complicates inheritance in cases where we
-    # already have a state_push() method. 
+    # already have a state_push() method.
     # (isinstance(g,Parameterized) below is used to exclude classes.)
 
     def state_push(self):


### PR DESCRIPTION
Removed a bunch of outdated ALERT comments, NOTE, CB, etc. now that there is documentation.  ALERTS should in future be handled as open GitHub issues with full descriptions. Some items are marked PARAM2_DEPRECATION indicating functionality or API that could and ideally should be removed in param 2.0.

A few of the comments were too cryptic for me to decipher:

1. `CBENHANCEMENT: Add an 'epsilon' slot. See email 'Re: simulation-time-controlled Dynamic parameters' Dec 22, 2007 CB->JAB`: I found no such email. I can imagine why an epsilon might be useful for time-dependent parameters, but only in a vague way.
2. `CEBALERT: we break some aspects of slot handling for Parameter and Parameterized. The __new__ methods in the metaclasses for those two classes omit to handle the case where __dict__ is passed in __slots__ (and they possibly omit other things too).` ParameterizedMetaclass doesn't even have a `__new__` method, and I can't see any reason for special handling in ParameterMetaclass.
3. `Additionally, various bits of code in the Parameterized class assumes that all Parameterized instances have a __dict__, but I'm not sure that's guaranteed to be true (although it's true at the moment).`: I can't see why a Parameterized wouldn't have a `__dict__`
4. `CEBALERT: I think I've noted elsewhere the fact that we sometimes have a method on Parameter that requires passing the owning Parameterized instance or class, and other times we have the method on Parameterized itself.  In case I haven't written that down elsewhere, here it is again.  We should clean that up (at least we should be consistent).`: agreed, but I couldn't find any examples of this on Parameter.
5. `cebalert: it's really time to stop and clean up this bothmethod stuff and repeated code in methods using it.`: I have no idea what could be cleaned up about it.

Now that there is a proper user manual, we should consider whether to shorten some of the very-detailed docstrings in these two files, since they may now drift out of sync with the official docs. They do have a bit more "reference manual" feel to them in some cases, so I'm not necessarily ready to delete them immediately.
