### PR TITLE
Don't set class attributes during initialization and don't warn when setting non-Param class attributes

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1636,7 +1636,10 @@ class Parameters(object):
         for name, val in params.items():
             desc = self.__class__.get_param_descriptor(name)[0] # pylint: disable-msg=E1101
             if not desc:
-                self.param.warning("Setting non-parameter attribute %s=%s using a mechanism intended only for parameters", name, val)
+                raise TypeError(
+                    f"{self.__class__.__name__} has no Parameter '{name}'; "
+                    f"cannot set '{name}' in the constructor"
+                )
             # i.e. if not desc it's setting an attribute in __dict__, not a Parameter
             setattr(self, name, val)
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2787,26 +2787,6 @@ class ParameterizedMetaclass(type):
 
             if isinstance(value,Parameter):
                 mcs.__param_inheritance(attribute_name,value)
-            elif isinstance(value,Parameters):
-                pass
-            else:
-                # the purpose of the warning below is to catch
-                # mistakes ("thinking you are setting a parameter, but
-                # you're not"). There are legitimate times when
-                # something needs be set on the class, and we don't
-                # want to see a warning then. Such attributes should
-                # presumably be prefixed by at least one underscore.
-                # (For instance, python's own pickling mechanism
-                # caches __slotnames__ on the class:
-                # http://mail.python.org/pipermail/python-checkins/2003-February/033517.html.)
-                # This warning bypasses the usual mechanisms, which
-                # has have consequences for warning counts, warnings
-                # as exceptions, etc.
-                if not attribute_name.startswith('_'):
-                    get_logger().log(WARNING,
-                                     "Setting non-Parameter class attribute %s.%s = %s ",
-                                     mcs.__name__,attribute_name,repr(value))
-
 
     def __param_inheritance(mcs,param_name,param):
         """

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -14,6 +14,7 @@ import pytest
 
 import random
 
+from param import parameterized
 from param.parameterized import ParamOverrides, shared_parameters
 from param.parameterized import default_label_formatter, no_instance_params
 
@@ -342,8 +343,11 @@ class TestParameterized(API1TestCase):
         assert t.param.params('ro_format').label == 'Foo'
         param.parameterized.label_formatter = default_label_formatter
 
+    def test_error_if_non_param_in_constructor(self):
+        msg = "TestPO has no Parameter 'not_a_param'; cannot set 'not_a_param' in the constructor"
+        with pytest.raises(TypeError, match=msg):
+            TestPO(not_a_param=2)
 
-from param import parameterized
 
 class some_fn(param.ParameterizedFunction):
     __test__ = False
@@ -462,7 +466,7 @@ class TestParamOverrides(API1TestCase):
 
     def setUp(self):
         super(TestParamOverrides, self).setUp()
-        self.po = param.Parameterized(name='A',print_level=0)
+        self.po = param.Parameterized(name='A')
 
     def test_init_name(self):
         self.assertEqual(self.po.name, 'A')
@@ -470,7 +474,6 @@ class TestParamOverrides(API1TestCase):
     def test_simple_override(self):
         overrides = ParamOverrides(self.po,{'name':'B'})
         self.assertEqual(overrides['name'], 'B')
-        self.assertEqual(overrides['print_level'], 0)
 
     # CEBALERT: missing test for allow_extra_keywords (e.g. getting a
     # warning on attempting to override non-existent parameter when
@@ -487,10 +490,10 @@ class TestSharedParameters(API1TestCase):
     def setUp(self):
         super(TestSharedParameters, self).setUp()
         with shared_parameters():
-            self.p1 = TestPO(name='A', print_level=0)
-            self.p2 = TestPO(name='B', print_level=0)
-            self.ap1 = AnotherTestPO(name='A', print_level=0)
-            self.ap2 = AnotherTestPO(name='B', print_level=0)
+            self.p1 = TestPO(name='A')
+            self.p2 = TestPO(name='B')
+            self.ap1 = AnotherTestPO(name='A')
+            self.ap2 = AnotherTestPO(name='B')
 
     def test_shared_object(self):
         self.assertTrue(self.ap1.instPO is self.ap2.instPO)


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/174

- Setting a non-Parameter class attribute no longer raises a warning
- Setting a non-Parameter in the constructor raises a `TypeError` (breaking change)

<img width="951" alt="image" src="https://user-images.githubusercontent.com/35924738/230140055-c73deb57-3668-4992-ba28-16912f8ca3da.png">

