### PR TITLE
Overriding the `name` Parameter is taken into account at the class and instance level

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2894,14 +2894,15 @@ class ParameterizedMetaclass(type):
             setattr(param,'objtype',mcs)
             del slots['objtype']
 
+        supers = classlist(mcs)[::-1]
+
         # instantiate is handled specially
-        for superclass in classlist(mcs)[::-1]:
+        for superclass in supers:
             super_param = superclass.__dict__.get(param_name)
             if isinstance(super_param, Parameter) and super_param.instantiate is True:
                 param.instantiate=True
         del slots['instantiate']
 
-        supers = classlist(mcs)[::-1]
         callables = {}
         for slot in slots.keys():
             superclasses = iter(supers)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2735,7 +2735,7 @@ class ParameterizedMetaclass(type):
 
     def __set_name(mcs, name, dict_):
         """
-        # Give Parameterized classes a useful 'name' attribute that is by
+        Give Parameterized classes a useful 'name' attribute that is by
         default the class name, unless a class in the hierarchy has defined
         a `name` String Parameter with a defined `default` value, in which case
         that value is used to set the class name.

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2678,7 +2678,6 @@ class ParameterizedMetaclass(type):
         default values (see __param_inheritance()) and setting
         attrib_names (see _set_names()).
         """
-        # print('DEBUG', mcs, name, bases, dict_)
         type.__init__(mcs, name, bases, dict_)
 
         mcs.__set_name(name, dict_)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2737,7 +2737,7 @@ class ParameterizedMetaclass(type):
         """
         # Give Parameterized classes a useful 'name' attribute that is by
         default the class name, unless a class in the hierarchy has defined
-        a `name` Parameter with a defined `default` value, in which case
+        a `name` String Parameter with a defined `default` value, in which case
         that value is used to set the class name.
         """
         mcs.__renamed = False

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -118,6 +118,150 @@ class TestParameterized(unittest.TestCase):
         with pytest.raises(AttributeError):
             testpo.param.const.name = 'notconst'
 
+    def test_name_overriden(self):
+        class P(param.Parameterized):
+            name = param.String(default='other')
+        
+        assert P.name == 'other'
+
+        p = P()
+
+        assert p.name == 'other'
+
+    def test_name_overriden_without_default(self):
+        class A(param.Parameterized):
+            pass
+        class B(param.Parameterized):
+            name = param.String(doc='some help')
+        
+        class C(B):
+            pass
+        
+        assert B.name == 'B'
+        assert B.param.name.doc == 'some help'
+        assert C.name == 'C'
+        assert C.param.name.doc == 'some help'
+
+    def test_name_overriden_constructor(self):
+        class P(param.Parameterized):
+            name = param.String(default='other')
+        
+        p = P(name='another')
+
+        assert p.name == 'another'
+
+    def test_name_overriden_subclasses(self):
+        class P(param.Parameterized):
+            name = param.String(default='other')
+        
+        class Q(P):
+            pass
+
+        class R(Q):
+            name = param.String(default='yetanother')
+
+        assert Q.name == 'other'
+
+        q1 = Q()
+
+        assert q1.name == 'other'
+
+        q2 = Q(name='another')
+
+        assert q2.name == 'another'
+
+        assert R.name == 'yetanother'
+
+        r1 = R()
+
+        assert r1.name == 'yetanother'
+
+        r2 = R(name='last')
+
+        assert r2.name == 'last'
+
+
+    def test_name_overriden_subclasses_name_set(self):
+        class P(param.Parameterized):
+            name = param.String(default='other')
+        
+        class Q(P):
+            pass
+
+        P.name = 'another'
+
+        assert Q.name == 'another'
+
+        Q.name = 'yetanother'
+
+        assert Q.name == 'yetanother'
+
+        q = Q()
+
+        assert q.name == 'yetanother'
+
+    def test_name_overriden_error_not_String(self):
+
+        msg = "Parameterized class 'P' cannot override the 'name' Parameter " \
+              "with type <class 'str'>. Overriding 'name' is only allowed with " \
+              "a 'String' Parameter."
+
+        with pytest.raises(TypeError, match=msg):
+            class P(param.Parameterized):
+                name = 'other'
+
+        msg = "Parameterized class 'P' cannot override the 'name' Parameter " \
+              "with type <class 'param.parameterized.Parameter'>. Overriding 'name' " \
+              "is only allowed with a 'String' Parameter."
+
+        with pytest.raises(TypeError, match=msg):
+            class P(param.Parameterized):
+                name = param.Parameter(default='other')
+
+    def test_name_complex_hierarchy(self):
+        class Mixin1: pass
+        class Mixin2: pass
+        class Mixin3(param.Parameterized): pass
+        
+        class A(param.Parameterized, Mixin1): pass
+        class B(A): pass
+        class C(B, Mixin2): pass
+        class D(C, Mixin3): pass
+
+        assert A.name == 'A'
+        assert B.name == 'B'
+        assert C.name == 'C'
+        assert D.name == 'D'
+
+    def test_name_overriden_complex_hierarchy(self):
+        class Mixin1: pass
+        class Mixin2: pass
+        class Mixin3(param.Parameterized): pass
+        
+        class A(param.Parameterized, Mixin1): pass
+        class B(A):
+            name = param.String(default='other')
+
+        class C(B, Mixin2):
+            name = param.String(default='another')
+
+        class D(C, Mixin3): pass
+
+        assert A.name == 'A'
+        assert B.name == 'other'
+        assert C.name == 'another'
+        assert D.name == 'another'
+
+    def test_name_overriden_multiple(self):
+        class A(param.Parameterized):
+            name = param.String(default='AA')
+        class B(param.Parameterized):
+            name = param.String(default='BB')
+        
+        class C(A, B): pass
+
+        assert C.name == 'AA'
+
     def test_constant_parameter(self):
         """Test that you can't set a constant parameter after construction."""
         testpo = TestPO(const=17)

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -110,8 +110,7 @@ class TestParameterized(unittest.TestCase):
 
         p = P()
 
-        match = re.fullmatch(r'P\w{5}', p.name)
-        assert match is not None
+        assert p.name == 'Other'
 
     def test_parameter_name_fixed(self):
         testpo = TestPO()


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/644

Overriding the `name` String Parameter was possible at the class level but it actually had no effect. This PR changes that so it is taken into account. This is the new behavior:

```python
import param

class P(param.Parameterized):
    name = param.String(default='other')

assert P.name == 'other'

p = P()

assert p.name == 'other'
```

Overriding is only allowed when `name` is set to be a `String` Parameter, as this is something that `Param` relies on internally for other things. A Parameterized class and its instances will have its `name` overriden if the `default` value of the `name` String Parameter is set to something that is not `None` or not an empty string.

I used this branch to run the test suites of Panel and HoloViews (both somewhat partially as I don't have all the dependencies installed locally), which helped me to refine it, as there are indeed a few cases of `name` being overriden by both Panel and HoloViews.

- [x] I still have a question to resolve. For the need of the implementation I have set a new internal attribute on `Parameterized`, whose value is set to `True` when that particular class overrides the value of `name`. I am not particularly happy with adding new attributes, even if internal, to `Parameterized` as there is still a chance they will interact with some user defined attribute. However, I played around with some different implementation and this is the only one I found that worked. I would like this variable name to be as "hidden" as possible, I have called it `__renamed` so that it's mangled, and it happens I can always retrieve it later on the class via the attribute name `'_ParameterizedMetaclass__renamed'`. I don't find that particularly simple to understand and clean, even if I think it does a pretty good job at making the attribute internal and pretty safe from a user perspective. I'm open to better ideas on naming this internal attribute!

To the reviewers. I suggest to have a close look at the tests that have been added and capture the new behavior. Notably a test I added just before opening this PR on *main* needed to be updated (`test_name_instance_generated_class_name_reset`).