### PR TITLE
CI: update the codecov step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,5 @@ jobs:
       - name: unit all_deps
         if: (contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py'))
         run: tox -e with_all
-      - uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
+      - uses: codecov/codecov-action@v3
+        if: github.event_name == 'push'


### PR DESCRIPTION
The scheduled runs were failing because the same commit reference was sent to codecov again and again (param master branch isn't updated that often) and apparently codecov has some limits on that. So coverage reports are now uploaded to codecov only on push events, no longer on scheduled events.