### PR TITLE
WIP: raise ValueError if param.depends is used without arguments or without defining dependencies

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -372,8 +372,7 @@ def get_method_owner(method):
     return method.__self__ if sys.version_info.major >= 3 else method.im_self
 
 
-@accept_arguments
-def depends(func, *dependencies, **kw):
+def depends(*dependencies, **kw):
     """
     Annotates a function or Parameterized method to express its
     dependencies.  The specified dependencies can be either be
@@ -384,71 +383,85 @@ def depends(func, *dependencies, **kw):
     on Parameter values, or on other metadata about the Parameter.
     """
 
+    if len(dependencies) == 1 and isinstance(dependencies[0], FunctionType):
+        fname = dependencies[0].__name__
+        raise ValueError('The depends decorator on the callable %r cannot be '
+                        'used without arguments.' % fname)
+
     # PARAM2_DEPRECATION: python2 workaround; python3 allows kw-only args
     # (i.e. "func, *dependencies, watch=False" rather than **kw and the check below)
     watch = kw.pop("watch", False)
     on_init = kw.pop("on_init", False)
 
-    if iscoroutinefunction(func):
-        from ._async import generate_depends
-        _depends = generate_depends(func)
-    else:
-        @wraps(func)
-        def _depends(*args, **kw):
-            return func(*args, **kw)
+    def decorator(func):
 
-    deps = list(dependencies)+list(kw.values())
-    string_specs = False
-    for dep in deps:
-        if isinstance(dep, basestring):
-            string_specs = True
-        elif not isinstance(dep, Parameter):
-            raise ValueError('The depends decorator only accepts string '
-                             'types referencing a parameter or parameter '
-                             'instances, found %s type instead.' %
-                             type(dep).__name__)
-        elif not (isinstance(dep.owner, Parameterized) or
-                  (isinstance(dep.owner, ParameterizedMetaclass))):
-            owner = 'None' if dep.owner is None else '%s class' % type(dep.owner).__name__
-            raise ValueError('Parameters supplied to the depends decorator, '
-                             'must be bound to a Parameterized class or '
-                             'instance not %s.' % owner)
-
-    if (any(isinstance(dep, Parameter) for dep in deps) and
-        any(isinstance(dep, basestring) for dep in deps)):
-        raise ValueError('Dependencies must either be defined as strings '
-                         'referencing parameters on the class defining '
-                         'the decorated method or as parameter instances. '
-                         'Mixing of string specs and parameter instances '
-                         'is not supported.')
-    elif string_specs and kw:
-        raise AssertionError('Supplying keywords to the decorated method '
-                             'or function is not supported when referencing '
-                             'parameters by name.')
-
-    if not string_specs and watch: # string_specs case handled elsewhere (later), in Parameterized.__init__
         if iscoroutinefunction(func):
-            from ._async import generate_callback
-            cb = generate_callback(func, dependencies, kw)
+            from ._async import generate_depends
+            _depends = generate_depends(func)
         else:
-            def cb(*events):
-                args = (getattr(dep.owner, dep.name) for dep in dependencies)
-                dep_kwargs = {n: getattr(dep.owner, dep.name) for n, dep in kw.items()}
-                return func(*args, **dep_kwargs)
+            @wraps(func)
+            def _depends(*args, **kw):
+                return func(*args, **kw)
 
-        grouped = defaultdict(list)
+        deps = list(dependencies)+list(kw.values())
+
+        if not deps:
+            raise ValueError('The depends decorator on the callable %r require dependencies '
+                            'to be defined.' % func.__name__)
+
+        string_specs = False
         for dep in deps:
-            grouped[id(dep.owner)].append(dep)
-        for group in grouped.values():
-            group[0].owner.param.watch(cb, [dep.name for dep in group])
+            if isinstance(dep, basestring):
+                string_specs = True
+            elif not isinstance(dep, Parameter):
+                raise ValueError('The depends decorator only accepts string '
+                                'types referencing a parameter or parameter '
+                                'instances, found %s type instead.' %
+                                type(dep).__name__)
+            elif not (isinstance(dep.owner, Parameterized) or
+                    (isinstance(dep.owner, ParameterizedMetaclass))):
+                owner = 'None' if dep.owner is None else '%s class' % type(dep.owner).__name__
+                raise ValueError('Parameters supplied to the depends decorator, '
+                                'must be bound to a Parameterized class or '
+                                'instance not %s.' % owner)
 
-    _dinfo = getattr(func, '_dinfo', {})
-    _dinfo.update({'dependencies': dependencies,
-                   'kw': kw, 'watch': watch, 'on_init': on_init})
+        if (any(isinstance(dep, Parameter) for dep in deps) and
+            any(isinstance(dep, basestring) for dep in deps)):
+            raise ValueError('Dependencies must either be defined as strings '
+                            'referencing parameters on the class defining '
+                            'the decorated method or as parameter instances. '
+                            'Mixing of string specs and parameter instances '
+                            'is not supported.')
+        elif string_specs and kw:
+            raise AssertionError('Supplying keywords to the decorated method '
+                                'or function is not supported when referencing '
+                                'parameters by name.')
 
-    _depends._dinfo = _dinfo
+        if not string_specs and watch: # string_specs case handled elsewhere (later), in Parameterized.__init__
+            if iscoroutinefunction(func):
+                from ._async import generate_callback
+                cb = generate_callback(func, dependencies, kw)
+            else:
+                def cb(*events):
+                    args = (getattr(dep.owner, dep.name) for dep in dependencies)
+                    dep_kwargs = {n: getattr(dep.owner, dep.name) for n, dep in kw.items()}
+                    return func(*args, **dep_kwargs)
 
-    return _depends
+            grouped = defaultdict(list)
+            for dep in deps:
+                grouped[id(dep.owner)].append(dep)
+            for group in grouped.values():
+                group[0].owner.param.watch(cb, [dep.name for dep in group])
+
+        _dinfo = getattr(func, '_dinfo', {})
+        _dinfo.update({'dependencies': dependencies,
+                    'kw': kw, 'watch': watch, 'on_init': on_init})
+
+        _depends._dinfo = _dinfo
+
+        return _depends
+
+    return decorator
 
 
 @accept_arguments

--- a/tests/API1/testparamdepends.py
+++ b/tests/API1/testparamdepends.py
@@ -216,6 +216,29 @@ class TestParamDepends(API1TestCase):
         self.P = P
         self.P2 = P2
 
+    def test_param_depends_no_arguments_raise(self):
+        with pytest.raises(
+            ValueError,
+            match="The depends decorator on the callable 'callback' cannot be used without arguments."
+        ):
+            class A(param.Parameterized):
+
+                @param.depends
+                def callback(self):
+                    pass
+
+
+    def test_param_depends_no_dependencies_raise(self):
+        with pytest.raises(
+            ValueError,
+            match="The depends decorator on the callable 'callback' require dependencies to be defined."
+        ):
+            class A(param.Parameterized):
+
+                @param.depends()
+                def callback(self):
+                    pass
+
     def test_param_depends_on_init(self):
         class A(param.Parameterized):
 
@@ -706,6 +729,26 @@ class TestParamDependsFunction(API1TestCase):
 
 
         self.P = P
+
+    def test_param_depends_no_arguments_raise(self):
+        with pytest.raises(
+            ValueError,
+            match="The depends decorator on the callable 'function' cannot be used without arguments."
+        ):
+
+            @param.depends
+            def function():
+                pass
+
+    def test_param_depends_no_dependencies_raise(self):
+        with pytest.raises(
+            ValueError,
+            match="The depends decorator on the callable 'function' require dependencies to be defined."
+        ):
+
+            @param.depends()
+            def function():
+                pass
 
     def test_param_depends_function_instance_params(self):
         p = self.P()


### PR DESCRIPTION
To raise an error in these cases where the `depends` decorator is used either without arguments or without providing any dependencies (same on methods on Parameterized classes).

```python
@param.depends
def foo():
    pass

# ValueError: The depends decorator on the callable 'foo' cannot be used without arguments.

@param.depends()
def foo():
    pass

# ValueError: The depends decorator on the callable 'foo' require dependencies to be defined.
```

WIP because as such the following would raise an error (since internally Panel uses the `depends` decorator when it binds a callable) while the approach retained is to warn in this case (https://github.com/holoviz/panel/pull/3545).

```python
import panel

def foo(val):
    return val

pn.panel(pn.bind(foo, val='bob'))
```

Emitting a warning instead of raising an error when no dependencies are defined may be a better idea (that Panel could silence).