### PR TITLE
Fetch tags before running tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,8 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        # python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
-        python-version: ['3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
         exclude:
           # Started failing with `Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.``
           - platform: ubuntu-latest
@@ -31,8 +30,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - run: git fetch --prune --tags --unshallow
-        shell: bash -el {0}
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow -f
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -41,13 +40,6 @@ jobs:
         run: |
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install "tox<4" tox-gh-actions
-          # python -m pip install -e .
-      - name: test available
-        run: |
-          which git
-          git status
-          git tag --list
-          python -c "import param; print(repr(param.__version__))"
       - name: lint
         run: tox -e flakes
       - name: unit
@@ -70,48 +62,48 @@ jobs:
         run: tox -e with_all
       - uses: codecov/codecov-action@v3
         if: github.event_name == 'push'
-  # test_suite27:
-  #   name: Tox on ${{ matrix.python-version }}, ${{ matrix.platform }}
-  #   runs-on: ${{ matrix.platform }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-  #       python-version: ['2.7']
-  #   timeout-minutes: 30
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: "100"
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: env setup
-  #       run: |
-  #         python -m pip install --upgrade setuptools pip wheel
-  #         python -m pip install "tox<4" tox-gh-actions
-  #     - name: lint
-  #       run: tox -e flakes
-  #     - name: unit
-  #       run: tox -c tox27.ini
-  #     - name: unit with_ipython
-  #       run: tox -c tox27.ini -e with_ipython
-  #     - name: unit with_numpy
-  #       if: (!startsWith(matrix.python-version, 'py'))
-  #       run: tox -c tox27.ini -e with_numpy
-  #     - name: unit with_pandas
-  #       if: (!startsWith(matrix.python-version, 'py'))
-  #       run: tox  -c tox27.ini -e with_pandas
-  #     - name: unit with_jsonschema
-  #       run: tox -c tox27.ini -e with_jsonschema
-  #     - name: unit with_gmpy
-  #       if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
-  #       run: tox -c tox27.ini -e with_gmpy
-  #     - name: unit all_deps
-  #       if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
-  #       run: tox -c tox27.ini -e with_all
-  #     - uses: codecov/codecov-action@v3
-  #       if: github.event_name == 'push'
+  test_suite27:
+    name: Tox on ${{ matrix.python-version }}, ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        python-version: ['2.7']
+    timeout-minutes: 30
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "100"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: env setup
+        run: |
+          python -m pip install --upgrade setuptools pip wheel
+          python -m pip install "tox<4" tox-gh-actions
+      - name: lint
+        run: tox -e flakes
+      - name: unit
+        run: tox -c tox27.ini
+      - name: unit with_ipython
+        run: tox -c tox27.ini -e with_ipython
+      - name: unit with_numpy
+        if: (!startsWith(matrix.python-version, 'py'))
+        run: tox -c tox27.ini -e with_numpy
+      - name: unit with_pandas
+        if: (!startsWith(matrix.python-version, 'py'))
+        run: tox  -c tox27.ini -e with_pandas
+      - name: unit with_jsonschema
+        run: tox -c tox27.ini -e with_jsonschema
+      - name: unit with_gmpy
+        if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
+        run: tox -c tox27.ini -e with_gmpy
+      - name: unit all_deps
+        if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
+        run: tox -c tox27.ini -e with_all
+      - uses: codecov/codecov-action@v3
+        if: github.event_name == 'push'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
+        # python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
+        python-version: ['3.10']
         exclude:
           # Started failing with `Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.``
           - platform: ubuntu-latest
@@ -38,6 +39,10 @@ jobs:
         run: |
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install "tox<4" tox-gh-actions
+      - name: test available
+        run: |
+          which git
+          python -c "import param; print(repr(param.__version__))"
       - name: lint
         run: tox -e flakes
       - name: unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: env setup
         run: |
-          python -m pip install --upgrade "setuptools<66" pip wheel
+          python -m pip install --upgrade setuptools pip wheel
           python -m pip install "tox<4" tox-gh-actions
       - name: lint
         run: tox -e flakes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
+      - run: git fetch --prune --tags --unshallow
+        shell: bash -el {0}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,10 +39,12 @@ jobs:
         run: |
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install "tox<4" tox-gh-actions
-          python -m pip install -e .
+          # python -m pip install -e .
       - name: test available
         run: |
           which git
+          git status
+          git tag --list
           python -c "import param; print(repr(param.__version__))"
       - name: lint
         run: tox -e flakes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
         run: |
           python -m pip install --upgrade setuptools pip wheel
           python -m pip install "tox<4" tox-gh-actions
+          python -m pip install -e .
       - name: test available
         run: |
           which git
@@ -65,48 +66,48 @@ jobs:
         run: tox -e with_all
       - uses: codecov/codecov-action@v3
         if: github.event_name == 'push'
-  test_suite27:
-    name: Tox on ${{ matrix.python-version }}, ${{ matrix.platform }}
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ['2.7']
-    timeout-minutes: 30
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: "100"
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: env setup
-        run: |
-          python -m pip install --upgrade setuptools pip wheel
-          python -m pip install "tox<4" tox-gh-actions
-      - name: lint
-        run: tox -e flakes
-      - name: unit
-        run: tox -c tox27.ini
-      - name: unit with_ipython
-        run: tox -c tox27.ini -e with_ipython
-      - name: unit with_numpy
-        if: (!startsWith(matrix.python-version, 'py'))
-        run: tox -c tox27.ini -e with_numpy
-      - name: unit with_pandas
-        if: (!startsWith(matrix.python-version, 'py'))
-        run: tox  -c tox27.ini -e with_pandas
-      - name: unit with_jsonschema
-        run: tox -c tox27.ini -e with_jsonschema
-      - name: unit with_gmpy
-        if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
-        run: tox -c tox27.ini -e with_gmpy
-      - name: unit all_deps
-        if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
-        run: tox -c tox27.ini -e with_all
-      - uses: codecov/codecov-action@v3
-        if: github.event_name == 'push'
+  # test_suite27:
+  #   name: Tox on ${{ matrix.python-version }}, ${{ matrix.platform }}
+  #   runs-on: ${{ matrix.platform }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+  #       python-version: ['2.7']
+  #   timeout-minutes: 30
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: "100"
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: env setup
+  #       run: |
+  #         python -m pip install --upgrade setuptools pip wheel
+  #         python -m pip install "tox<4" tox-gh-actions
+  #     - name: lint
+  #       run: tox -e flakes
+  #     - name: unit
+  #       run: tox -c tox27.ini
+  #     - name: unit with_ipython
+  #       run: tox -c tox27.ini -e with_ipython
+  #     - name: unit with_numpy
+  #       if: (!startsWith(matrix.python-version, 'py'))
+  #       run: tox -c tox27.ini -e with_numpy
+  #     - name: unit with_pandas
+  #       if: (!startsWith(matrix.python-version, 'py'))
+  #       run: tox  -c tox27.ini -e with_pandas
+  #     - name: unit with_jsonschema
+  #       run: tox -c tox27.ini -e with_jsonschema
+  #     - name: unit with_gmpy
+  #       if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
+  #       run: tox -c tox27.ini -e with_gmpy
+  #     - name: unit all_deps
+  #       if: contains(matrix.platform, 'ubuntu') && !startsWith(matrix.python-version, 'py')
+  #       run: tox -c tox27.ini -e with_all
+  #     - uses: codecov/codecov-action@v3
+  #       if: github.event_name == 'push'

--- a/param/version.py
+++ b/param/version.py
@@ -194,6 +194,7 @@ class Version(object):
                 output = run_cmd([cmd, 'describe', '--long', '--match',
                                   "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
                                  cwd=os.path.dirname(self.fpath))
+                print(output)
             if as_string: return output
         except Exception as e1:
             try:

--- a/param/version.py
+++ b/param/version.py
@@ -194,7 +194,6 @@ class Version(object):
                 output = run_cmd([cmd, 'describe', '--long', '--match',
                                   "v[0-9]*.[0-9]*.[0-9]*", '--dirty'],
                                  cwd=os.path.dirname(self.fpath))
-                print(output)
             if as_string: return output
         except Exception as e1:
             try:


### PR DESCRIPTION
The test suite did not fetch the tags before the test and would therefore have a version of `"None"`.

With the latest release of `setuptools`, `"None"` was no longer a valid version tag, which was why the tests were failing. 