### PR TITLE
Ensure named_objs does not fail on unhashable objects

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -144,7 +144,7 @@ def named_objs(objlist, namesdict=None):
 
     for obj in objlist:
         if reverse_lookup and hashable(obj) in reverse_lookup:
-            k = objtoname[hashable(obj)]
+            k = reverse_lookup[hashable(obj)]
         elif any(obj is v for (_, v) in unhashables):
             k = [k for (k, v) in unhashables if v is obj][0]
         elif hasattr(obj, "name"):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -133,18 +133,18 @@ def named_objs(objlist, namesdict=None):
     """
     objs = OrderedDict()
 
-    reverse_lookup = {}
+    objtoname = {}
     unhashables = []
     if namesdict is not None:
         for k, v in namesdict.items():
             try:
-                reverse_lookup[hashable(v)] = k
+                objtoname[hashable(v)] = k
             except TypeError:
                 unhashables.append((k, v))
 
     for obj in objlist:
-        if reverse_lookup and hashable(obj) in reverse_lookup:
-            k = reverse_lookup[hashable(obj)]
+        if objtoname and hashable(obj) in objtoname:
+            k = objtoname[hashable(obj)]
         elif any(obj is v for (_, v) in unhashables):
             k = [k for (k, v) in unhashables if v is obj][0]
         elif hasattr(obj, "name"):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -133,7 +133,10 @@ def named_objs(objlist, namesdict=None):
     objs = OrderedDict()
 
     if namesdict is not None:
-        objtoname = {hashable(v): k for k, v in namesdict.items()}
+        try:
+            objtoname = {hashable(v): k for k, v in namesdict.items()}
+        except Exception:
+            return namesdict
 
     for obj in objlist:
         if namesdict is not None and hashable(obj) in objtoname:

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -123,6 +123,7 @@ def hashable(x):
     else:
         return x
 
+
 def named_objs(objlist, namesdict=None):
     """
     Given a list of objects, returns a dictionary mapping from
@@ -132,15 +133,20 @@ def named_objs(objlist, namesdict=None):
     """
     objs = OrderedDict()
 
+    reverse_lookup = {}
+    unhashables = []
     if namesdict is not None:
-        try:
-            objtoname = {hashable(v): k for k, v in namesdict.items()}
-        except Exception:
-            return namesdict
+        for k, v in namesdict.items():
+            try:
+                reverse_lookup[hashable(v)] = k
+            except TypeError:
+                unhashables.append((k, v))
 
     for obj in objlist:
-        if namesdict is not None and hashable(obj) in objtoname:
+        if reverse_lookup and hashable(obj) in reverse_lookup:
             k = objtoname[hashable(obj)]
+        elif any(obj is v for (_, v) in unhashables):
+            k = [k for (k, v) in unhashables if v is obj][0]
         elif hasattr(obj, "name"):
             k = obj.name
         elif hasattr(obj, '__name__'):


### PR DESCRIPTION
Not all objects are hashable so the `named_objs` implementation has started causing some errors (e.g. because mpl colormaps aren't hashable anymore). For unhashable objects we try to reverse map the objects by identity.