### PR TITLE
CI: exclude linux - Python 3.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,10 @@ jobs:
       matrix:
         platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
+        exclude:
+          # Started failing with `Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.``
+          - os: ubuntu-latest
+            python-version: '3.6'
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Python 3.6 seems not to be able on Ubuntu 22.04