### PR TITLE
Fix copying when having watchers on e.g. bounds on inherited Parameter types

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1117,7 +1117,7 @@ class Parameter(object):
                                  "it has been bound to a Parameterized.")
 
         implemented = (attribute != "default" and hasattr(self, 'watchers') and attribute in self.watchers)
-        slot_attribute = attribute in self.__slots__
+        slot_attribute = attribute in get_all_slots(type(self))
         try:
             old = getattr(self, attribute) if implemented else NotImplemented
             if slot_attribute:

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -512,6 +512,7 @@ class TestWatch(API1TestCase):
         obj = SimpleWatchExample()
 
         obj.param.watch(obj.method, ['a'])
+        obj.param.watch(lambda x: None, 'd', what='bounds')
 
         copied = copy.deepcopy(obj)
 


### PR DESCRIPTION
When exposing a parameter with Panel, it might be watched for changes in its `bounds`. Suppose you later want to make a `deepcopy` of this parameter. This will work fine if the parameter is a `Number`, but not if it is e.g. an `Integer`, per this example:
```python
import param
import copy


class A(param.Parameterized):
    n = param.Number(default=0)
    i = param.Integer(default=0)


obj_1 = A()
obj_1.param.watch(lambda x: x, 'n', 'bounds')
copy.deepcopy(obj_1)  # Works!

obj_2 = A()
obj_2.param.watch(lambda x: x, 'i', 'bounds')
copy.deepcopy(obj_2)  # Raises AttributeError!
```

As I see it, this issue is due to `Parameter.__setattr__` only checking for slot attributes in the class in question itself, and not its superclasses:
https://github.com/holoviz/param/blob/10fff770a50235deab4afad8641a667c7540eece/param/parameterized.py#L1120

In the case of `Integer`, the `bounds` attribute is part of `__slots__` in `Number`, but not in `Integer`, later resulting in the error above.

## Proposed solution
Use `get_all_slots` to traverse up the class hierarchy and see if the attribute is part of any superclass' `__slots__`.

This is the shortest fix I could think of, but should this rather be handled by calling the superclasses' `__setattr__` a few rows down? https://github.com/holoviz/param/blob/10fff770a50235deab4afad8641a667c7540eece/param/parameterized.py#L1133 
I know too little about the nuances of Param to tell. However, the approach does not seem to break any tests.

I would love to have this solved, so please chime in on how we can do it the best way possible 😃