### PR TITLE
Allow (de)serializing CalendarRange and DateRange Parameters

### DIFF
--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -73,6 +73,18 @@ class TestSet(param.Parameterized):
     y = None if np is None else param.Array(default=None)
     z = None if pd is None else param.DataFrame(default=None, allow_None=True)
     aa = param.Tuple(default=None, allow_None=True, length=1)
+    ab = param.CalendarDateRange(default=(
+        datetime.date(2020, 1, 1),
+        datetime.date(2021, 1, 1)
+    ))
+    ac = param.DateRange(default=(
+        datetime.date(2020, 1, 1),
+        datetime.date(2021, 1, 1)
+    ))
+    ad = param.DateRange(default=(
+        datetime.datetime(2020, 1, 1, 1, 1, 1, 1),
+        datetime.datetime(2021, 1, 1, 1, 1, 1, 1)
+    ))
 
 
 test = TestSet(a=29)
@@ -194,6 +206,23 @@ class TestSerialization(API1TestCase):
             else:
                 self.assertTrue(getattr(test, pname).equals(deserialized[pname]))
 
+    def test_serialize_calendar_date_range_class(self):
+        self._test_serialize(TestSet, 'ab')
+
+    def test_serialize_calendar_date_range_instance(self):
+        self._test_serialize(test, 'ab')
+
+    def test_serialize_date_range_class(self):
+        self._test_serialize(TestSet, 'ac')
+
+    def test_serialize_date_range_instance(self):
+        self._test_serialize(test, 'ac')
+
+    def test_serialize_datetime_range_class(self):
+        self._test_serialize(TestSet, 'ad')
+
+    def test_serialize_datetime_range_instance(self):
+        self._test_serialize(test, 'ad')
 
 
 class TestJSONSerialization(TestSerialization):

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -252,15 +252,19 @@ class TestSerialization(API1TestCase):
     def test_serialize_datetime_range_instance(self):
         self._test_serialize(test, 'ad')
 
+    @np_skip
     def test_serialize_datetime_range_numpy_class(self):
         self._test_serialize(TestSet, 'ae')
 
+    @np_skip
     def test_serialize_datetime_range_numpy_instance(self):
         self._test_serialize(test, 'ae')
 
+    @pd_skip
     def test_serialize_datetime_range_pandas_class(self):
         self._test_serialize(TestSet, 'af')
 
+    @pd_skip
     def test_serialize_datetime_range_pandas_instance(self):
         self._test_serialize(test, 'af')
 

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -18,11 +18,16 @@ except ImportError:
         raise ImportError("PARAM_TEST_JSONSCHEMA=1 but jsonschema not available.")
     validate = None
 
+now = datetime.datetime.now()
+after_now = now + datetime.timedelta(days=1)
+
 try:
     import numpy as np
     ndarray = np.array([[1,2,3],[4,5,6]])
+    npdt1 = np.datetime64(now)
+    npdt2 = np.datetime64(after_now)
 except:
-    np, ndarray = None, None
+    np, ndarray, npdt1, npdt2 = None, None, None, None
 
 np_skip = skipIf(np is None, "NumPy is not available")
 
@@ -30,8 +35,10 @@ try:
     import pandas as pd
     df1 = pd.DataFrame({'A':[1,2,3], 'B':[1.1,2.2,3.3]})
     df2 = pd.DataFrame({'A':[1.1,2.2,3.3], 'B':[1.1,2.2,3.3]})
+    pdts1 = pd.Timestamp(now)
+    pdts2 = pd.Timestamp(after_now)
 except:
-    pd, df1, df2 = None, None, None
+    pd, df1, df2, pdts1, pdts2 = None, None, None, None, None
 
 pd_skip = skipIf(pd is None, "pandas is not available")
 
@@ -52,6 +59,8 @@ class TestSet(param.Parameterized):
     e = param.List([1,2,3], class_=int)
     f = param.List([1,2,3])
     g = param.Date(default=datetime.datetime.now())
+    g2 = None if np is None else param.Date(default=npdt1)
+    g3 = None if pd is None else param.Date(default=pdts1)
     h = param.Tuple(default=(1,2,3), length=3)
     i = param.NumericTuple(default=(1,2,3,4))
     j = param.XYCoordinates(default=(32.1, 51.5))
@@ -85,6 +94,8 @@ class TestSet(param.Parameterized):
         datetime.datetime(2020, 1, 1, 1, 1, 1, 1),
         datetime.datetime(2021, 1, 1, 1, 1, 1, 1)
     ))
+    ae = None if np is None else param.DateRange(default=(npdt1, npdt2))
+    af = None if pd is None else param.DateRange(default=(pdts1, pdts2))
 
 
 test = TestSet(a=29)
@@ -139,6 +150,23 @@ class TestSerialization(API1TestCase):
 
     def test_serialize_date_instance(self):
         self._test_serialize(test, 'g')
+
+    @np_skip
+    def test_serialize_date_numpy_class(self):
+        self._test_serialize(TestSet, 'g2')
+
+    @np_skip
+    def test_serialize_date_numpy_instance(self):
+        self._test_serialize(test, 'g2')
+        self._test_serialize(test, 'g')
+
+    @pd_skip
+    def test_serialize_date_pandas_class(self):
+        self._test_serialize(TestSet, 'g3')
+
+    @pd_skip
+    def test_serialize_date_pandas_instance(self):
+        self._test_serialize(test, 'g3')
 
     def test_serialize_tuple_class(self):
         self._test_serialize(TestSet, 'h')
@@ -223,6 +251,18 @@ class TestSerialization(API1TestCase):
 
     def test_serialize_datetime_range_instance(self):
         self._test_serialize(test, 'ad')
+
+    def test_serialize_datetime_range_numpy_class(self):
+        self._test_serialize(TestSet, 'ae')
+
+    def test_serialize_datetime_range_numpy_instance(self):
+        self._test_serialize(test, 'ae')
+
+    def test_serialize_datetime_range_pandas_class(self):
+        self._test_serialize(TestSet, 'af')
+
+    def test_serialize_datetime_range_pandas_instance(self):
+        self._test_serialize(test, 'af')
 
 
 class TestJSONSerialization(TestSerialization):

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -4,6 +4,7 @@ Testing JSON serialization of parameters and the corresponding schemas.
 
 import datetime
 import json
+import sys
 
 import param
 
@@ -30,6 +31,9 @@ except:
     np, ndarray, npdt1, npdt2 = None, None, None, None
 
 np_skip = skipIf(np is None, "NumPy is not available")
+
+on_py2 = sys.version_info[0] == 2
+py2_skip = skipIf(on_py2, "Ignore Python 2")
 
 try:
     import pandas as pd
@@ -94,7 +98,8 @@ class TestSet(param.Parameterized):
         datetime.datetime(2020, 1, 1, 1, 1, 1, 1),
         datetime.datetime(2021, 1, 1, 1, 1, 1, 1)
     ))
-    ae = None if np is None else param.DateRange(default=(npdt1, npdt2))
+    # datetime.datetime comparison with numpy.datetime64 fails on Python 2
+    ae = None if (np is None or on_py2) else param.DateRange(default=(npdt1, npdt2))
     af = None if pd is None else param.DateRange(default=(pdts1, pdts2))
 
 
@@ -151,14 +156,15 @@ class TestSerialization(API1TestCase):
     def test_serialize_date_instance(self):
         self._test_serialize(test, 'g')
 
+    @py2_skip
     @np_skip
     def test_serialize_date_numpy_class(self):
         self._test_serialize(TestSet, 'g2')
 
+    @py2_skip
     @np_skip
     def test_serialize_date_numpy_instance(self):
         self._test_serialize(test, 'g2')
-        self._test_serialize(test, 'g')
 
     @pd_skip
     def test_serialize_date_pandas_class(self):
@@ -252,10 +258,12 @@ class TestSerialization(API1TestCase):
     def test_serialize_datetime_range_instance(self):
         self._test_serialize(test, 'ad')
 
+    @py2_skip
     @np_skip
     def test_serialize_datetime_range_numpy_class(self):
         self._test_serialize(TestSet, 'ae')
 
+    @py2_skip
     @np_skip
     def test_serialize_datetime_range_numpy_instance(self):
         self._test_serialize(test, 'ae')

--- a/tests/API1/testjsonserialization.py
+++ b/tests/API1/testjsonserialization.py
@@ -63,7 +63,7 @@ class TestSet(param.Parameterized):
     e = param.List([1,2,3], class_=int)
     f = param.List([1,2,3])
     g = param.Date(default=datetime.datetime.now())
-    g2 = None if np is None else param.Date(default=npdt1)
+    g2 = None if (np is None or on_py2) else param.Date(default=npdt1)
     g3 = None if pd is None else param.Date(default=pdts1)
     h = param.Tuple(default=(1,2,3), length=3)
     i = param.NumericTuple(default=(1,2,3,4))


### PR DESCRIPTION
I got the following error while working on a Lumen app that has a DateRange filter widget synced to the URL:
```
  File "/Users/mliquet/miniconda3/envs/lumen-dev37/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

We found out that the `DateRange` and `CalendarRange` parameters inherit from the `Tuple` parameter (de)serialization methods, while they should override these methods as Python's `json` module can't serialize datetime objects (`import datetime as dt, json; json.dumps(dt.datetime.now())` raises the TypeError mentioned above).

This PR adds these methods to the two parameters, and test them. I've added tests, including tests that use `np.datetime64` and `pd.Timestamp` objects since they appeared to be supported (I learnt that `pd.Timestamp` objects inherits from `datetime.datetime`).