### PR TITLE
Fix stacklevel start

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1867,7 +1867,7 @@ class List(Parameter):
             warnings.warn(
                 message="The 'class_' attribute on 'List' is deprecated. Use instead 'item_type'",
                 category=_ParamDeprecationWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
         if item_type is not Undefined and class_ is not Undefined:
             self.item_type = item_type


### PR DESCRIPTION
fixes #756

The decorator adds an extra stack level. 




``` python
import param

class Defaults(param.Parameterized):
    filters = param.List(doc="Defaults for Filter objects.", class_=dict)
```


Before: 
![image](https://github.com/holoviz/param/assets/19758978/900095c0-0b72-4152-bfe0-99ec882b798c)


After:
![image](https://github.com/holoviz/param/assets/19758978/c29f1a46-03ca-439d-9d21-b18aae52a618)
