### PR TITLE
Add tests to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include setup.py
 include param/.version
 recursive-include param *.py
 recursive-include numbergen *.py
+recursive-include tests *.md *.py


### PR DESCRIPTION
Fixes #678.

This PR adds the `tests` directory to the `sdist` so that those who build the library from the `sdist` rather than github repo have access to the tests. This includes Linux distribution packagers.

Contents of `sdist` are now:
```
$ tar tf param-1.12.3.post6+g00d89ba.tar.gz
param-1.12.3.post6+g00d89ba/
param-1.12.3.post6+g00d89ba/LICENSE.txt
param-1.12.3.post6+g00d89ba/MANIFEST.in
param-1.12.3.post6+g00d89ba/PKG-INFO
param-1.12.3.post6+g00d89ba/README.md
param-1.12.3.post6+g00d89ba/numbergen/
param-1.12.3.post6+g00d89ba/numbergen/__init__.py
param-1.12.3.post6+g00d89ba/param/
param-1.12.3.post6+g00d89ba/param/.version
param-1.12.3.post6+g00d89ba/param/__init__.py
param-1.12.3.post6+g00d89ba/param/_async.py
param-1.12.3.post6+g00d89ba/param/ipython.py
param-1.12.3.post6+g00d89ba/param/parameterized.py
param-1.12.3.post6+g00d89ba/param/serializer.py
param-1.12.3.post6+g00d89ba/param/version.py
param-1.12.3.post6+g00d89ba/param.egg-info/
param-1.12.3.post6+g00d89ba/param.egg-info/PKG-INFO
param-1.12.3.post6+g00d89ba/param.egg-info/SOURCES.txt
param-1.12.3.post6+g00d89ba/param.egg-info/dependency_links.txt
param-1.12.3.post6+g00d89ba/param.egg-info/requires.txt
param-1.12.3.post6+g00d89ba/param.egg-info/top_level.txt
param-1.12.3.post6+g00d89ba/setup.cfg
param-1.12.3.post6+g00d89ba/setup.py
param-1.12.3.post6+g00d89ba/tests/
param-1.12.3.post6+g00d89ba/tests/API0/
param-1.12.3.post6+g00d89ba/tests/API0/__init__.py
param-1.12.3.post6+g00d89ba/tests/API0/testcalendardateparam.py
param-1.12.3.post6+g00d89ba/tests/API0/testcalendardaterangeparam.py
param-1.12.3.post6+g00d89ba/tests/API0/testclassselector.py
param-1.12.3.post6+g00d89ba/tests/API0/testcolorparameter.py
param-1.12.3.post6+g00d89ba/tests/API0/testcompositeparams.py
param-1.12.3.post6+g00d89ba/tests/API0/testdateparam.py
param-1.12.3.post6+g00d89ba/tests/API0/testdaterangeparam.py
param-1.12.3.post6+g00d89ba/tests/API0/testdefaults.py
param-1.12.3.post6+g00d89ba/tests/API0/testdynamicparams.py
param-1.12.3.post6+g00d89ba/tests/API0/testipythonmagic.py
param-1.12.3.post6+g00d89ba/tests/API0/testlistselector.py
param-1.12.3.post6+g00d89ba/tests/API0/testnumbergen.py
param-1.12.3.post6+g00d89ba/tests/API0/testnumpy.py
param-1.12.3.post6+g00d89ba/tests/API0/testobjectselector.py
param-1.12.3.post6+g00d89ba/tests/API0/testparameterizedobject.py
param-1.12.3.post6+g00d89ba/tests/API0/testparameterizedrepr.py
param-1.12.3.post6+g00d89ba/tests/API0/testrangeparameter.py
param-1.12.3.post6+g00d89ba/tests/API0/teststringparam.py
param-1.12.3.post6+g00d89ba/tests/API0/testtimedependent.py
param-1.12.3.post6+g00d89ba/tests/API1/
param-1.12.3.post6+g00d89ba/tests/API1/__init__.py
param-1.12.3.post6+g00d89ba/tests/API1/testbytesparam.py
param-1.12.3.post6+g00d89ba/tests/API1/testcalendardateparam.py
param-1.12.3.post6+g00d89ba/tests/API1/testcalendardaterangeparam.py
param-1.12.3.post6+g00d89ba/tests/API1/testclassselector.py
param-1.12.3.post6+g00d89ba/tests/API1/testcolorparameter.py
param-1.12.3.post6+g00d89ba/tests/API1/testcomparator.py
param-1.12.3.post6+g00d89ba/tests/API1/testcompositeparams.py
param-1.12.3.post6+g00d89ba/tests/API1/testdateparam.py
param-1.12.3.post6+g00d89ba/tests/API1/testdaterangeparam.py
param-1.12.3.post6+g00d89ba/tests/API1/testdefaults.py
param-1.12.3.post6+g00d89ba/tests/API1/testdynamicparams.py
param-1.12.3.post6+g00d89ba/tests/API1/testipythonmagic.py
param-1.12.3.post6+g00d89ba/tests/API1/testjsonserialization.py
param-1.12.3.post6+g00d89ba/tests/API1/testlist.py
param-1.12.3.post6+g00d89ba/tests/API1/testlistselector.py
param-1.12.3.post6+g00d89ba/tests/API1/testnumbergen.py
param-1.12.3.post6+g00d89ba/tests/API1/testnumberparameter.py
param-1.12.3.post6+g00d89ba/tests/API1/testnumpy.py
param-1.12.3.post6+g00d89ba/tests/API1/testobjectselector.py
param-1.12.3.post6+g00d89ba/tests/API1/testpandas.py
param-1.12.3.post6+g00d89ba/tests/API1/testparamdepends.py
param-1.12.3.post6+g00d89ba/tests/API1/testparamdepends_py3.py
param-1.12.3.post6+g00d89ba/tests/API1/testparameterizedobject.py
param-1.12.3.post6+g00d89ba/tests/API1/testparameterizedrepr.py
param-1.12.3.post6+g00d89ba/tests/API1/testparamoutput.py
param-1.12.3.post6+g00d89ba/tests/API1/testparamunion.py
param-1.12.3.post6+g00d89ba/tests/API1/testrangeparameter.py
param-1.12.3.post6+g00d89ba/tests/API1/testselector.py
param-1.12.3.post6+g00d89ba/tests/API1/teststringparam.py
param-1.12.3.post6+g00d89ba/tests/API1/testtimedependent.py
param-1.12.3.post6+g00d89ba/tests/API1/testutils.py
param-1.12.3.post6+g00d89ba/tests/API1/testwatch.py
param-1.12.3.post6+g00d89ba/tests/API1/utils.py
param-1.12.3.post6+g00d89ba/tests/README.md
param-1.12.3.post6+g00d89ba/tests/__init__.py
```

I have not added the `docs` directory to the `sdist`; there is an argument for doing so alongside this.