### PR TITLE
create initial project governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
-For the code of conduct, see [HoloViz/HoloViz - CODE_OF_CONDUCT.md](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/CODE_OF_CONDUCT.md).
+For the code of conduct, see [HoloViz/HoloViz - CODE_OF_CONDUCT.md](https://github.com/holoviz/holoviz/blob/param-gov/CODE_OF_CONDUCT.md).
 
 The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project adopts the [HoloViz.org code of conduct](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/CODE_OF_CONDUCT.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
 # Code of Conduct
 
-This project adopts the [HoloViz.org code of conduct](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/CODE_OF_CONDUCT.md).
+For the code of conduct, see [HoloViz/HoloViz - CODE_OF_CONDUCT.md](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/CODE_OF_CONDUCT.md).
+
+The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-docs/CONTRIBUTING.md
+++ b/doc/governance/project-docs/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
-For the contributing policy, see [HoloViz/HoloViz - CONTRIBUTING.md](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/doc/governance/project-docs/CONTRIBUTING.md).
+For the contributing policy, see [HoloViz/HoloViz - CONTRIBUTING.md](https://github.com/holoviz/holoviz/blob/param-gov/doc/governance/project-docs/CONTRIBUTING.md).
 
 The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-docs/CONTRIBUTING.md
+++ b/doc/governance/project-docs/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+For the contributing policy, see [HoloViz/HoloViz - CONTRIBUTING.md](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/doc/governance/project-docs/CONTRIBUTING.md).
+
+The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-docs/GOVERNANCE.md
+++ b/doc/governance/project-docs/GOVERNANCE.md
@@ -2,6 +2,6 @@
 
 The "Project" is herein defined as the activities related to this specific GitHub repository [`Param`](https://github.com/holoviz/param), within the `HoloViz` GitHub Organization.
 
-This Project adopts the governance specified by all of the numbered sections of [HoloViz/HoloViz - GOVERNANCE.md](https://github.com/holoviz/holoviz/blob/ffc1a609fb0ffa908ecb461538dfa78419bd081f/doc/governance/project-docs/GOVERNANCE.md).
+This Project adopts the governance specified by all of the numbered sections of [HoloViz/HoloViz - GOVERNANCE.md](https://github.com/holoviz/holoviz/blob/param-gov/doc/governance/project-docs/GOVERNANCE.md).
 
 The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-docs/GOVERNANCE.md
+++ b/doc/governance/project-docs/GOVERNANCE.md
@@ -1,0 +1,7 @@
+# Governance Policy
+
+The "Project" is herein defined as the activities related to this specific GitHub repository [`Param`](https://github.com/holoviz/param), within the `HoloViz` GitHub Organization.
+
+This Project adopts the governance specified by all of the numbered sections of [HoloViz/HoloViz - GOVERNANCE.md](https://github.com/holoviz/holoviz/blob/ffc1a609fb0ffa908ecb461538dfa78419bd081f/doc/governance/project-docs/GOVERNANCE.md).
+
+The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.

--- a/doc/governance/project-docs/LICENSE.md
+++ b/doc/governance/project-docs/LICENSE.md
@@ -1,0 +1,3 @@
+# License
+
+For the license, see [HoloViz/Param - LICENSE.txt](https://github.com/holoviz/param/blob/main/LICENSE.txt).

--- a/doc/governance/project-docs/MEMBERS.md
+++ b/doc/governance/project-docs/MEMBERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-For member policy, see [HoloViz/HoloViz - MEMBERS.md](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/doc/governance/project-docs/MEMBERS.md)
+For member policy, see the description at the top of [HoloViz/HoloViz - MEMBERS.md](https://github.com/holoviz/holoviz/blob/param-gov/doc/governance/project-docs/MEMBERS.md)
 
 The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.
 

--- a/doc/governance/project-docs/MEMBERS.md
+++ b/doc/governance/project-docs/MEMBERS.md
@@ -1,0 +1,11 @@
+# Maintainers
+
+For member policy, see [HoloViz/HoloViz - MEMBERS.md](https://github.com/holoviz/holoviz/blob/8257fe24af9d18598cee9f55055b78301307bd65/doc/governance/project-docs/MEMBERS.md)
+
+The Param Project’s equivalently named documents take precedence over any external materials referenced within this linked document above.
+
+| **NAME** | **Role** | **GitHub Handle** | **Affiliated Organization** |
+| --- | --- | --- | --- |
+| James Bednar | Project Director | [jbednar](https://github.com/jbednar) | |
+| Jean-Luc Stevens | Maintainer | [jlstevens](https://github.com/jlstevens) | |
+| Philipp Rudiger | Maintainer | [philippjfr](https://github.com/philippjfr) | |


### PR DESCRIPTION
The files in this pull request should act as examples of how other HoloViz projects could quickly adopt the default project docs using references to the project docs at holoviz/holoviz.

The maintainer list is based on the HoloViz Duties spreadsheet. All three maintainers should participate and/or approve.

I'll mention this at the next docs meeting, but I've written the [guidance to create project docs](https://docs.google.com/document/d/1DSPq7oyR5VyV20g7Ez52tVAkwm12ilfMKZtZumFzAaI/edit?usp=sharing). I'll update this if there are any further changes to this PR.