### PR TITLE
Make iscoroutinefunction more robust

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -340,7 +340,10 @@ def iscoroutinefunction(function):
     """
     if not hasattr(inspect, 'iscoroutinefunction'):
         return False
-    return inspect.isasyncgenfunction(function) or inspect.iscoroutinefunction(function)
+    try:
+        return inspect.isasyncgenfunction(function) or inspect.iscoroutinefunction(function)
+    except AttributeError:
+        return False
 
 
 def instance_descriptor(f):


### PR DESCRIPTION
Certain functions may raise an error when passed to `inspect.iscoroutinefunction`.