### PR TITLE
Improve DateRange validation

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2112,9 +2112,15 @@ class DateRange(Range):
     """
 
     def _validate_value(self, val, allow_None):
+        # Cannot use super()._validate_value as DateRange inherits from
+        # NumericTuple which check that the tuple values are numbers and
+        # datetime objects aren't numbers.
         if allow_None and val is None:
             return
 
+        if not isinstance(val, tuple):
+            raise ValueError("DateRange parameter %r only takes a tuple value, "
+                             "not %s." % (self.name, type(val).__name__))
         for n in val:
             if isinstance(n, dt_types):
                 continue

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2124,15 +2124,14 @@ class DateRange(Range):
         for n in val:
             if isinstance(n, dt_types):
                 continue
-            raise ValueError("DateRange parameter %r only takes datetime "
-                             "types, not %r." % (self.name, type(val)))
+            raise ValueError("DateRange parameter %r only takes date/datetime "
+                             "values, not type %s." % (self.name, type(n).__name__))
 
         start, end = val
         if not end >= start:
             raise ValueError("DateRange parameter %r's end datetime %s "
                              "is before start datetime %s." %
                              (self.name, val[1], val[0]))
-
 
 
 class CalendarDateRange(Range):

--- a/tests/API1/testdaterangeparam.py
+++ b/tests/API1/testdaterangeparam.py
@@ -3,8 +3,16 @@ Unit tests for DateRange parameter.
 """
 
 import datetime as dt
+
 import param
+import pytest
+
 from . import API1TestCase
+
+try:
+    import numpy as np
+except:
+    np = None
 
 # Assuming tests of range parameter cover most of what's needed to
 # test date range.
@@ -14,67 +22,109 @@ class TestDateRange(API1TestCase):
     bad_range = (dt.datetime(2017,2,27),dt.datetime(2017,2,26))
 
     def test_wrong_type_default(self):
-        try:
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter None only takes a tuple value, not str."
+        ):
+            class Q(param.Parameterized):
+                a = param.DateRange(default='wrong')
+
+    def test_wrong_inner_type_default(self):
+        with pytest.raises(
+            ValueError,
+            match='DateRange parameter None only takes date/datetime values, not type float.'
+        ):
             class Q(param.Parameterized):
                 a = param.DateRange(default=(1.0,2.0))
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date type was accepted.")
+
+    def test_wrong_inner_type_init(self):
+        class Q(param.Parameterized):
+            a = param.DateRange()
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter 'a' only takes date/datetime values, not type float."
+        ):
+            Q(a=(1.0, 2.0))
+
+    def test_wrong_inner_type_set(self):
+        class Q(param.Parameterized):
+            a = param.DateRange()
+        q = Q()
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter 'a' only takes date/datetime values, not type float."
+        ):
+            q.a = (1.0, 2.0)
 
     def test_wrong_type_init(self):
         class Q(param.Parameterized):
             a = param.DateRange()
-
-        try:
-            Q(a=self.bad_range)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date type was accepted.")
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter 'a' only takes a tuple value, not str."
+        ):
+            Q(a='wrong')
 
     def test_wrong_type_set(self):
         class Q(param.Parameterized):
             a = param.DateRange()
         q = Q()
-
-        try:
-            q.a = self.bad_range
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date type was accepted.")
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter 'a' only takes a tuple value, not str."
+        ):
+            q.a = 'wrong'
 
     def test_start_before_end_default(self):
-        try:
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter None's end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00."
+        ):
             class Q(param.Parameterized):
                 a = param.DateRange(default=self.bad_range)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date range was accepted.")
 
     def test_start_before_end_init(self):
         class Q(param.Parameterized):
             a = param.DateRange()
-
-        try:
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter 'a''s end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00."
+        ):
             Q(a=self.bad_range)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date range was accepted.")
 
     def test_start_before_end_set(self):
         class Q(param.Parameterized):
             a = param.DateRange()
-
         q = Q()
-        try:
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter 'a''s end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00."
+        ):
             q.a = self.bad_range
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date range was accepted.")
 
+    @pytest.mark.skipif(np is None, reason='NumPy is not available')
+    def test_numpy_default(self):
+        class Q(param.Parameterized):
+            a = param.DateRange(default=(np.datetime64('2022-01-01T00:00'), np.datetime64('2022-10-01T00:00')))
 
+    @pytest.mark.skipif(np is None, reason='NumPy is not available')
+    def test_numpy_set(self):
+        class Q(param.Parameterized):
+            a = param.DateRange()
+        q = Q()
+        q.a = (np.datetime64('2022-01-01T00:00'), np.datetime64('2022-10-01T00:00'))
+
+    @pytest.mark.skipif(np is None, reason='NumPy is not available')
+    def test_numpy_init(self):
+        class Q(param.Parameterized):
+            a = param.DateRange()
+        Q(a=(np.datetime64('2022-01-01T00:00'), np.datetime64('2022-10-01T00:00')))
+
+    @pytest.mark.skipif(np is None, reason='NumPy is not available')
+    def test_numpy_start_before_end_default(self):
+        with pytest.raises(
+            ValueError,
+            match="DateRange parameter None's end datetime 2022-01-01T00:00 is before start datetime 2022-10-01T00:00."
+        ):
+            class Q(param.Parameterized):
+                a = param.DateRange(default=(np.datetime64('2022-10-01T00:00'), np.datetime64('2022-01-01T00:00')))


### PR DESCRIPTION
Noticed that the `DateRange` parameter was not checking that the value provided is a `tuple`, which it should be given that `DateRange` inherits from Tuple.

I've also changed the error message reported when one of the values is not of the correct type:

    DateRange parameter 'a' only takes date/datetime values, not type float.

This is slightly different formatting compared to the messages reported by other Parameters, e.g. with a List:

    List parameter None must be a list, not an object of type <class 'str'>.

Notice `of type float` vs. `of type <class 'str'>`. If the latter is preferred, I could update the error messages of the other Parameters.