### PR TITLE
Fix the coverage report uploaded to codecov

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
     # (https://github.com/pypa/pip/issues/1197)
     'tests': [
         'pytest',
-        'pytest-cov',
+        'coverage',
         'flake8',
     ],
     'doc': [

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,9 @@ python =
 description = run test suite under {basepython}
 deps = .[tests]
 commands =
-    pytest tests --cov=numbergen --cov=param --cov-append --cov-report xml
+    coverage run --source=numbergen,param -m pytest tests
+    coverage report
+    coverage xml
 
 [testenv:with_numpy]
 description = run test suite with numpy under {basepython}

--- a/tox27.ini
+++ b/tox27.ini
@@ -10,7 +10,9 @@ python =
 description = run test suite under {basepython}
 deps = .[tests]
 commands =
-    pytest tests --ignore tests/API1/testparamdepends_py3.py --cov=numbergen --cov=param --cov-append --cov-report xml
+    coverage run --source=numbergen,param -m pytest tests --ignore tests/API1/testparamdepends_py3.py
+    coverage report
+    coverage xml
 
 [testenv:with_numpy]
 description = run test suite with numpy under {basepython}

--- a/tox27.ini
+++ b/tox27.ini
@@ -11,8 +11,8 @@ description = run test suite under {basepython}
 deps = .[tests]
 commands =
     coverage run --source=numbergen,param -m pytest tests --ignore tests/API1/testparamdepends_py3.py
-    coverage report
-    coverage xml
+    coverage report --omit param/_async.py
+    coverage xml --omit param/_async.py
 
 [testenv:with_numpy]
 description = run test suite with numpy under {basepython}


### PR DESCRIPTION
Found out that because of a bug or user error the XML report produced by `pytest-cov` included the report of only one `__init__.py` file instead of two, coming from Param and Numbergen. It happened to report the one of Numbergen only. This PR runs `coverage` directly which when it builds the XML coverage report does so in a nested way, including the two `__init__.py` files.