### PR TITLE
Schedule CI workflows and add downstream tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,10 @@ on:
     - 'v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+  # Dry-run only
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * SUN'
 
 jobs:
   conda_build:
@@ -44,12 +48,12 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda build conda.recipe/
       - name: conda dev upload
-        if: (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc'))
+        if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           eval "$(conda shell.bash hook)"
           anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev $(conda build --output conda.recipe)
       - name: conda main upload
-        if: (!(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+        if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           eval "$(conda shell.bash hook)"
           anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label=dev --label=main $(conda build --output conda.recipe)
@@ -76,6 +80,7 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
       - name: Publish package to PyPI
+        if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: ${{ secrets.PPU }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,9 +9,16 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'dev or main'     
+        description: 'Site to build and deploy'
+        type: choice
+        options:
+        - dev
+        - main
+        - dryrun
         required: true
-        default: 'dev'
+        default: dryrun
+  schedule:
+    - cron: '0 13 * * SUN'
 
 jobs:
   build_docs:
@@ -46,14 +53,18 @@ jobs:
           python -m nbsite build --org holoviz --project-name param
       - name: Deploy dev
         uses: peaceiris/actions-gh-pages@v3
-        if: (github.event.inputs.target == 'dev' || contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc'))
+        if: |
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
+          (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         with:
           personal_token: ${{ secrets.ACCESS_TOKEN }}
           external_repository: pyviz-dev/param
           publish_dir: ./builtdocs
           force_orphan: true
       - name: Deploy main
-        if: (github.event.inputs.target == 'main' || !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+        if: |
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
+          (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/downstream_tests.yaml
+++ b/.github/workflows/downstream_tests.yaml
@@ -1,0 +1,23 @@
+name: downstream_tests
+
+on:
+  # Run this workflow after the build workflow has completed.
+  workflow_run:
+    workflows: [packages]
+    types: [completed]
+  # Or by triggering it manually via Github's UI
+  workflow_dispatch:
+    inputs:
+      manual:
+        description: don't change me!
+        type: boolean
+        required: true
+        default: true
+
+jobs:
+  downstream_tests:
+    uses: pyviz-dev/holoviz_tasks/.github/workflows/run_downstream_tests.yaml@main
+    with:
+      downstream_repos_as_json: "{\"downstream_repo\":[\"panel\", \"lumen\", \"holoviews\", \"datashader\", \"colorcet\"]}"
+    secrets:
+      ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
     - '*'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * SUN'
 
 jobs:
   test_suite:


### PR DESCRIPTION
* The test, build and doc workflows are set to run every Sunday on a dry-run mode
* Add a downstream test workflow that will trigger the tests of packages depending on Param on every Param release