### PR TITLE
Add a dedicated namespace for private objs on Parameterized

### DIFF
--- a/examples/user_guide/How_Param_Works.ipynb
+++ b/examples/user_guide/How_Param_Works.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "class Count:\n",
     "    def __init__(self, start=0):\n",
-    "        self._count=start\n",
+    "        self._count = start\n",
     "    \n",
     "    def __get__(self, obj, objtype=None):\n",
     "        self._count += 1\n",
@@ -89,7 +89,7 @@
     "\n",
     "- allowing Parameter default values to be set at the class level (as just described),\n",
     "- supporting inheriting Parameter objects from superclasses, \n",
-    "- instantiating parameter default values into the class's dictionary (if needed)\n",
+    "- instantiating parameter default values (if needed)\n",
     "- populating the `name` slot of each Parameter by its attribute name in the class,\n",
     "- reporting whether a class has been declared to be abstract (useful for ignoring it in selectors),\n",
     "- various bookkeeping about dependencies and watchers, \n",
@@ -175,7 +175,7 @@
    "id": "36ef8c10",
    "metadata": {},
    "source": [
-    "If the value of `p` is set on `a1`, `a1`'s value of `p` is stored in the `a1` instance itself, under a specially mangled attribute name. The mangled name is called the `_internal_name` of the parameter, and is constructed from the \"attrib name\" of the parameter (i.e. `p` in this case) but modified so that it will not be confused with the underlying `Parameter` object `p`:"
+    "If the value of `p` is set on `a1`, `a1`'s value of `p` is stored in the `a1` instance itself, in a dictionary named `values` under the private namespace `_param__private`:"
    ]
   },
   {
@@ -185,8 +185,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a1.p=2\n",
-    "a1.__dict__['_p_param_value']"
+    "a1.p = 2\n",
+    "a1._param__private.values['p']"
    ]
   },
   {
@@ -194,7 +194,7 @@
    "id": "9b5c6a79",
    "metadata": {},
    "source": [
-    "When `a1.p` is requested, `a1.__dict__['_p_param_value']` is returned. When `a2.p` is requested, `_p_param_value` is not found in `a2.__dict__`, so `A.__dict__['p'].default` (i.e. `A.p`) is returned instead:"
+    "When `a1.p` is requested, `a1._param__private.values['p']` is returned. When `a2.p` is requested, `p` is not found in `a2._param__private.values`, so `A.__dict__['p'].default` (i.e. `A.p`) is returned instead:"
    ]
   },
   {
@@ -222,7 +222,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A.p=3\n",
+    "A.p = 3\n",
     "a2.p, a1.p"
    ]
   },

--- a/examples/user_guide/Parameters.ipynb
+++ b/examples/user_guide/Parameters.ipynb
@@ -923,7 +923,8 @@
    "outputs": [],
    "source": [
     "class P(param.Parameterized):\n",
-    "    x = param.Parameter()\n",
+    "    a = param.Number()\n",
+    "    b = param.String()\n",
     "\n",
     "p = P()\n",
     "print(f'{P.name=}, {p.name=}')"

--- a/examples/user_guide/Parameters.ipynb
+++ b/examples/user_guide/Parameters.ipynb
@@ -899,12 +899,75 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3830ace8",
+   "metadata": {},
+   "source": [
+    "## Parameterized namespace\n",
+    "\n",
+    "Param allows you to create Parameterized objects by inheriting from the `Parameterized` base class. Param has evolved over time to reduce its footprint and reserve as few as possible attributes on this namespace, to reduce the risk of name clashes and allow you to freely define your attribute names. Param reserves a few names that are described below, make sure not to override, unless it is stated it is allowed:\n",
+    "\n",
+    "- Public attributes:\n",
+    "    - `name`: Parameterized classes and instances have a name `String` Parameter, that by default is set to the class name when accessed from the class and to the class name appended with a 5 digit when accessed from the instance. You can override this Parameter by your own `String` Parameter if you need to.\n",
+    "    - `param`: Property that helps keep the Parameterized namespace clean and disambiguate between Parameter objects and parameter values, it gives access to a namespace that offers various methods (see the section below) to update and inspect the Parameterized object at hand.\n",
+    "- Private attributes:\n",
+    "    - `_param__parameters`: Store the object returned by `.param` on the class\n",
+    "    - `_param__private`: Store various internal data on Parameterized class and instances\n",
+    "    - `_param_watchers` (to be removed soon): Store a dictionary of instance watchers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01759e1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class P(param.Parameterized):\n",
+    "    x = param.Parameter()\n",
+    "\n",
+    "p = P()\n",
+    "print(f'{P.name=}, {p.name=}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e802c7c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def namespace(obj):\n",
+    "    return [o for o in dir(obj) if not o.startswith('__')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c702205",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "namespace(P)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b74fb157",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "namespace(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "23979d82",
    "metadata": {},
    "source": [
     "## Other Parameterized methods\n",
     "\n",
-    "Like `.param.pprint`, the remaining \"utility\" or convenience methods available for a `Parameterized` class or object are provided via a subobject called `param` that helps keep the namespace clean and disambiguate between Parameter objects and parameter values:\n",
+    "Like `.param.pprint`, the remaining \"utility\" or convenience methods available for a `Parameterized` class or object are provided via the `.param` subobject:\n",
     "\n",
     "- `.param.update(**kwargs)`: Set parameter values from the given `param=value` keyword arguments (or a dict or iterable), delaying watching and dependency handling until all have been updated. `.param.update` can also be used as a context manager to temporarily set values, that are restored to their original values when the context manager exits."
    ]

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2967,7 +2967,7 @@ class Event(Boolean):
         if obj is None:
             self.default = val
         else:
-            obj._param__private.values[self._internal_name] = val
+            obj._param__private.values[self.name] = val
         self._post_setter(obj, val)
 
     @instance_descriptor

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2970,7 +2970,7 @@ class Event(Boolean):
         if obj is None:
             self.default = val
         else:
-            obj._param__private.values[self._internal_name] = val
+            obj._param__private.values[self.name] = val
         self._post_setter(obj, val)
 
     @instance_descriptor

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2970,7 +2970,7 @@ class Event(Boolean):
         if obj is None:
             self.default = val
         else:
-            obj._param__private.values[self.name] = val
+            obj._param__private.values[self._internal_name] = val
         self._post_setter(obj, val)
 
     @instance_descriptor

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2970,7 +2970,7 @@ class Event(Boolean):
         if obj is None:
             self.default = val
         else:
-            obj.__dict__[self._internal_name] = val
+            obj._param__private.values[self._internal_name] = val
         self._post_setter(obj, val)
 
     @instance_descriptor

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1764,8 +1764,8 @@ class Parameters:
             raise AttributeError
 
         try:
-            params = list(getattr(cls, '_%s__params' % cls.__name__))
-        except AttributeError:
+            params = list(cls._param__private.params['_%s__params' % cls.__name__])
+        except KeyError:
             params = [n for class_ in classlist(cls) for n, v in class_.__dict__.items()
                       if isinstance(v, Parameter)]
 
@@ -2018,7 +2018,7 @@ class Parameters:
         ParameterizedMetaclass._initialize_parameter(cls,param_name,param_obj)
         # delete cached params()
         try:
-            delattr(cls,'_%s__params'%cls.__name__)
+            delattr(cls._param__private, '_%s__params' % cls.__name__)
         except AttributeError:
             pass
 
@@ -2136,8 +2136,8 @@ class Parameters:
         # We cache the parameters because this method is called often,
         # and parameters are rarely added (and cannot be deleted)
         try:
-            pdict = getattr(cls, '_%s__params' % cls.__name__)
-        except AttributeError:
+            pdict = cls._param__private.params[f'_{cls.__name__}__params']
+        except KeyError:
             paramdict = {}
             for class_ in classlist(cls):
                 for name, val in class_.__dict__.items():
@@ -2148,7 +2148,7 @@ class Parameters:
             # params() is called, so we mangle the name ourselves at
             # runtime (if we were to mangle it now, it would be
             # _Parameterized.__params for all classes).
-            setattr(cls, '_%s__params' % cls.__name__, paramdict)
+            cls._param__private.params[f'_{cls.__name__}__params'] = paramdict
             pdict = paramdict
 
         if instance and self_.self is not None:
@@ -3450,6 +3450,7 @@ class _ClassPrivate:
         'parameters_state',
         '_disable_instance__params',
         'renamed',
+        'params',
     ]
 
     def __init__(
@@ -3459,6 +3460,7 @@ class _ClassPrivate:
     ):
         self.parameters_state = parameters_state
         self._disable_instance__params = _disable_instance__params
+        self.params = {}
 
 
 class _InstancePrivate:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1340,7 +1340,12 @@ class Parameter(_ParameterBase):
         if obj is None: # e.g. when __get__ called for a Parameterized class
             result = self.default
         else:
-            result = obj._param__private.values.get(self._internal_name, self.default)
+            # Attribute error when .values does not exist (_ClassPrivate)
+            # and KeyError when there's no cached value for this parameter.
+            try:
+                result = obj._param__private.values[self._internal_name]
+            except (AttributeError, KeyError):
+                result = self.default
         return result
 
     @instance_descriptor

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2423,7 +2423,7 @@ class Parameters:
         else:
             internal_name = "_%s_param_value" % name
             # TODO: is this always an instance?
-            if internal_name in cls_or_slf._param__private.values:
+            if isinstance(cls_or_slf, Parameterized) and internal_name in cls_or_slf._param__private.values:
                 # dealing with object and it's been set on this object
                 value = cls_or_slf._param__private.values[internal_name]
             else:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1066,11 +1066,11 @@ class Parameter(_ParameterBase):
     #   object (A.__dict__['p'].default).
     #
     # * If the value of p is set on a1 (e.g. a1.p=2), a1's value of p
-    #   is stored in a1 itself (a1.__dict__['_p_param_value'])
+    #   is stored in a1 itself (a1._param__private.values['p'])
     #
-    # * When a1.p is requested, a1.__dict__['_p_param_value'] is
-    #   returned. When a2.p is requested, '_p_param_value' is not
-    #   found in a2.__dict__, so A.__dict__['p'].default (i.e. A.p) is
+    # * When a1.p is requested, a1._param__private.values['p'] is
+    #   returned. When a2.p is requested, 'p' is not found in
+    #   a1._param__private.values, so A.__dict__['p'].default (i.e. A.p) is
     #   returned instead.
     #
     #
@@ -1078,12 +1078,11 @@ class Parameter(_ParameterBase):
     #
     # * A Parameterized class has a name for the attribute which is
     #   being represented by the Parameter ('p' in the example above);
-    #   in the code, this is called the 'attrib_name'.
+    #   in the code, this is called the 'name'.
     #
     # * When a Parameterized instance has its own local value for a
-    #   parameter, it is stored as '_X_param_value' (where X is the
-    #   attrib_name for the Parameter); in the code, this is called
-    #   the internal_name.
+    #   parameter, it is stored as 'p._param__private.values[X]' where X is the
+    #   name of the Parameter
 
 
     # So that the extra features of Parameters do not require a lot of
@@ -1364,7 +1363,8 @@ class Parameter(_ParameterBase):
 
         If called for a Parameterized instance, set the value of
         this Parameter on that instance (i.e. in the instance's
-        __dict__, under the parameter's internal_name).
+        `values` dictionary located in the private namespace `_param__private`,
+        under the parameter's name).
 
         If the Parameter's constant attribute is True, only allows
         the value to be set for a Parameterized class or on
@@ -1851,8 +1851,8 @@ class Parameters:
         return not Comparator.is_equal(event.old, event.new)
 
     def _instantiate_param(self_, param_obj, dict_=None, key=None):
-        # deepcopy param_obj.default into self.__dict__ (or dict_ if supplied)
-        # under the parameter's _internal_name (or key if supplied)
+        # deepcopy param_obj.default into self._param__private.values (or dict_ if supplied)
+        # under the parameter's name (or key if supplied)
         self = self_.self
         dict_ = dict_ or self._param__private.values
         key = key or param_obj.name
@@ -3629,7 +3629,7 @@ class _InstancePrivate:
     #         parameter_name:
     #             parameter_attribute (e.g. 'value'): list of `Watcher`s
     values: dict
-        Dict of internal_name: value
+        Dict of parameter name: value
     """
 
     __slots__ = [

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -369,7 +369,7 @@ def no_instance_params(cls):
     """
     Disables instance parameters on the class
     """
-    cls._private__param._disable_instance__params = True
+    cls._param__private._disable_instance__params = True
     return cls
 
 
@@ -392,8 +392,8 @@ def iscoroutinefunction(function):
 def instance_descriptor(f):
     # If parameter has an instance Parameter, delegate setting
     def _f(self, obj, val):
-        _private__param = getattr(obj, '_private__param', None)
-        instance_params = getattr(_private__param, 'instance_params', {})
+        _param__private = getattr(obj, '_param__private', None)
+        instance_params = getattr(_param__private, 'instance_params', {})
         instance_param = None if instance_params is None else instance_params.get(self.name)
         if instance_param is not None and self is not instance_param:
             instance_param.__set__(obj, val)
@@ -1372,7 +1372,7 @@ class Parameter(_ParameterBase):
             elif obj is None:
                 _old = self.default
                 self.default = val
-            elif not obj._private__param.initialized:
+            elif not obj._param__private.initialized:
                 _old = obj.__dict__.get(self._internal_name, self.default)
                 obj.__dict__[self._internal_name] = val
             else:
@@ -1390,14 +1390,14 @@ class Parameter(_ParameterBase):
         self._post_setter(obj, val)
 
         if obj is not None:
-            if not hasattr(obj, '_private__param') or not getattr(obj._private__param, 'initialized', False):
+            if not hasattr(obj, '_param__private') or not getattr(obj._param__private, 'initialized', False):
                 return
             obj.param._update_deps(self.name)
 
         if obj is None:
             watchers = self.watchers.get("value")
-        elif hasattr(obj, '_private__param') and hasattr(obj._private__param, 'param_watchers') and obj._private__param.param_watchers is not None and self.name in obj._private__param.param_watchers:
-            watchers = obj._private__param.param_watchers[self.name].get('value')
+        elif hasattr(obj, '_param__private') and hasattr(obj._param__private, 'param_watchers') and obj._param__private.param_watchers is not None and self.name in obj._param__private.param_watchers:
+            watchers = obj._param__private.param_watchers[self.name].get('value')
             if watchers is None:
                 watchers = self.watchers.get("value")
         else:
@@ -1555,10 +1555,10 @@ def as_uninitialized(fn):
     @wraps(fn)
     def override_initialization(self_,*args,**kw):
         parameterized_instance = self_.self
-        original_initialized = parameterized_instance._private__param.initialized
-        parameterized_instance._private__param.initialized = False
+        original_initialized = parameterized_instance._param__private.initialized
+        parameterized_instance._param__private.initialized = False
         fn(parameterized_instance, *args, **kw)
-        parameterized_instance._private__param.initialized = original_initialized
+        parameterized_instance._param__private.initialized = original_initialized
     return override_initialization
 
 
@@ -1642,35 +1642,35 @@ class Parameters:
 
     @property
     def _BATCH_WATCH(self_):
-        return self_.self_or_cls._private__param.parameters_state['BATCH_WATCH']
+        return self_.self_or_cls._param__private.parameters_state['BATCH_WATCH']
 
     @_BATCH_WATCH.setter
     def _BATCH_WATCH(self_, value):
-        self_.self_or_cls._private__param.parameters_state['BATCH_WATCH'] = value
+        self_.self_or_cls._param__private.parameters_state['BATCH_WATCH'] = value
 
     @property
     def _TRIGGER(self_):
-        return self_.self_or_cls._private__param.parameters_state['TRIGGER']
+        return self_.self_or_cls._param__private.parameters_state['TRIGGER']
 
     @_TRIGGER.setter
     def _TRIGGER(self_, value):
-        self_.self_or_cls._private__param.parameters_state['TRIGGER'] = value
+        self_.self_or_cls._param__private.parameters_state['TRIGGER'] = value
 
     @property
     def _events(self_):
-        return self_.self_or_cls._private__param.parameters_state['events']
+        return self_.self_or_cls._param__private.parameters_state['events']
 
     @_events.setter
     def _events(self_, value):
-        self_.self_or_cls._private__param.parameters_state['events'] = value
+        self_.self_or_cls._param__private.parameters_state['events'] = value
 
     @property
     def _watchers(self_):
-        return self_.self_or_cls._private__param.parameters_state['watchers']
+        return self_.self_or_cls._param__private.parameters_state['watchers']
 
     @_watchers.setter
     def _watchers(self_, value):
-        self_.self_or_cls._private__param.parameters_state['watchers'] = value
+        self_.self_or_cls._param__private.parameters_state['watchers'] = value
 
     @property
     def watchers(self):
@@ -1684,10 +1684,10 @@ class Parameters:
     def __setstate__(self, state):
         # Set old parameters state on Parameterized.parameters_state
         self_or_cls = state.get('self', state.get('cls'))
-        for k in self_or_cls._private__param.parameters_state:
+        for k in self_or_cls._param__private.parameters_state:
             key = '_'+k
             if key in state:
-                self_or_cls._private__param.parameters_state[k] = state.pop(key)
+                self_or_cls._param__private.parameters_state[k] = state.pop(key)
         for k, v in state.items():
             setattr(self, k, v)
 
@@ -1698,9 +1698,9 @@ class Parameters:
         inst = self_.self
         parameters = self_.objects(False) if inst is None else inst.param.objects(False)
         p = parameters[key]
-        if (inst is not None and getattr(inst._private__param, 'initialized', False) and p.per_instance and
-            not getattr(self_.cls._private__param, '_disable_instance__params', False)):
-            if key not in inst._private__param.instance_params:
+        if (inst is not None and getattr(inst._param__private, 'initialized', False) and p.per_instance and
+            not getattr(self_.cls._param__private, '_disable_instance__params', False)):
+            if key not in inst._param__private.instance_params:
                 try:
                     # Do not copy watchers on class parameter
                     watchers = p.watchers
@@ -1711,9 +1711,9 @@ class Parameters:
                 finally:
                     p.watchers = {k: list(v) for k, v in watchers.items()}
                 p.owner = inst
-                inst._private__param.instance_params[key] = p
+                inst._param__private.instance_params[key] = p
             else:
-                p = inst._private__param.instance_params[key]
+                p = inst._param__private.instance_params[key]
         return p
 
 
@@ -1860,7 +1860,7 @@ class Parameters:
                 if on_init and m not in init_methods:
                     init_methods.append(m)
             elif dynamic:
-                for w in obj._private__param.dynamic_watchers.pop(method, []):
+                for w in obj._param__private.dynamic_watchers.pop(method, []):
                     (w.inst or w.cls).param.unwatch(w)
             else:
                 continue
@@ -1873,7 +1873,7 @@ class Parameters:
 
             for group in grouped.values():
                 watcher = self_._watch_group(obj, method, queued, group, attribute)
-                obj._private__param.dynamic_watchers[method].append(watcher)
+                obj._param__private.dynamic_watchers[method].append(watcher)
         for m in init_methods:
             m()
 
@@ -2129,8 +2129,8 @@ class Parameters:
 
         if instance and self_.self is not None:
             if instance == 'existing':
-                if getattr(self_.self._private__param, 'initialized', False) and self_.self._private__param.instance_params:
-                    return dict(pdict, **self_.self._private__param.instance_params)
+                if getattr(self_.self._param__private, 'initialized', False) and self_.self._param__private.instance_params:
+                    return dict(pdict, **self_.self._param__private.instance_params)
                 return pdict
             else:
                 return {k: self_.self.param[k] for k in pdict}
@@ -2583,7 +2583,7 @@ class Parameters:
                                  "parameters of class {}".format(parameter_name, self_.cls.__name__))
 
             if self_.self is not None and what == "value":
-                watchers = self_.self._private__param.param_watchers
+                watchers = self_.self._param__private.param_watchers
                 if parameter_name not in watchers:
                     watchers[parameter_name] = {}
                 if what not in watchers[parameter_name]:
@@ -2855,18 +2855,18 @@ class ParameterizedMetaclass(type):
             "events": [], # Queue of batched events
             "watchers": [] # Queue of batched watchers
         }
-        _private__param = _ClassPrivate(
+        _param__private = _ClassPrivate(
             parameters_state=parameters_state,
         )
-        mcs._private__param = _private__param
-        mcs._param = Parameters(mcs)
+        mcs._param__private = _param__private
+        mcs._param_parameters = Parameters(mcs)
 
         # All objects (with their names) of type Parameter that are
         # defined in this class
         parameters = [(n, o) for (n, o) in dict_.items()
                       if isinstance(o, Parameter)]
 
-        mcs._param._parameters = dict(parameters)
+        mcs._param_parameters._parameters = dict(parameters)
 
         for param_name,param in parameters:
             mcs._initialize_parameter(param_name, param)
@@ -2890,7 +2890,7 @@ class ParameterizedMetaclass(type):
         # Resolve dependencies in class hierarchy
         _inherited = []
         for cls in classlist(mcs)[:-1][::-1]:
-            if not hasattr(cls, '_param'):
+            if not hasattr(cls, '_param_parameters'):
                 continue
             for dep in cls.param._depends['watch']:
                 method = getattr(mcs, dep[0], None)
@@ -2963,7 +2963,7 @@ class ParameterizedMetaclass(type):
     abstract = property(__is_abstract)
 
     def _get_param(mcs):
-        return mcs._param
+        return mcs._param_parameters
 
     param = property(_get_param)
 
@@ -3405,7 +3405,7 @@ class Parameterized(metaclass=ParameterizedMetaclass):
             "events": [], # Queue of batched events
             "watchers": [] # Queue of batched watchers
         }
-        self._private__param = _InstancePrivate(
+        self._param__private = _InstancePrivate(
             initialized=False,
             parameters_state=parameters_state,
             dynamic_watchers=defaultdict(list),
@@ -3419,7 +3419,7 @@ class Parameterized(metaclass=ParameterizedMetaclass):
 
         self.param._update_deps(init=True)
 
-        self._private__param.initialized = True
+        self._param__private.initialized = True
 
     @property
     def param(self):
@@ -3453,17 +3453,17 @@ class Parameterized(metaclass=ParameterizedMetaclass):
 
         During this process the object is considered uninitialized.
         """
-        self._private__param = _InstancePrivate()
-        self._private__param.initialized = False
+        self._param__private = _InstancePrivate()
+        self._param__private.initialized = False
 
-        _private__param = state.get('_private__param', None)
-        if _private__param is None:
-            _private__param = _InstancePrivate()
+        _param__private = state.get('_param__private', None)
+        if _param__private is None:
+            _param__private = _InstancePrivate()
 
         # When making a copy the internal watchers have to be
         # recreated and point to the new instance
-        if getattr(_private__param, 'param_watchers', None) is not None:
-            param_watchers = _private__param.param_watchers
+        if getattr(_param__private, 'param_watchers', None) is not None:
+            param_watchers = _param__private.param_watchers
             for p, attrs in param_watchers.items():
                 for attr, watchers in attrs.items():
                     new_watchers = []
@@ -3479,15 +3479,15 @@ class Parameterized(metaclass=ParameterizedMetaclass):
                         new_watchers.append(Watcher(*watcher_args))
                     param_watchers[p][attr] = new_watchers
 
-        if getattr(_private__param, 'instance_params', None) is None:
-            _private__param.instance_params = {}
-        if getattr(_private__param, 'param_watchers', None) is None:
-            _private__param.param_watchers = {}
+        if getattr(_param__private, 'instance_params', None) is None:
+            _param__private.instance_params = {}
+        if getattr(_param__private, 'param_watchers', None) is None:
+            _param__private.param_watchers = {}
         state.pop('param', None)
 
         for name,value in state.items():
             setattr(self,name,value)
-        self._private__param.initialized = True
+        self._param__private.initialized = True
 
     @recursive_repr()
     def __repr__(self):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1093,7 +1093,7 @@ class Parameter(_ParameterBase):
     # attributes.  Using __slots__ requires special support for
     # operations to copy and restore Parameters (e.g. for Python
     # persistent storage pickling); see __getstate__ and __setstate__.
-    __slots__ = ['name', 'default', 'doc',
+    __slots__ = ['name', '_internal_name', 'default', 'doc',
                  'precedence', 'instantiate', 'constant', 'readonly',
                  'pickle_default_value', 'allow_None', 'per_instance',
                  'watchers', 'owner', '_label']
@@ -1207,6 +1207,7 @@ class Parameter(_ParameterBase):
         self.constant = constant is True or readonly is True # readonly => constant
         self.readonly = readonly
         self._label = label
+        self._internal_name = None
         self._set_instantiate(instantiate)
         self.pickle_default_value = pickle_default_value
         self._set_allow_None(allow_None)
@@ -1343,7 +1344,7 @@ class Parameter(_ParameterBase):
         if obj is None: # e.g. when __get__ called for a Parameterized class
             result = self.default
         else:
-            result = obj._param__private.values.get(self.name, self.default)
+            result = obj._param__private.values.get(self._internal_name, self.default)
         return result
 
     @instance_descriptor
@@ -1395,10 +1396,10 @@ class Parameter(_ParameterBase):
                 _old = self.default
                 self.default = val
             elif not obj._param__private.initialized:
-                _old = obj._param__private.values.get(self.name, self.default)
-                obj._param__private.values[self.name] = val
+                _old = obj._param__private.values.get(self._internal_name, self.default)
+                obj._param__private.values[self._internal_name] = val
             else:
-                _old = obj._param__private.values.get(self.name, self.default)
+                _old = obj._param__private.values.get(self._internal_name, self.default)
                 if val is not _old:
                     raise TypeError("Constant parameter '%s' cannot be modified"%self.name)
         else:
@@ -1406,8 +1407,8 @@ class Parameter(_ParameterBase):
                 _old = self.default
                 self.default = val
             else:
-                _old = obj._param__private.values.get(self.name, self.default)
-                obj._param__private.values[self.name] = val
+                _old = obj._param__private.values.get(self._internal_name, self.default)
+                obj._param__private.values[self._internal_name] = val
 
         self._post_setter(obj, val)
 
@@ -1462,6 +1463,7 @@ class Parameter(_ParameterBase):
                                  'instance for each new class.'.format(type(self).__name__, self.name,
                                     self.owner.name, attrib_name))
         self.name = attrib_name
+        self._internal_name = "_%s_param_value" % attrib_name
 
     def __getstate__(self):
         """
@@ -1843,7 +1845,7 @@ class Parameters:
         # under the parameter's _internal_name (or key if supplied)
         self = self_.self
         dict_ = dict_ or self._param__private.values
-        key = key or param_obj.name
+        key = key or param_obj._internal_name
         if shared_parameters._share:
             param_key = (str(type(self)), param_obj.name)
             if param_key in shared_parameters._shared_cache:
@@ -2418,10 +2420,11 @@ class Parameters:
 
         # Dynamic Parameter...
         else:
+            internal_name = "_%s_param_value" % name
             # TODO: is this always an instance?
-            if isinstance(cls_or_slf, Parameterized) and name in cls_or_slf._param__private.values:
+            if isinstance(cls_or_slf, Parameterized) and internal_name in cls_or_slf._param__private.values:
                 # dealing with object and it's been set on this object
-                value = cls_or_slf._param__private.values[name]
+                value = cls_or_slf._param__private.values[internal_name]
             else:
                 # dealing with class or isn't set on the object
                 value = param_obj.default

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3408,10 +3408,6 @@ class Parameterized(metaclass=ParameterizedMetaclass):
     def param(self):
         return Parameters(self.__class__, self=self)
 
-    @property
-    def _private(self):
-        return Private(self.__class__, self=self)
-
     # 'Special' methods
 
     def __getstate__(self):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2952,7 +2952,6 @@ class ParameterizedMetaclass(type):
             classes = classlist(mcs)[::-1]
             found_renamed = False
             for c in classes:
-                # if getattr(c, "_ParameterizedMetaclass__renamed", False):
                 if hasattr(c, '_param__private') and c._param__private.renamed:
                     found_renamed = True
                     break

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -387,8 +387,10 @@ def iscoroutinefunction(function):
 def instance_descriptor(f):
     # If parameter has an instance Parameter, delegate setting
     def _f(self, obj, val):
-        _param__private = getattr(obj, '_param__private', None)
-        instance_params = getattr(_param__private, 'instance_params', {})
+        if obj is None:
+            # obj is None when the metaclass is setting
+            return f(self, obj, val)
+        instance_params = obj._param__private.instance_params
         instance_param = None if instance_params is None else instance_params.get(self.name)
         if instance_param is not None and self is not instance_param:
             instance_param.__set__(obj, val)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2871,7 +2871,6 @@ class ParameterizedMetaclass(type):
         """
         type.__init__(mcs, name, bases, dict_)
 
-        mcs.__set_name(name, dict_)
 
         parameters_state = {
             "BATCH_WATCH": False, # If true, Event and watcher objects are queued.
@@ -2883,6 +2882,7 @@ class ParameterizedMetaclass(type):
             parameters_state=parameters_state,
         )
         mcs._param__private = _param__private
+        mcs.__set_name(name, dict_)
         mcs._param__parameters = Parameters(mcs)
 
         # All objects (with their names) of type Parameter that are
@@ -2935,7 +2935,7 @@ class ParameterizedMetaclass(type):
         a `name` String Parameter with a defined `default` value, in which case
         that value is used to set the class name.
         """
-        mcs.__renamed = False
+        mcs._param__private.renamed = False
         name_param = dict_.get("name", None)
         if name_param is not None:
             if not type(name_param) is String:
@@ -2946,14 +2946,15 @@ class ParameterizedMetaclass(type):
                 )
             if name_param.default:
                 mcs.name = name_param.default
-                mcs.__renamed = True
+                mcs._param__private.renamed = True
             else:
                 mcs.name = name
         else:
             classes = classlist(mcs)[::-1]
             found_renamed = False
             for c in classes:
-                if getattr(c, "_ParameterizedMetaclass__renamed", False):
+                # if getattr(c, "_ParameterizedMetaclass__renamed", False):
+                if hasattr(c, '_param__private') and c._param__private.renamed:
                     found_renamed = True
                     break
             if not found_renamed:
@@ -3448,6 +3449,7 @@ class _ClassPrivate:
     __slots__ = [
         'parameters_state',
         '_disable_instance__params',
+        'renamed',
     ]
 
     def __init__(

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3309,6 +3309,15 @@ def recursive_repr(fillvalue='...'):
 
 class Private:
 
+    __slots__ = [
+        'initialized',
+        '_parameters_state',
+        '_dynamic_watchers',
+        '_instance__params',
+        '_param_watchers',
+        '_disable_instance__params',
+    ]
+
     def __init__(
         self,
         initialized=None,

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1349,7 +1349,7 @@ class Parameter(_ParameterBase):
             # Attribute error when .values does not exist (_ClassPrivate)
             # and KeyError when there's no cached value for this parameter.
             try:
-                result = obj._param__private.values[self._internal_name]
+                result = obj._param__private.values[self.name]
             except (AttributeError, KeyError):
                 result = self.default
         return result
@@ -1403,10 +1403,10 @@ class Parameter(_ParameterBase):
                 _old = self.default
                 self.default = val
             elif not obj._param__private.initialized:
-                _old = obj._param__private.values.get(self._internal_name, self.default)
-                obj._param__private.values[self._internal_name] = val
+                _old = obj._param__private.values.get(self.name, self.default)
+                obj._param__private.values[self.name] = val
             else:
-                _old = obj._param__private.values.get(self._internal_name, self.default)
+                _old = obj._param__private.values.get(self.name, self.default)
                 if val is not _old:
                     raise TypeError("Constant parameter '%s' cannot be modified"%self.name)
         else:
@@ -1414,8 +1414,8 @@ class Parameter(_ParameterBase):
                 _old = self.default
                 self.default = val
             else:
-                _old = obj._param__private.values.get(self._internal_name, self.default)
-                obj._param__private.values[self._internal_name] = val
+                _old = obj._param__private.values.get(self.name, self.default)
+                obj._param__private.values[self.name] = val
 
         self._post_setter(obj, val)
 
@@ -1855,7 +1855,7 @@ class Parameters:
         # under the parameter's _internal_name (or key if supplied)
         self = self_.self
         dict_ = dict_ or self._param__private.values
-        key = key or param_obj._internal_name
+        key = key or param_obj.name
         if shared_parameters._share:
             param_key = (str(type(self)), param_obj.name)
             if param_key in shared_parameters._shared_cache:
@@ -2430,11 +2430,10 @@ class Parameters:
 
         # Dynamic Parameter...
         else:
-            internal_name = "_%s_param_value" % name
             # TODO: is this always an instance?
-            if isinstance(cls_or_slf, Parameterized) and internal_name in cls_or_slf._param__private.values:
+            if isinstance(cls_or_slf, Parameterized) and name in cls_or_slf._param__private.values:
                 # dealing with object and it's been set on this object
-                value = cls_or_slf._param__private.values[internal_name]
+                value = cls_or_slf._param__private.values[name]
             else:
                 # dealing with class or isn't set on the object
                 value = param_obj.default

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2859,14 +2859,14 @@ class ParameterizedMetaclass(type):
             parameters_state=parameters_state,
         )
         mcs._param__private = _param__private
-        mcs._param_parameters = Parameters(mcs)
+        mcs._param__parameters = Parameters(mcs)
 
         # All objects (with their names) of type Parameter that are
         # defined in this class
         parameters = [(n, o) for (n, o) in dict_.items()
                       if isinstance(o, Parameter)]
 
-        mcs._param_parameters._parameters = dict(parameters)
+        mcs._param__parameters._parameters = dict(parameters)
 
         for param_name,param in parameters:
             mcs._initialize_parameter(param_name, param)
@@ -2890,7 +2890,7 @@ class ParameterizedMetaclass(type):
         # Resolve dependencies in class hierarchy
         _inherited = []
         for cls in classlist(mcs)[:-1][::-1]:
-            if not hasattr(cls, '_param_parameters'):
+            if not hasattr(cls, '_param__parameters'):
                 continue
             for dep in cls.param._depends['watch']:
                 method = getattr(mcs, dep[0], None)
@@ -2963,7 +2963,7 @@ class ParameterizedMetaclass(type):
     abstract = property(__is_abstract)
 
     def _get_param(mcs):
-        return mcs._param_parameters
+        return mcs._param__parameters
 
     param = property(_get_param)
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -369,7 +369,7 @@ def no_instance_params(cls):
     """
     Disables instance parameters on the class
     """
-    cls._private._disable_instance__params = True
+    cls._private__param._disable_instance__params = True
     return cls
 
 
@@ -392,9 +392,9 @@ def iscoroutinefunction(function):
 def instance_descriptor(f):
     # If parameter has an instance Parameter, delegate setting
     def _f(self, obj, val):
-        _private = getattr(obj, '_private', None)
-        _instance__params = getattr(_private, '_instance__params', {})
-        instance_param = None if _instance__params is None else _instance__params.get(self.name)
+        _private__param = getattr(obj, '_private__param', None)
+        instance_params = getattr(_private__param, 'instance_params', {})
+        instance_param = None if instance_params is None else instance_params.get(self.name)
         if instance_param is not None and self is not instance_param:
             instance_param.__set__(obj, val)
             return
@@ -1372,7 +1372,7 @@ class Parameter(_ParameterBase):
             elif obj is None:
                 _old = self.default
                 self.default = val
-            elif not obj._private.initialized:
+            elif not obj._private__param.initialized:
                 _old = obj.__dict__.get(self._internal_name, self.default)
                 obj.__dict__[self._internal_name] = val
             else:
@@ -1390,14 +1390,14 @@ class Parameter(_ParameterBase):
         self._post_setter(obj, val)
 
         if obj is not None:
-            if not hasattr(obj, '_private') or not getattr(obj._private, 'initialized', False):
+            if not hasattr(obj, '_private__param') or not getattr(obj._private__param, 'initialized', False):
                 return
             obj.param._update_deps(self.name)
 
         if obj is None:
             watchers = self.watchers.get("value")
-        elif hasattr(obj, '_private') and hasattr(obj._private, '_param_watchers') and obj._private._param_watchers is not None and self.name in obj._private._param_watchers:
-            watchers = obj._private._param_watchers[self.name].get('value')
+        elif hasattr(obj, '_private__param') and hasattr(obj._private__param, 'param_watchers') and obj._private__param.param_watchers is not None and self.name in obj._private__param.param_watchers:
+            watchers = obj._private__param.param_watchers[self.name].get('value')
             if watchers is None:
                 watchers = self.watchers.get("value")
         else:
@@ -1555,10 +1555,10 @@ def as_uninitialized(fn):
     @wraps(fn)
     def override_initialization(self_,*args,**kw):
         parameterized_instance = self_.self
-        original_initialized = parameterized_instance._private.initialized
-        parameterized_instance._private.initialized = False
+        original_initialized = parameterized_instance._private__param.initialized
+        parameterized_instance._private__param.initialized = False
         fn(parameterized_instance, *args, **kw)
-        parameterized_instance._private.initialized = original_initialized
+        parameterized_instance._private__param.initialized = original_initialized
     return override_initialization
 
 
@@ -1642,35 +1642,35 @@ class Parameters:
 
     @property
     def _BATCH_WATCH(self_):
-        return self_.self_or_cls._private._parameters_state['BATCH_WATCH']
+        return self_.self_or_cls._private__param.parameters_state['BATCH_WATCH']
 
     @_BATCH_WATCH.setter
     def _BATCH_WATCH(self_, value):
-        self_.self_or_cls._private._parameters_state['BATCH_WATCH'] = value
+        self_.self_or_cls._private__param.parameters_state['BATCH_WATCH'] = value
 
     @property
     def _TRIGGER(self_):
-        return self_.self_or_cls._private._parameters_state['TRIGGER']
+        return self_.self_or_cls._private__param.parameters_state['TRIGGER']
 
     @_TRIGGER.setter
     def _TRIGGER(self_, value):
-        self_.self_or_cls._private._parameters_state['TRIGGER'] = value
+        self_.self_or_cls._private__param.parameters_state['TRIGGER'] = value
 
     @property
     def _events(self_):
-        return self_.self_or_cls._private._parameters_state['events']
+        return self_.self_or_cls._private__param.parameters_state['events']
 
     @_events.setter
     def _events(self_, value):
-        self_.self_or_cls._private._parameters_state['events'] = value
+        self_.self_or_cls._private__param.parameters_state['events'] = value
 
     @property
     def _watchers(self_):
-        return self_.self_or_cls._private._parameters_state['watchers']
+        return self_.self_or_cls._private__param.parameters_state['watchers']
 
     @_watchers.setter
     def _watchers(self_, value):
-        self_.self_or_cls._private._parameters_state['watchers'] = value
+        self_.self_or_cls._private__param.parameters_state['watchers'] = value
 
     @property
     def watchers(self):
@@ -1682,12 +1682,12 @@ class Parameters:
         return self_.cls if self_.self is None else self_.self
 
     def __setstate__(self, state):
-        # Set old parameters state on Parameterized._parameters_state
+        # Set old parameters state on Parameterized.parameters_state
         self_or_cls = state.get('self', state.get('cls'))
-        for k in self_or_cls._private._parameters_state:
+        for k in self_or_cls._private__param.parameters_state:
             key = '_'+k
             if key in state:
-                self_or_cls._private._parameters_state[k] = state.pop(key)
+                self_or_cls._private__param.parameters_state[k] = state.pop(key)
         for k, v in state.items():
             setattr(self, k, v)
 
@@ -1698,9 +1698,9 @@ class Parameters:
         inst = self_.self
         parameters = self_.objects(False) if inst is None else inst.param.objects(False)
         p = parameters[key]
-        if (inst is not None and getattr(inst._private, 'initialized', False) and p.per_instance and
-            not getattr(self_.cls._private, '_disable_instance__params', False)):
-            if key not in inst._private._instance__params:
+        if (inst is not None and getattr(inst._private__param, 'initialized', False) and p.per_instance and
+            not getattr(self_.cls._private__param, '_disable_instance__params', False)):
+            if key not in inst._private__param.instance_params:
                 try:
                     # Do not copy watchers on class parameter
                     watchers = p.watchers
@@ -1711,9 +1711,9 @@ class Parameters:
                 finally:
                     p.watchers = {k: list(v) for k, v in watchers.items()}
                 p.owner = inst
-                inst._private._instance__params[key] = p
+                inst._private__param.instance_params[key] = p
             else:
-                p = inst._private._instance__params[key]
+                p = inst._private__param.instance_params[key]
         return p
 
 
@@ -1860,7 +1860,7 @@ class Parameters:
                 if on_init and m not in init_methods:
                     init_methods.append(m)
             elif dynamic:
-                for w in obj._private._dynamic_watchers.pop(method, []):
+                for w in obj._private__param.dynamic_watchers.pop(method, []):
                     (w.inst or w.cls).param.unwatch(w)
             else:
                 continue
@@ -1873,7 +1873,7 @@ class Parameters:
 
             for group in grouped.values():
                 watcher = self_._watch_group(obj, method, queued, group, attribute)
-                obj._private._dynamic_watchers[method].append(watcher)
+                obj._private__param.dynamic_watchers[method].append(watcher)
         for m in init_methods:
             m()
 
@@ -2129,8 +2129,8 @@ class Parameters:
 
         if instance and self_.self is not None:
             if instance == 'existing':
-                if getattr(self_.self._private, 'initialized', False) and self_.self._private._instance__params:
-                    return dict(pdict, **self_.self._private._instance__params)
+                if getattr(self_.self._private__param, 'initialized', False) and self_.self._private__param.instance_params:
+                    return dict(pdict, **self_.self._private__param.instance_params)
                 return pdict
             else:
                 return {k: self_.self.param[k] for k in pdict}
@@ -2583,7 +2583,7 @@ class Parameters:
                                  "parameters of class {}".format(parameter_name, self_.cls.__name__))
 
             if self_.self is not None and what == "value":
-                watchers = self_.self._private._param_watchers
+                watchers = self_.self._private__param.param_watchers
                 if parameter_name not in watchers:
                     watchers[parameter_name] = {}
                 if what not in watchers[parameter_name]:
@@ -2849,16 +2849,16 @@ class ParameterizedMetaclass(type):
         # Give Parameterized classes a useful 'name' attribute.
         mcs.name = name
 
-        _parameters_state = {
+        parameters_state = {
             "BATCH_WATCH": False, # If true, Event and watcher objects are queued.
             "TRIGGER": False,
             "events": [], # Queue of batched events
             "watchers": [] # Queue of batched watchers
         }
-        _private = _ClassPrivate(
-            _parameters_state=_parameters_state,
+        _private__param = _ClassPrivate(
+            parameters_state=parameters_state,
         )
-        mcs._private = _private
+        mcs._private__param = _private__param
         mcs._param = Parameters(mcs)
 
         # All objects (with their names) of type Parameter that are
@@ -3310,16 +3310,16 @@ def recursive_repr(fillvalue='...'):
 class _ClassPrivate:
 
     __slots__ = [
-        '_parameters_state',
+        'parameters_state',
         '_disable_instance__params',
     ]
 
     def __init__(
         self,
-        _parameters_state=None,
+        parameters_state=None,
         _disable_instance__params=None,
     ):
-        self._parameters_state = _parameters_state
+        self.parameters_state = parameters_state
         self._disable_instance__params = _disable_instance__params
 
 
@@ -3327,25 +3327,25 @@ class _InstancePrivate:
 
     __slots__ = [
         'initialized',
-        '_parameters_state',
-        '_dynamic_watchers',
-        '_instance__params',
-        '_param_watchers',
+        'parameters_state',
+        'dynamic_watchers',
+        'instance_params',
+        'param_watchers',
     ]
 
     def __init__(
         self,
         initialized=None,
-        _parameters_state=None,
-        _dynamic_watchers=None,
-        _instance__params=None,
-        _param_watchers=None,
+        parameters_state=None,
+        dynamic_watchers=None,
+        instance_params=None,
+        param_watchers=None,
     ):
         self.initialized = initialized
-        self._parameters_state = _parameters_state
-        self._dynamic_watchers = _dynamic_watchers
-        self._instance__params = _instance__params
-        self._param_watchers = _param_watchers
+        self.parameters_state = parameters_state
+        self.dynamic_watchers = dynamic_watchers
+        self.instance_params = instance_params
+        self.param_watchers = param_watchers
 
 
 class Parameterized(metaclass=ParameterizedMetaclass):
@@ -3399,18 +3399,18 @@ class Parameterized(metaclass=ParameterizedMetaclass):
 
         # Flag that can be tested to see if e.g. constant Parameters
         # can still be set
-        _parameters_state = {
+        parameters_state = {
             "BATCH_WATCH": False, # If true, Event and watcher objects are queued.
             "TRIGGER": False,
             "events": [], # Queue of batched events
             "watchers": [] # Queue of batched watchers
         }
-        self._private = _InstancePrivate(
+        self._private__param = _InstancePrivate(
             initialized=False,
-            _parameters_state=_parameters_state,
-            _dynamic_watchers=defaultdict(list),
-            _instance__params={},
-            _param_watchers={},
+            parameters_state=parameters_state,
+            dynamic_watchers=defaultdict(list),
+            instance_params={},
+            param_watchers={},
         )
 
         self.param._generate_name()
@@ -3419,7 +3419,7 @@ class Parameterized(metaclass=ParameterizedMetaclass):
 
         self.param._update_deps(init=True)
 
-        self._private.initialized = True
+        self._private__param.initialized = True
 
     @property
     def param(self):
@@ -3453,17 +3453,17 @@ class Parameterized(metaclass=ParameterizedMetaclass):
 
         During this process the object is considered uninitialized.
         """
-        self._private = _InstancePrivate()
-        self._private.initialized = False
+        self._private__param = _InstancePrivate()
+        self._private__param.initialized = False
 
-        _private = state.get('_private', None)
-        if _private is None:
-            _private = _InstancePrivate()
+        _private__param = state.get('_private__param', None)
+        if _private__param is None:
+            _private__param = _InstancePrivate()
 
         # When making a copy the internal watchers have to be
         # recreated and point to the new instance
-        if getattr(_private, '_param_watchers', None) is not None:
-            param_watchers = _private._param_watchers
+        if getattr(_private__param, 'param_watchers', None) is not None:
+            param_watchers = _private__param.param_watchers
             for p, attrs in param_watchers.items():
                 for attr, watchers in attrs.items():
                     new_watchers = []
@@ -3479,15 +3479,15 @@ class Parameterized(metaclass=ParameterizedMetaclass):
                         new_watchers.append(Watcher(*watcher_args))
                     param_watchers[p][attr] = new_watchers
 
-        if getattr(_private, '_instance__params', None) is None:
-            _private._instance__params = {}
-        if getattr(_private, '_param_watchers', None) is None:
-            _private._param_watchers = {}
+        if getattr(_private__param, 'instance_params', None) is None:
+            _private__param.instance_params = {}
+        if getattr(_private__param, 'param_watchers', None) is None:
+            _private__param.param_watchers = {}
         state.pop('param', None)
 
         for name,value in state.items():
             setattr(self,name,value)
-        self._private.initialized = True
+        self._private__param.initialized = True
 
     @recursive_repr()
     def __repr__(self):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1763,9 +1763,8 @@ class Parameters:
         if cls is None: # Class not initialized
             raise AttributeError
 
-        try:
-            params = list(cls._param__private.params['_%s__params' % cls.__name__])
-        except KeyError:
+        params = list(cls._param__private.params)
+        if not params:
             params = [n for class_ in classlist(cls) for n, v in class_.__dict__.items()
                       if isinstance(v, Parameter)]
 
@@ -2017,10 +2016,7 @@ class Parameters:
         type.__setattr__(cls,param_name,param_obj)
         ParameterizedMetaclass._initialize_parameter(cls,param_name,param_obj)
         # delete cached params()
-        try:
-            delattr(cls._param__private, '_%s__params' % cls.__name__)
-        except AttributeError:
-            pass
+        cls._param__private.params.clear()
 
     # PARAM3_DEPRECATION
     @_deprecated(extra_msg="Use instead `.param.add_parameter`")
@@ -2135,9 +2131,8 @@ class Parameters:
         cls = self_.cls
         # We cache the parameters because this method is called often,
         # and parameters are rarely added (and cannot be deleted)
-        try:
-            pdict = cls._param__private.params[f'_{cls.__name__}__params']
-        except KeyError:
+        pdict = cls._param__private.params
+        if not pdict:
             paramdict = {}
             for class_ in classlist(cls):
                 for name, val in class_.__dict__.items():
@@ -2148,7 +2143,8 @@ class Parameters:
             # params() is called, so we mangle the name ourselves at
             # runtime (if we were to mangle it now, it would be
             # _Parameterized.__params for all classes).
-            cls._param__private.params[f'_{cls.__name__}__params'] = paramdict
+            # cls._param__private.params[f'_{cls.__name__}__params'] = paramdict
+            cls._param__private.params = paramdict
             pdict = paramdict
 
         if instance and self_.self is not None:

--- a/tests/testaddparameter.py
+++ b/tests/testaddparameter.py
@@ -89,12 +89,12 @@ def test_add_parameter_cache_cleared():
     # Generate the cache
     P.param.objects(instance=True)
 
-    assert 'x' in P._P__params
+    assert 'x' in P._param__private.params
 
     P.param.add_parameter('y', param.Parameter())
 
     # Check the cache has been removed (not sure why)
-    assert not hasattr(P, '_P__params')
+    assert not P._param__private.params
 
 
 def test_add_parameter_subclass():

--- a/tests/testaddparameter.py
+++ b/tests/testaddparameter.py
@@ -40,7 +40,6 @@ def test_add_parameter_class():
     assert 'y' in P.param
     # Check the name is set
     assert P.param.y.name == 'y'
-    assert P.param.y._internal_name == '_y_param_value'
 
 
 def test_add_parameter_instance():
@@ -53,7 +52,6 @@ def test_add_parameter_instance():
 
     assert 'y' in p.param
     assert p.param.y.name == 'y'
-    assert p.param.y._internal_name == '_y_param_value'
 
 
 def test_add_parameter_class_validation():

--- a/tests/testaddparameter.py
+++ b/tests/testaddparameter.py
@@ -40,6 +40,7 @@ def test_add_parameter_class():
     assert 'y' in P.param
     # Check the name is set
     assert P.param.y.name == 'y'
+    assert P.param.y._internal_name == '_y_param_value'
 
 
 def test_add_parameter_instance():
@@ -52,6 +53,7 @@ def test_add_parameter_instance():
 
     assert 'y' in p.param
     assert p.param.y.name == 'y'
+    assert p.param.y._internal_name == '_y_param_value'
 
 
 def test_add_parameter_class_validation():

--- a/tests/testdynamicparams.py
+++ b/tests/testdynamicparams.py
@@ -110,7 +110,7 @@ class TestDynamicParameterBasics(TestDynamicParameters):
     def test_setting_y_param_numbergen(self):
         self.TestPO2.y=numbergen.UniformRandom()  # now the Parameter instantiate should be true
         t9 = self.TestPO2()
-        self.assertEqual('_y_param_value' in t9.__dict__, True)
+        self.assertEqual('_y_param_value' in t9._param__private.values, True)
 
     def test_shared_numbergen(self):
         """

--- a/tests/testdynamicparams.py
+++ b/tests/testdynamicparams.py
@@ -110,7 +110,7 @@ class TestDynamicParameterBasics(TestDynamicParameters):
     def test_setting_y_param_numbergen(self):
         self.TestPO2.y=numbergen.UniformRandom()  # now the Parameter instantiate should be true
         t9 = self.TestPO2()
-        self.assertEqual('_y_param_value' in t9._param__private.values, True)
+        self.assertEqual('y' in t9._param__private.values, True)
 
     def test_shared_numbergen(self):
         """

--- a/tests/testdynamicparams.py
+++ b/tests/testdynamicparams.py
@@ -110,7 +110,7 @@ class TestDynamicParameterBasics(TestDynamicParameters):
     def test_setting_y_param_numbergen(self):
         self.TestPO2.y=numbergen.UniformRandom()  # now the Parameter instantiate should be true
         t9 = self.TestPO2()
-        self.assertEqual('y' in t9._param__private.values, True)
+        self.assertEqual('_y_param_value' in t9._param__private.values, True)
 
     def test_shared_numbergen(self):
         """

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1224,7 +1224,6 @@ def test_namespace_class():
     assert _dir(P) == [
         '_param__parameters',
         '_param__private',
-        '_repr_html_',
         'foo',
         'name',
         'param',
@@ -1247,7 +1246,6 @@ def test_namespace_inst():
         '_param__parameters',
         '_param__private',
         '_param_watchers',
-        '_repr_html_',
         'foo',
         'name',
         'param',

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1036,3 +1036,52 @@ def test_inheritance_parameter_attribute_without_default():
     with pytest.raises(KeyError, match="Slot 'foo' of parameter 'c' has no default value defined in `_slot_defaults`"):
         class A(param.Parameterized):
             c = CustomParameter()
+
+
+def _dir(obj):
+    return [attr for attr in dir(obj) if not attr.startswith('__')]
+
+
+def test_namespace_class():
+
+    class P(param.Parameterized):
+        x = param.Parameter()
+
+        @param.depends('x', watch=True)
+        def foo(self): pass
+
+    P.x = 1
+    P.param.x
+
+    assert _dir(P) == [
+        '_param__parameters',
+        '_param__private',
+        '_repr_html_',
+        'foo',
+        'name',
+        'param',
+        'x'
+    ]
+
+
+def test_namespace_inst():
+
+    class P(param.Parameterized):
+        x = param.Parameter()
+
+        @param.depends('x', watch=True)
+        def foo(self): pass
+
+    p = P(x=2)
+    p.param.x
+
+    assert _dir(p) == [
+        '_param__parameters',
+        '_param__private',
+        '_param_watchers',
+        '_repr_html_',
+        'foo',
+        'name',
+        'param',
+        'x'
+    ]

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1085,3 +1085,15 @@ def test_namespace_inst():
         'param',
         'x'
     ]
+
+
+def test_parameterized_access_param_before_super():
+    class P(param.Parameterized):
+        x = param.Parameter(1)
+
+        def __init__(self, **params):
+            # Reaching out to a Parameter default before calling super
+            assert self.x == 1
+            super().__init__(**params)
+
+    P()


### PR DESCRIPTION
At this stage this is more of a POC, that I wanted to share to see whether it's going in the right direction. The idea with this PR is to cleanup the private namespace of Parameterized classes and instances, mostly by defining a private namespace that we can defend and document, hopefully making it less likely for users to get name collisions. Some additional clean-up/renaming could also be done.

Take this example:

```python
import param

class A(param.Parameterized):
    x = param.Number()

a = A(x=2)
```

Ignoring dunder methods and some public & private API meant to be removed for Param 2.0 (https://github.com/holoviz/param/pull/767), these are the attributes (calling `dir()`) of `A` and `a` on the *main* branch currently:

`A`:
```
['_A__params',
 '_Parameterized__params',
 '_param',
 '_parameters_state',
 'name',
 'param',
 'x']
```

`a`:
```
['_A__params',
 '_Parameterized__params',
 '_dynamic_watchers',
 '_instance__params',
 '_name_param_value',
 '_param',
 '_param_watchers',
 '_parameters_state',
 '_x_param_value',
 'initialized',
 'name',
 'param',
 'x']
```

Among these:
- `_{{ClassName}}__params` (class+instance) are Parameter dicts, mangled directly by Param. The double underscore after the class name is good IMO as it makes name clashes a lot less likely https://github.com/holoviz/param/blob/154afe66ba57418ac5755af8688776f47b60657c/param/parameterized.py#L2127
- `_{{AttributeName}}_param_value`(instance) is the internal variable name that holds the current attribute value. It doesn't look too bad, the variable name including double underscore wouldn't hurt.
- `_param` (class+instance) is the reference to the class `Parameters` object, that is returned when you call `A.param` (on a Parameterized instance like `a` calling `a.param` returns every time a new `Parameters` instance). `_param` seems very prone to name clashes.
- `_parameters_state` (class+instance), `_dynamic_watchers` (instance), `_param_watchers` (instance), `_instance__params` (instance) and `initialized` (instance) are internal attributes. `initialized` is obviously the most embarrassing one, it's not private and is a pretty common variable name (@jlstevens  had a problem with that just recently).

What I have done in this PR so far is to:
- put the variables of the last item above under a private namespace (called `_param__private` for now) and adapted the code accordingly. I've renamed them under this namespace, removing their starting underscore.
- rename `_param` to `_param__parameters`

These are the updated namespaces after these changes:

`A`:
```
['_A__params',
 '_Parameterized__params',
 '_param__parameters',
 '_param__private',
 'name',
 'param',
 'x']
```

`a`:
```
['_A__params',
 '_Parameterized__params',
 '_name_param_value',
 '_param__parameters',
 '_param__private',
 '_x_param_value',
 'name',
 'param',
 'x']
```

Additional notes:
- The examples tests are currently failing due to Panel expecting somewhere the `initialized` attribute. I've also found 8 occurrences of `_param_watchers` being accessed in Panel and 1 in Lumen. Maybe there's a need for a public API to `_param_watchers`?
- There aren't that many tests around pickling/unpickling (1?), if we go forward with the suggested approach reviewers will have to look closely at `__setstate__` for instance.
- I'm not entirely sure about the implementation yet, at this stage I'm more interested in feedback on the general approach of putting (part of) the private API under a single private namespace. Of course, pieces of advice on the implementation will be appreciated!

EDIT:
- [x] Update docs
- [x] Update docstrings
- [x] Test pickling more
- [x] Benchmark
- [x] Update Panel
