### PR TITLE
Don't hard-code allow_None to True in Array

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1518,7 +1518,7 @@ class Array(ClassSelector):
 
     def __init__(self, default=None, **params):
         from numpy import ndarray
-        super(Array, self).__init__(ndarray, allow_None=True, default=default, **params)
+        super(Array, self).__init__(ndarray, default=default, **params)
 
     @classmethod
     def serialize(cls, value):


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/583

This is effectively a breaking change. The code below used to work fine, while after this change `p.a = None` will raise an error.

```python
import param, numpy as np

class P(param.Parameterized):
    a = param.Array(np.zeros((2, 2)))

p = P()

p.a = None
```
