### PR TITLE
Raise an error when setting `None` to a base Parameter with `allow_None=False`

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1255,6 +1255,8 @@ class Parameter(object):
 
     def _validate_value(self, value, allow_None):
         """Implements validation for parameter value"""
+        if value is None and allow_None is False:
+            raise ValueError("Parameter %r does not accept `None`." % (self.name))
 
     def _validate(self, val):
         """Implements validation for the parameter value and attributes"""

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -396,7 +396,7 @@ class TestPO1(param.Parameterized):
 class TestParameter(API1TestCase):
 
     def setUp(self):
-        super().setUp()
+        super(TestParameter, self).setUp()
 
         class TestParameter(param.Parameterized):
             a = param.Parameter(default='')

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -398,12 +398,12 @@ class TestParameter(API1TestCase):
     def setUp(self):
         super(TestParameter, self).setUp()
 
-        class TestParameter(param.Parameterized):
+        class _TestParameter(param.Parameterized):
             a = param.Parameter(default='')
             b = param.Parameter(default='',allow_None=True)
             c = param.Parameter(default=None)
 
-        self._TestParameter = TestParameter
+        self._TestParameter = _TestParameter
 
     def test_handling_of_None(self):
         t = self._TestParameter()

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -392,6 +392,30 @@ class TestPO1(param.Parameterized):
     x = param.Number(default=numbergen.UniformRandom(lbound=-1,ubound=1,seed=1),bounds=(-1,1))
     y = param.Number(default=1,bounds=(-1,1))
 
+
+class TestParameter(API1TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class TestParameter(param.Parameterized):
+            a = param.Parameter(default='')
+            b = param.Parameter(default='',allow_None=True)
+            c = param.Parameter(default=None)
+
+        self._TestParameter = TestParameter
+
+    def test_handling_of_None(self):
+        t = self._TestParameter()
+
+        with self.assertRaises(ValueError):
+            t.a = None
+
+        t.b = None
+
+        assert t.c is None
+
+
 class TestNumberParameter(API1TestCase):
 
     def test_outside_bounds(self):


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/689