### PR TITLE
Support comparing date-like objects

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -27,7 +27,7 @@ import collections
 
 from .parameterized import (
     Parameterized, Parameter, String, ParameterizedFunction, ParamOverrides,
-    descendents, get_logger, instance_descriptor, basestring)
+    descendents, get_logger, instance_descriptor, basestring, dt_types)
 
 from .parameterized import (batch_watch, depends, output, script_repr, # noqa: api import
                             discard_events, edit_constant, instance_descriptor)
@@ -46,16 +46,6 @@ try:
     __version__ = str(Version(fpath=__file__, archive_commit="$Format:%h$", reponame="param"))
 except:
     __version__ = "0.0.0+unknown"
-
-
-dt_types = (dt.datetime, dt.date)
-
-try:
-    import numpy as np
-    dt_types = dt_types + (np.datetime64,)
-except:
-    pass
-
 
 try:
     import collections.abc as collections_abc
@@ -201,12 +191,13 @@ def guess_param_types(**kwargs):
                 params[k] = Tuple(**kws)
         elif isinstance(v, list):
             params[k] = List(**kws)
-        elif isinstance(v, np.ndarray):
-            params[k] = Array(**kws)
         else:
+            from numpy import ndarray
             from pandas import DataFrame as pdDFrame
             from pandas import Series as pdSeries
 
+            if isinstance(v, ndarray):
+                params[k] = Array(**kws)
             if isinstance(v, pdDFrame):
                 params[k] = DataFrame(**kws)
             elif isinstance(v, pdSeries):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -9,6 +9,7 @@ __init__.py (providing specialized Parameter types).
 """
 
 import copy
+import datetime as dt
 import re
 import sys
 import inspect
@@ -43,6 +44,14 @@ try:
     from inspect import getfullargspec
 except:
     from inspect import getargspec as getfullargspec # python2
+
+dt_types = (dt.datetime, dt.date)
+
+try:
+    import numpy as np
+    dt_types = dt_types + (np.datetime64,)
+except:
+    pass
 
 basestring = basestring if sys.version_info[0]==2 else str # noqa: it is defined
 
@@ -1398,8 +1407,9 @@ class Comparator(object):
         numbers.Number: operator.eq,
         basestring: operator.eq,
         bytes: operator.eq,
-        type(None): operator.eq
+        type(None): operator.eq,
     }
+    equalities.update({dtt: operator.eq for dtt in dt_types})
 
     @classmethod
     def is_equal(cls, obj1, obj2):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1413,8 +1413,6 @@ class Comparator(object):
 
     @classmethod
     def is_equal(cls, obj1, obj2):
-        if obj1 is obj2:
-            return True
         for eq_type, eq in cls.equalities.items():
             if ((isinstance(eq_type, FunctionType)
                  and eq_type(obj1) and eq_type(obj2))

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1413,6 +1413,8 @@ class Comparator(object):
 
     @classmethod
     def is_equal(cls, obj1, obj2):
+        if obj1 is obj2:
+            return True
         for eq_type, eq in cls.equalities.items():
             if ((isinstance(eq_type, FunctionType)
                  and eq_type(obj1) and eq_type(obj2))

--- a/tests/API1/testcomparator.py
+++ b/tests/API1/testcomparator.py
@@ -1,9 +1,10 @@
 import datetime
 import decimal
-
-from param.parameterized import Comparator
+import sys
 
 import pytest
+
+from param.parameterized import Comparator
 
 try:
     import numpy as np
@@ -17,28 +18,32 @@ except ImportError:
 _now = datetime.datetime.now()
 _today = datetime.date.today()
 
-_supported = {
-    'str': 'test',
-    'float': 1.2,
-    'int': 1,
-    'decimal': decimal.Decimal(1) / decimal.Decimal(7),
-    'bytes': (1024).to_bytes(2, byteorder='big'),
-    'None': None,
-    'list': [1, 2],
-    'tuple': (1, 2),
-    'set': {1, 2},
-    'dict': {'a': 1, 'b': 2},
-    'date': _today,
-    'datetime': _now,
-}
+if sys.version_info[0] >= 3:
+    _supported = {
+        'str': 'test',
+        'float': 1.2,
+        'int': 1,
+        'decimal': decimal.Decimal(1) / decimal.Decimal(7),
+        'bytes': (1024).to_bytes(2, byteorder='big'),
+        'None': None,
+        'list': [1, 2],
+        'tuple': (1, 2),
+        'set': {1, 2},
+        'dict': {'a': 1, 'b': 2},
+        'date': _today,
+        'datetime': _now,
+    }
 
-if np:
-    _supported.update({
-        'np.datetime64': np.datetime64(_now),
-    })
-if pd:
-    _supported.update({'pd.Timestamp': pd.Timestamp(_now)})
+    if np:
+        _supported.update({
+            'np.datetime64': np.datetime64(_now),
+        })
+    if pd:
+        _supported.update({'pd.Timestamp': pd.Timestamp(_now)})
+else:
+    _supported = {}
 
+@pytest.mark.skipif(sys.version_info[0] == 2, reason="requires python 3 or higher")
 @pytest.mark.parametrize('obj', _supported.values(), ids=_supported.keys())
 def test_comparator_equal(obj):
     assert Comparator.is_equal(obj, obj)

--- a/tests/API1/testcomparator.py
+++ b/tests/API1/testcomparator.py
@@ -1,0 +1,45 @@
+import datetime
+import decimal
+
+from param.parameterized import Comparator
+
+import pytest
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
+_now = datetime.datetime.now()
+_today = datetime.date.today()
+
+_supported = {
+    'str': 'test',
+    'float': 1.2,
+    'int': 1,
+    'decimal': decimal.Decimal(1) / decimal.Decimal(7),
+    'bytes': (1024).to_bytes(2, byteorder='big'),
+    'None': None,
+    'list': [1, 2],
+    'tuple': (1, 2),
+    'set': {1, 2},
+    'dict': {'a': 1, 'b': 2},
+    'date': _today,
+    'datetime': _now,
+}
+
+if np:
+    _supported.update({
+        'np.datetime64': np.datetime64(_now),
+    })
+if pd:
+    _supported.update({'pd.Timestamp': pd.Timestamp(_now)})
+
+@pytest.mark.parametrize('obj', _supported.values(), ids=_supported.keys())
+def test_comparator_equal(obj):
+    assert Comparator.is_equal(obj, obj)
+


### PR DESCRIPTION
Discovered this bug while working on https://github.com/holoviz/lumen/pull/276

The `Comparator` class didn't support `datetime.date`, `datetime.datetime` and `np.datetime64` object. This meant that, if a parameter value was set to its old value, Param would still see it as a new value and would let potential watchers be executed, while they should not. This caused problems for Panel bidirectional links which don't check for equality but rely on Param.

I see that other types aren't supported, like Numpy Arrays, Pandas DataFrame, or frozensets. If more types should be added, let's come up with a list and add them in another PR.