### PR TITLE
CI: Run more tests on Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,3 @@
-# things not included
-# language
-# notifications - no email notifications set up
-
 name: pytest
 on:
   push:
@@ -26,8 +22,6 @@ jobs:
         shell: bash -l {0} 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
-      CHANS_DEV: "-c pyviz/label/dev"
-      CHANS: "-c pyviz"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         if: (!startsWith(matrix.python-version, 'py'))
         run: tox -e with_numpy
       - name: unit with_pandas
-        if: (!startsWith(matrix.python-version, 'py') && !(contains(matrix.os, 'windows') && matrix.python-version == '3.10'))
+        if: (!startsWith(matrix.python-version, 'py'))
         run: tox -e with_pandas
       - name: unit with_jsonschema
         run: tox -e with_jsonschema

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 
 [testenv]
 deps = .[tests]
-commands = pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml
+commands = pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml -W error
 
 [testenv:with_numpy]
 deps = {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 
 [testenv]
 deps = .[tests]
-commands = pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml -W error
+commands = pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml
 
 [testenv:with_numpy]
 deps = {[testenv]deps}


### PR DESCRIPTION
The CI is already running on Python 3.10 but was avoiding running a few tests because at the time it was set a few packages were not yet available on Python 3.10
