### PR TITLE
Create a new `objects` instead of appending a value when `check_on_set` is False

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1289,7 +1289,7 @@ class Selector(SelectorBase):
         to check each item instead.
         """
         if not (val in self.objects):
-            self.objects.append(val)
+            self.objects = self.objects + [val]
 
     def get_range(self):
         """


### PR DESCRIPTION
This is useful for Panel when an `AutocompleteInput` widget is created from a `Selector` Parameter, with `restrict` (widget) and `check_on_set` (Parameter) set to False. Before this change, a new value manually added to the list of completions/options by a user would just be appended to `objects`, and as such not reflected in the widget `options`. With this change `objects` and `options` are in sync.