### PR TITLE
Fix depending on the method of a sub parameter object

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -29,7 +29,7 @@ from collections import defaultdict, namedtuple, OrderedDict
 from functools import partial, wraps, reduce
 from operator import itemgetter,attrgetter
 from threading import get_ident
-from types import FunctionType
+from types import FunctionType, MethodType
 
 import logging
 from contextlib import contextmanager
@@ -2556,7 +2556,7 @@ class Parameters:
             attr_obj = getattr(src, attr)
             if isinstance(attr_obj, Parameterized):
                 return [], []
-            elif isinstance(attr_obj, FunctionType):
+            elif isinstance(attr_obj, (FunctionType, MethodType)):
                 info = MInfo(inst=inst, cls=cls, name=attr,
                              method=attr_obj)
             else:

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -736,6 +736,90 @@ class TestParamDepends(unittest.TestCase):
         inst.a = 2
         assert method_count == 1
 
+    def test_param_depends_on_method_subparameter(self):
+
+        method1_count = 0
+        method2_count = 0
+
+        class Sub(param.Parameterized):
+            a = param.Integer()
+
+            @param.depends('a')
+            def method1(self):
+                nonlocal method1_count
+                method1_count += 1
+
+        class Main(param.Parameterized):
+            sub = param.Parameter()
+
+            @param.depends('sub.method1', watch=True)
+            def method2(self):
+                nonlocal method2_count
+                method2_count += 1
+
+        sub = Sub()
+        main = Main(sub=sub)
+        pinfos = main.param.method_dependencies('method2')
+        assert len(pinfos) == 1
+
+        pinfo = pinfos[0]
+        assert pinfo.cls is Sub
+        assert pinfo.inst is sub
+        assert pinfo.name == 'a'
+        assert pinfo.what == 'value'
+
+        sub.a = 2
+        assert method1_count == 0
+        assert method2_count == 1
+
+
+    def test_param_depends_on_method_subparameter_after_init(self):
+        # Setup inspired from https://github.com/holoviz/param/issues/764
+
+        method1_count = 0
+        method2_count = 0
+
+        class Controls(param.Parameterized):
+
+            explorer = param.Parameter()
+
+            @param.depends('explorer.method1', watch=True)
+            def method2(self):
+                nonlocal method2_count
+                method2_count += 1
+
+
+        class Explorer(param.Parameterized):
+
+            controls = param.Parameter()
+
+            x = param.Selector(objects=['a', 'b'])
+
+            def __init__(self, **params):
+                super().__init__(**params)
+                self.controls = Controls(explorer=self)
+
+            @param.depends('x')
+            def method1(self):
+                nonlocal method1_count
+                method1_count += 1
+
+        explorer = Explorer()
+
+        pinfos = explorer.controls.param.method_dependencies('method2')
+        assert len(pinfos) == 1
+
+        pinfo = pinfos[0]
+        assert pinfo.cls is Explorer
+        assert pinfo.inst is explorer
+        assert pinfo.name == 'x'
+        assert pinfo.what == 'value'
+
+        explorer.x = 'b'
+
+        assert method1_count == 0
+        assert method2_count == 1
+
 
 class TestParamDependsFunction(unittest.TestCase):
 

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -707,6 +707,35 @@ class TestParamDepends(unittest.TestCase):
 
         assert not called
 
+    def test_param_depends_on_method(self):
+
+        method_count = 0
+
+        class A(param.Parameterized):
+            a = param.Integer()
+
+            @param.depends('a', watch=True)
+            def method1(self):
+                pass
+
+            @param.depends('method1', watch=True)
+            def method2(self):
+                nonlocal method_count
+                method_count += 1
+
+        inst = A()
+        pinfos = inst.param.method_dependencies('method2')
+        assert len(pinfos) == 1
+
+        pinfo = pinfos[0]
+        assert pinfo.cls is A
+        assert pinfo.inst is inst
+        assert pinfo.name == 'a'
+        assert pinfo.what == 'value'
+
+        inst.a = 2
+        assert method_count == 1
+
 
 class TestParamDependsFunction(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #764

This PR fixes a regression that was introduced in https://github.com/holoviz/param/pull/753. It appeared that depending on a method was pretty much untested so I have added some more tests.

When `_spec_to_obj` resolves a dependency on a Parameterized *method*, the type of the resolved method is:
- `FunctionType` if it's a *direct* dependency, as in `@param.depends('method')`. The object holding the reference to the method seen by `_spec_to_obj` is a class.
- `MethodType` if it's a dependency on a sub object, as in `@param.depends('sub.method')`. The object holding the reference to the method seen by `_spec_to_obj` is an instance.

Good to know!

```python
from types import FunctionType, MethodType

class A:
    def foo(self): pass

assert isinstance(A.foo, FunctionType)
assert isinstance(A().foo, MethodType)
```

The change made in this PR is pretty simple, I'll however kindly ask @philippjfr to review it to ensure that this is correct, and check that the problem actually doesn't lie with how the object holding the method reference is resolved (class vs. instance).