### PR TITLE
Add Python 3.11 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup_args = dict(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Add Python 3.11 classifier now Python 3.11 support has been added to Param.