### PR TITLE
Allow type change for DateRange

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2396,6 +2396,19 @@ class DateRange(Range):
     Bounds must be specified as datetime or date types (see param.dt_types).
     """
 
+    @staticmethod
+    def _to_datetime(x):
+        # Can't compare datetime.datetime to datetime.date
+        if isinstance(x, dt.date) and not isinstance(x, dt.datetime):
+            return dt.datetime(*x.timetuple()[:6])
+        return x
+
+    def _validate_bounds(self, val, bounds, inclusive_bounds):
+        val = None if val is None else map(self._to_datetime, val)
+        bounds = None if bounds is None else map(self._to_datetime, bounds)
+        super()._validate_bounds(val, bounds, inclusive_bounds)
+
+
     def _validate_value(self, val, allow_None):
         # Cannot use super()._validate_value as DateRange inherits from
         # NumericTuple which check that the tuple values are numbers and

--- a/tests/testdaterangeparam.py
+++ b/tests/testdaterangeparam.py
@@ -133,6 +133,18 @@ class TestDateRange(unittest.TestCase):
         ):
             q.a = self.bad_range
 
+    def test_change_value_type(self):
+        class DateSlider(param.Parameterized):
+            date = param.DateRange(
+                default=(dt.date(2021, 1, 1), dt.date(2024, 1, 1)),
+                bounds=(dt.date(2020, 1, 1), dt.date(2025, 1, 1)),
+            )
+
+        ds = DateSlider()
+
+        # Change the value from date to datetime without erroring
+        ds.date = (dt.datetime(2022, 1, 1), dt.datetime(2023, 1, 1))
+
     @pytest.mark.skipif(np is None, reason='NumPy is not available')
     def test_numpy_default(self):
         class Q(param.Parameterized):


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/4566

This adds support for having both `datetime.date` and `datetime.datetime` values in `param.DateRange`.   