### PR TITLE
Add more tests

### DIFF
--- a/tests/API1/testlist.py
+++ b/tests/API1/testlist.py
@@ -158,3 +158,113 @@ class TestHookListParameters(API1TestCase):
             pass
         else:
             raise AssertionError("Object set outside range.")
+
+    def test_inheritance_behavior1(self):
+        class A(param.Parameterized):
+            p = param.List()
+
+        class B(A):
+            p = param.List()
+
+        assert B.param.p.default == []
+        assert B.param.p.instantiate is True
+        assert B.param.p.bounds == (0, None)
+
+        b = B()
+
+        assert b.param.p.default == []
+        assert b.param.p.instantiate is True
+        assert b.param.p.bounds == (0, None)
+
+    def test_inheritance_behavior2(self):
+        class A(param.Parameterized):
+            p = param.List(default=[0, 1])
+
+        class B(A):
+            p = param.List()
+
+        # B does not inherit default from A
+        assert B.param.p.default == []
+        assert B.param.p.instantiate is True
+        assert B.param.p.bounds == (0, None)
+
+        b = B()
+
+        assert b.param.p.default == []
+        assert b.param.p.instantiate is True
+        assert b.param.p.bounds == (0, None)
+
+    def test_inheritance_behavior3(self):
+        class A(param.Parameterized):
+            p = param.List(default=[0, 1], bounds=(1, 10))
+
+        class B(A):
+            p = param.List()
+
+        # B does not inherit default and bounds from A
+        assert B.param.p.default == []
+        assert B.param.p.instantiate is True
+        assert B.param.p.bounds == (0, None)
+
+        b = B()
+
+        assert b.param.p.default == []
+        assert b.param.p.instantiate is True
+        assert b.param.p.bounds == (0, None)
+
+    def test_inheritance_behavior4(self):
+        class A(param.Parameterized):
+            p = param.List(default=[0], item_type=int)
+
+        class B(A):
+            p = param.List()
+
+        # B inherit item_type
+        assert B.param.p.default == []
+        assert B.param.p.instantiate is True
+        assert B.param.p.bounds == (0, None)
+        assert B.param.p.item_type == int
+
+        b = B()
+
+        assert b.param.p.default == []
+        assert b.param.p.instantiate is True
+        assert b.param.p.bounds == (0, None)
+        assert b.param.p.item_type == int
+
+    def test_inheritance_behavior5(self):
+        class A(param.Parameterized):
+            p = param.List(default=[0, 1], allow_None=True)
+
+        class B(A):
+            p = param.List()
+
+        # B does not inherit allow_None
+        assert B.param.p.default == []
+        assert B.param.p.allow_None is False
+        assert B.param.p.instantiate is True
+        assert B.param.p.bounds == (0, None)
+
+        b = B()
+
+        assert b.param.p.default == []
+        assert b.param.p.allow_None is False
+        assert b.param.p.instantiate is True
+        assert b.param.p.bounds == (0, None)
+
+    def test_inheritance_behavior6(self):
+        class A(param.Parameterized):
+            p = param.List(default=[0, 1], bounds=(1, 10))
+
+        class B(A):
+            p = param.List(default=[0, 1, 2, 3])
+
+        assert B.param.p.default == [0, 1, 2, 3]
+        assert B.param.p.instantiate is True
+        assert B.param.p.bounds == (0, None)
+
+        b = B()
+
+        assert b.param.p.default == [0, 1, 2, 3]
+        assert b.param.p.instantiate is True
+        assert b.param.p.bounds == (0, None)

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -501,7 +501,6 @@ class TestSharedParameters(API1TestCase):
         self.assertTrue(self.p1.param.params('inst').default is not self.p2.inst)
 
 
-@pytest.mark.xfail
 def test_inheritance_None_is_not_special_cased_default():
 
     class A(param.Parameterized):
@@ -512,10 +511,9 @@ def test_inheritance_None_is_not_special_cased_default():
 
     b = B()
 
-    assert b.p is None
+    assert b.p == 'test'
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize('attribute', [
     'default',
     'doc',
@@ -545,10 +543,9 @@ def test_inheritance_None_is_not_special_cased(attribute):
 
     b = B()
 
-    assert getattr(b.param.p, attribute) is None
+    assert getattr(b.param.p, attribute) == 'test'
 
 
-@pytest.mark.xfail
 def test_inheritance_no_default_declared_in_subclass():
     default = 5.0
     class A(param.Parameterized):
@@ -558,7 +555,7 @@ def test_inheritance_no_default_declared_in_subclass():
         p = param.Number()
 
     b = B()
-    assert b.p == default
+    assert b.p == 0.0
 
 
 def test_inheritance_attribute_from_non_subclass_not_inherited():

--- a/tests/API1/testselector.py
+++ b/tests/API1/testselector.py
@@ -60,6 +60,34 @@ class TestSelectorParameters(API1TestCase):
         check_defaults(s, label=None)
         self._check_defaults(s)
 
+    def test_unbound_default_inferred(self):
+        s = param.Selector(objects=[0, 1, 2])
+
+        assert s.default == 0
+
+    def test_unbound_default_explicit(self):
+        s = param.Selector(default=1, objects=[0, 1, 2])
+
+        assert s.default == 1
+
+    def test_unbound_default_check_on_set_inferred(self):
+        s1 = param.Selector(objects=[0, 1, 2])
+        s2 = param.Selector(objects=[])
+        s3 = param.Selector(objects={})
+        s4 = param.Selector()
+
+        assert s1.check_on_set is True
+        assert s2.check_on_set is False
+        assert s3.check_on_set is False
+        assert s4.check_on_set is False
+
+    def test_unbound_default_check_on_set_explicit(self):
+        s1 = param.Selector(check_on_set=True)
+        s2 = param.Selector(check_on_set=False)
+
+        assert s1.check_on_set is True
+        assert s2.check_on_set is False
+
     def test_set_object_constructor(self):
         p = self.P(e=6)
         self.assertEqual(p.e, 6)
@@ -294,4 +322,21 @@ class TestSelectorParameters(API1TestCase):
 
         assert b.param.p.objects == []
         assert b.param.p.default == 0
+        assert b.param.p.check_on_set is False
+
+    def test_inheritance_behavior6(self):
+        class A(param.Parameterized):
+            p = param.Selector(default=0, objects=[0, 1])
+
+        class B(A):
+            p = param.Selector(default=1)
+
+        assert B.param.p.objects == []
+        assert B.param.p.default == 1
+        assert B.param.p.check_on_set is False
+
+        b = B()
+
+        assert b.param.p.objects == []
+        assert b.param.p.default == 1
         assert b.param.p.check_on_set is False

--- a/tests/API1/testtupleparam.py
+++ b/tests/API1/testtupleparam.py
@@ -49,6 +49,16 @@ class TestTupleParameters(API1TestCase):
         check_defaults(t, label=None)
         self._check_defaults(t)
 
+    def test_unbound_length_inferred(self):
+        t = param.Tuple((0, 1, 2))
+
+        assert t.length == 3
+
+    def test_unbound_length_set(self):
+        t = param.Tuple(default=None, length=3)
+
+        assert t.length == 3
+
     def test_set_object_constructor(self):
         p = self.P(e=(2, 2))
         self.assertEqual(p.e, (2, 2))


### PR DESCRIPTION
Another one in the series of adding more tests:
- In a previous PR I added a few tests marked with `xfail`, anticipating new behavior obtained with the sentinel PR. Instead in this PR I have inverted them, they all pass now on the *main* branch, which means that the sentinel PR will have to update them, making it easier for reviewers to understand the changed behavior
- Add more tests on metadata inheritance. They are really there to capture the current behavior and catch changes that may happen in future PRs.
