### PR TITLE
CI: reduce the number of Python versions to test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
+        python-version: ${{ ( github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.ref_type == 'tag' ) ) && fromJSON('["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.9"]') || fromJSON('["3.7", "3.9", "3.11"]') }}
     timeout-minutes: 30
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '0 13 * * SUN'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_suite:
     name: Tox on ${{ matrix.python-version }}, ${{ matrix.platform }}


### PR DESCRIPTION
The CI is pretty slow because:
- the PyPy tests are slow
- it often needs to wait until some MacOS workers are available

This PR reduces the Python version tested to CPython 3.7, 3.9 and 3.11 on the three platforms.

The full matrix is tested on workflow_dispatch, schedule and push+tag events. I bumped the version of PyPy tested from 3.7 to 3.9.