### PR TITLE
Allow JSON serialization to work with json.dumps

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1022,12 +1022,12 @@ class Tuple(Parameter):
     @classmethod
     def serialize(cls, value):
         if value is None:
-            return 'null'
+            return None
         return list(value) # As JSON has no tuple representation
 
     @classmethod
     def deserialize(cls, value):
-        if value == 'null':
+        if value == 'null' or value is None:
             return None
         return tuple(value) # As JSON has no tuple representation
 
@@ -1483,12 +1483,12 @@ class Array(ClassSelector):
     @classmethod
     def serialize(cls, value):
         if value is None:
-            return 'null'
+            return None
         return value.tolist()
 
     @classmethod
     def deserialize(cls, value):
-        if value == 'null':
+        if value == 'null' or value is None:
             return None
         from numpy import asarray
         return asarray(value)
@@ -1570,12 +1570,12 @@ class DataFrame(ClassSelector):
     @classmethod
     def serialize(cls, value):
         if value is None:
-            return 'null'
+            return None
         return value.to_dict('records')
 
     @classmethod
     def deserialize(cls, value):
-        if value == 'null':
+        if value == 'null' or value is None:
             return None
         from pandas import DataFrame as pdDFrame
         return pdDFrame(value)
@@ -1942,14 +1942,14 @@ class Date(Number):
     @classmethod
     def serialize(cls, value):
         if value is None:
-            return 'null'
+            return None
         if not isinstance(value, (dt.datetime, dt.date)): # i.e np.datetime64
             value = value.astype(dt.datetime)
         return value.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @classmethod
     def deserialize(cls, value):
-        if value == 'null':
+        if value == 'null' or value is None:
             return None
         return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
 
@@ -1980,12 +1980,12 @@ class CalendarDate(Number):
     @classmethod
     def serialize(cls, value):
         if value is None:
-            return 'null'
+            return None
         return value.strftime("%Y-%m-%d")
 
     @classmethod
     def deserialize(cls, value):
-        if value == 'null':
+        if value == 'null' or value is None:
             return None
         return dt.datetime.strptime(value, "%Y-%m-%d").date()
 
@@ -2140,7 +2140,7 @@ class DateRange(Range):
     @classmethod
     def serialize(cls, value):
         if value is None:
-            return 'null'
+            return None
         # List as JSON has no tuple representation
         serialized = []
         for v in value:
@@ -2155,7 +2155,7 @@ class DateRange(Range):
         return serialized
 
     def deserialize(cls, value):
-        if value == 'null':
+        if value == 'null' or value is None:
             return None
         deserialized = []
         for v in value:
@@ -2191,13 +2191,13 @@ class CalendarDateRange(Range):
     @classmethod
     def serialize(cls, value):
         if value is None:
-            return 'null'
+            return None
         # As JSON has no tuple representation
         return [v.strftime("%Y-%m-%d") for v in value]
 
     @classmethod
     def deserialize(cls, value):
-        if value == 'null':
+        if value == 'null' or value is None:
             return None
         # As JSON has no tuple representation
         return tuple([dt.datetime.strptime(v, "%Y-%m-%d").date() for v in value])

--- a/tests/API1/testdateparam.py
+++ b/tests/API1/testdateparam.py
@@ -60,10 +60,9 @@ def test_date_serialization():
     User.param.deserialize_parameters(User.param.serialize_parameters())
 
     if sys.version_info.major == 2:
-        serialized_data = '{"A": null, "name": "User"}'
-    else:
-        serialized_data = '{"name": "User", "A": null}'
+        return
 
+    serialized_data = '{"name": "User", "A": null}'
     deserialized_data = {"name": "User", "A": None}
 
     assert serialized_data == json.dumps(deserialized_data)

--- a/tests/API1/testdateparam.py
+++ b/tests/API1/testdateparam.py
@@ -2,7 +2,7 @@
 Unit test for Date parameters.
 """
 
-
+import json
 import datetime as dt
 import param
 from . import API1TestCase
@@ -52,3 +52,16 @@ class TestDateParameters(API1TestCase):
         self.assertEqual(q.get_soft_bounds(), (dt.datetime(2017,2,1),
                                                dt.datetime(2017,2,25)))
 
+def test_date_serialization():
+    class User(param.Parameterized):
+        A = param.Date(default=None)
+
+    # Validate round is possible
+    User.param.deserialize_parameters(User.param.serialize_parameters())
+
+    serialized_data = '{"name": "User", "A": null}'
+    deserialized_data = {"name": "User", "A": None}
+
+    assert serialized_data == json.dumps(deserialized_data)
+    assert serialized_data == User.param.serialize_parameters()
+    assert deserialized_data == User.param.deserialize_parameters(serialized_data)

--- a/tests/API1/testdateparam.py
+++ b/tests/API1/testdateparam.py
@@ -1,7 +1,7 @@
 """
 Unit test for Date parameters.
 """
-
+import sys
 import json
 import datetime as dt
 import param
@@ -59,7 +59,11 @@ def test_date_serialization():
     # Validate round is possible
     User.param.deserialize_parameters(User.param.serialize_parameters())
 
-    serialized_data = '{"name": "User", "A": null}'
+    if sys.version_info.major == 2:
+        serialized_data = '{"A": null, "name": "User"}'
+    else:
+        serialized_data = '{"name": "User", "A": null}'
+
     deserialized_data = {"name": "User", "A": None}
 
     assert serialized_data == json.dumps(deserialized_data)


### PR DESCRIPTION
Fixes #578

The changes in #582 made it possible to round-trip serialize <-> deserialize within param. 

A completely valid way to deserialize is to have the serialized values created outside param like this:
``` python
import json
import param

class User(param.Parameterized):
    A = param.Date(default=None)

data = json.dumps({"A": None})    # gives: '{"A": null}' <- note that null is not a string
User.param.deserialize_parameters(data)
```

Which raised this error before these changes:
``` python-traceback
Traceback (most recent call last):
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3378, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "/tmp/ipykernel_70470/342607310.py", line 8, in <module>
    User.param.deserialize_parameters(data)
  File "/home/shh/Development/holoviz/repos/param/param/parameterized.py", line 2121, in deserialize_parameters
    return serializer.deserialize_parameters(self_or_cls, serialization, subset=subset)
  File "/home/shh/Development/holoviz/repos/param/param/serializer.py", line 113, in deserialize_parameters
    deserialized = pobj.param[name].deserialize(value)
  File "/home/shh/Development/holoviz/repos/param/param/__init__.py", line 1954, in deserialize
    return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
TypeError: strptime() argument 1 must be str, not None
```
