### PR TITLE
Avoid equality check on Watcher

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2031,7 +2031,7 @@ class Parameters(object):
 
         if self_.self_or_cls.param._BATCH_WATCH:
             self_._events.append(event)
-            if watcher not in self_._watchers:
+            if not any(watcher is w for w in self_._watchers):
                 self_._watchers.append(watcher)
         else:
             event = self_._update_event_type(watcher, event, self_.self_or_cls.param._TRIGGER)


### PR DESCRIPTION
Since a `Watcher` is simply a tuple a check like `watcher not in self_._watchers` effectively results in an equality comparison on all the objects inside the watcher tuple, including the Parameterized instance the watcher is attached to. Not all Parameterized objects implement equality checks that make sense in this context so to avoid this we only check for identity.