### PR TITLE
Validate type of param.Boolean default value

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -998,7 +998,14 @@ class Boolean(Parameter):
     # no effect since values are either False, True, or None (if allowed).
     def __init__(self, default=False, bounds=(0,1), **params):
         self.bounds = bounds
+        self._validate_default(default)
         super(Boolean, self).__init__(default=default, **params)
+
+    def _validate_default(self, default):
+        if not isinstance(default, bool) and default is not None:
+            raise ValueError("Boolean parameter only takes a "
+                             "Boolean default or None, not %s."
+                             % default)
 
     def _validate_value(self, val, allow_None):
         if allow_None:

--- a/tests/API1/testbooleanparam.py
+++ b/tests/API1/testbooleanparam.py
@@ -79,6 +79,12 @@ class TestBooleanParameters(API1TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = 'test'
 
+    def test_bad_default_type(self):
+        msg = r"Boolean parameter only takes a Boolean default or None, not test"
+
+        with self.assertRaisesRegex(ValueError, msg):
+            param.Boolean(default='test')
+
 
 class TestEventParameters(API1TestCase):
 


### PR DESCRIPTION
I've had a go at adding validation for the default for `param.Boolean` (see https://github.com/holoviz/param/issues/700). I was not sure whether the validation should occur before or after the `super` call, let me know if after that make more sense.