### PR TITLE
Method dependencies should not return intermediate dependencies by default

### DIFF
--- a/tests/API1/testparamdepends.py
+++ b/tests/API1/testparamdepends.py
@@ -318,7 +318,7 @@ class TestParamDepends(API1TestCase):
     def test_param_instance_depends_dynamic_single_nested_initialized_no_intermediates(self):
         init_b = self.P()
         inst = self.P(b=init_b)
-        pinfos = inst.param.params_depended_on('single_nested')
+        pinfos = inst.param.params_depended_on('single_nested', intermediate=False)
         self.assertEqual(len(pinfos), 1)
 
         assert pinfos[0].inst is init_b
@@ -327,10 +327,19 @@ class TestParamDepends(API1TestCase):
         new_b = self.P()
         inst.b = new_b
 
-        pinfos = inst.param.params_depended_on('single_nested')
+        pinfos = inst.param.params_depended_on('single_nested', intermediate=False)
         self.assertEqual(len(pinfos), 1)
         assert pinfos[0].inst is new_b
         assert pinfos[0].name == 'a'
+
+    def test_param_instance_depends_dynamic_single_nested_initialized_only_intermediates(self):
+        init_b = self.P()
+        inst = self.P(b=init_b)
+        pinfos = inst.param.params_depended_on('single_nested', intermediate='only')
+        self.assertEqual(len(pinfos), 1)
+
+        assert pinfos[0].inst is inst
+        assert pinfos[0].name == 'b'
 
     def test_param_instance_depends_dynamic_single_nested_initialized(self):
         init_b = self.P()


### PR DESCRIPTION
Recent changes to dynamic (or sub-object) dependency resolution meant that `_params_depended_on` now returns intermediate dependencies for sub-object dependency specs, e.g. for a dependency on `'a.b.c'` we would return dependencies on `a` and `b` as well as `c`. This is appropriate for internal use since we have to update the dynamic dependencies when either `a` or `b` are changed but for the public API `.param.method_dependencies` this is usually not what they want since they only care if the actual value of `c` has changed. Therefore we add an `intermediate` flag to this API and set the default to `False`. In addition we also support `intermediate='only'` which will allow downstream libraries to update the dependencies when an intermediate changes.