### PR TITLE
Update to Google Analytics 4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,7 +53,7 @@ html_theme_options = {
         "copyright",
         "last-updated",
     ],
-    "analytics": {"google_analytics_id": 'UA-154795830-6'},
+    "analytics": {"google_analytics_id": 'G-KD5GGLCB54'}
 }
 
 # Override the Sphinx default title that appends `documentation`


### PR DESCRIPTION
Updates tracking ID to the new GA4 since the old Universal Tracking is shutting down and we haven't yet decided to move away from GA.