### PR TITLE
Don't assume numpy/pandas is available in `guess_param_types` 

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -203,24 +203,22 @@ def guess_param_types(**kwargs):
         else:
             try:
                 from numpy import ndarray
-            except ImportError:
-                pass
-            else:
                 if isinstance(v, ndarray):
                     params[k] = Array(**kws)
                     continue
+            except ImportError:
+                pass
             try:
                 from pandas import DataFrame as pdDFrame
                 from pandas import Series as pdSeries
-            except ImportError:
-                pass
-            else:
                 if isinstance(v, pdDFrame):
                     params[k] = DataFrame(**kws)
                     continue
                 elif isinstance(v, pdSeries):
                     params[k] = Series(**kws)
                     continue
+            except ImportError:
+                pass
             params[k] = Parameter(**kws)
 
     return params

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -201,24 +201,21 @@ def guess_param_types(**kwargs):
         elif isinstance(v, list):
             params[k] = List(**kws)
         else:
-            try:
+            if 'numpy' in sys.modules:
                 from numpy import ndarray
                 if isinstance(v, ndarray):
                     params[k] = Array(**kws)
                     continue
-            except ImportError:
-                pass
-            try:
-                from pandas import DataFrame as pdDFrame
-                from pandas import Series as pdSeries
+            if 'pandas' in sys.modules:
+                from pandas import (
+                    DataFrame as pdDFrame, Series as pdSeries
+                )
                 if isinstance(v, pdDFrame):
                     params[k] = DataFrame(**kws)
                     continue
                 elif isinstance(v, pdSeries):
                     params[k] = Series(**kws)
                     continue
-            except ImportError:
-                pass
             params[k] = Parameter(**kws)
 
     return params

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -194,7 +194,7 @@ def guess_param_types(**kwargs):
         elif isinstance(v, tuple):
             if all(_is_number(el) for el in v):
                 params[k] = NumericTuple(**kws)
-            elif all(isinstance(el. dt_types) for el in v) and len(v)==2:
+            elif all(isinstance(el, dt_types) for el in v) and len(v)==2:
                 params[k] = DateRange(**kws)
             else:
                 params[k] = Tuple(**kws)

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -201,18 +201,27 @@ def guess_param_types(**kwargs):
         elif isinstance(v, list):
             params[k] = List(**kws)
         else:
-            from numpy import ndarray
-            from pandas import DataFrame as pdDFrame
-            from pandas import Series as pdSeries
-
-            if isinstance(v, ndarray):
-                params[k] = Array(**kws)
-            if isinstance(v, pdDFrame):
-                params[k] = DataFrame(**kws)
-            elif isinstance(v, pdSeries):
-                params[k] = Series(**kws)
+            try:
+                from numpy import ndarray
+            except ImportError:
+                pass
             else:
-                params[k] = Parameter(**kws)
+                if isinstance(v, ndarray):
+                    params[k] = Array(**kws)
+                    continue
+            try:
+                from pandas import DataFrame as pdDFrame
+                from pandas import Series as pdSeries
+            except ImportError:
+                pass
+            else:
+                if isinstance(v, pdDFrame):
+                    params[k] = DataFrame(**kws)
+                    continue
+                elif isinstance(v, pdSeries):
+                    params[k] = Series(**kws)
+                    continue
+            params[k] = Parameter(**kws)
 
     return params
 

--- a/tests/API1/testutils.py
+++ b/tests/API1/testutils.py
@@ -1,0 +1,58 @@
+import datetime as dt
+
+import param
+import pytest
+
+from param import guess_param_types
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
+now = dt.datetime.now()
+today = dt.date.today()
+
+guess_param_types_data = {
+    'Parameter': (param.Parameter(), param.Parameter),
+    'Date': (today, param.Date),
+    'Datetime': (now, param.Date),
+    'Boolean': (True, param.Boolean),
+    'Integer': (1, param.Integer),
+    'Number': (1.2, param.Number),
+    'String': ('test', param.String),
+    'Dict': (dict(a=1), param.Dict),
+    'NumericTuple': ((1, 2), param.NumericTuple),
+    'Tuple': (('a', 'b'), param.Tuple),
+    'DateRange': ((dt.date(2000, 1, 1), dt.date(2001, 1, 1)), param.DateRange),
+    'List': ([1, 2], param.List),
+    'Unsupported_None': (None, param.Parameter),
+}
+
+if np:
+    guess_param_types_data.update({
+        'Array':(np.ndarray([1, 2]), param.Array),
+    })
+if pd:
+    guess_param_types_data.update({
+        'DataFrame': (pd.DataFrame(data=dict(a=[1])), param.DataFrame),
+        'Series': (pd.Series([1, 2]), param.Series),
+    })
+
+@pytest.mark.parametrize('val,p', guess_param_types_data.values(), ids=guess_param_types_data.keys())
+def test_guess_param_types(val, p):
+    input = {'key': val}
+    output = guess_param_types(**input)
+    assert isinstance(output, dict)
+    assert len(output) == 1
+    assert 'key' in output
+    out_param = output['key']
+    assert isinstance(out_param, p)
+    if not type(out_param) == param.Parameter:
+        assert out_param.default is val
+        assert out_param.constant


### PR DESCRIPTION
Implementing the suggestion in https://github.com/holoviz/param/pull/629#discussion_r876410658, **needs https://github.com/holoviz/param/pull/629 to be merged first**

`guess_param_types` is actually not used at all across HoloViz and not documented. The PR that added this utility - https://github.com/holoviz/param/pull/317 - says that it "has cropped up several times and has resulted in some level of code duplication" and points to HoloViews [Streams.define](https://github.com/pyviz/holoviews/blob/master/holoviews/streams.py#L85) classmethod which indeed could make use of this utility, since it's basically inlining a partial implementation of it.

https://github.com/holoviz/param/pull/317 provides more details about the usefulness of this utility, and on the conversions it doesn't yet support.
