### PR TITLE
Remove the github source link from the navbar

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -29,6 +29,5 @@ User Guide <user_guide/index>
 Comparisons <comparisons>
 Roadmap <roadmap>
 API <reference>
-Github Source <https://github.com/holoviz/param>
 About <about>
 ```


### PR DESCRIPTION
Since there's already the GitHub icon link in the navbar.