### PR TITLE
Renamed incorrect BinaryPower example to EvenInteger

### DIFF
--- a/examples/user_guide/Parameters.ipynb
+++ b/examples/user_guide/Parameters.ipynb
@@ -730,7 +730,7 @@
     "\n",
     "As you can see above, a `Parameter` provides a lot of power already on its own, but in practice you will want to use much more specific parameter types that reject invalid inputs and keep your code clean and simple. A specialized Parameter acts as a \"contract\" with the users of the code you write, declaring and defending precisely what configuration is allowed and how to achieve it. If you need to accept specific inputs like that but don't add an appropriate Parameter type, you'll be stuck adding exceptions and validation code throughout your codebase, whereas anything you can express at the Parameter level will be enforced automatically without any further checks or code.\n",
     "\n",
-    "For instance, what if you want to accept a numeric parameter, but (for some reason) can only accept numbers that are integer powers of 2? You'll need a custom Parameter class to express a restriction like that. In this case you can do it by overriding the `_validate_value` method of the `Parameter` class:"
+    "For instance, what if you want to accept a numeric parameter, but (for some reason) can only accept numbers that are even integers? You'll need a custom Parameter class to express a restriction like that. In this case you can do it by overriding the `_validate_value` method of the `Parameter` class:"
    ]
   },
   {
@@ -741,22 +741,22 @@
    "source": [
     "import numbers\n",
     "\n",
-    "class BinaryPower(param.Parameter):\n",
-    "    \"\"\"Integer Parameter required to be a power of 2\"\"\"\n",
+    "class EvenInteger(param.Parameter):\n",
+    "    \"\"\"Integer Parameter that must be even\"\"\"\n",
     "\n",
     "    def _validate_value(self, val, allow_None):\n",
-    "        super(BinaryPower, self)._validate_value(val, allow_None)\n",
+    "        super(EvenInteger, self)._validate_value(val, allow_None)\n",
     "        if not isinstance(val, numbers.Number):\n",
-    "            raise ValueError(\"BinaryPower parameter %r must be a number, \"\n",
+    "            raise ValueError(\"EvenInteger parameter %r must be a number, \"\n",
     "                             \"not %r.\" % (self.name, val))\n",
     "        \n",
     "        if not (val % 2 == 0):\n",
-    "            raise ValueError(\"BinaryPower parameter %r must be a power of 2, \"\n",
+    "            raise ValueError(\"EvenInteger parameter %r must be even, \"\n",
     "                             \"not %r.\" % (self.name, val))\n",
     "\n",
     "class P(param.Parameterized):\n",
     "    n = param.Number()\n",
-    "    b = BinaryPower()\n",
+    "    b = EvenInteger()\n",
     "    \n",
     "p=P()\n",
     "P(n=5, b=4)\n",


### PR DESCRIPTION
Addresses #608 by keeping the simple code example but renaming the parameter to `EvenInteger` which expresses the actual check that is performed.