### PR TITLE
More Param 2.0 API cleanup

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -562,9 +562,6 @@ class Time(Parameterized):
             raise StopIteration
         return self._time
 
-    # PARAM2_DEPRECATION: For Python 2 compatibility; can be removed for Python 3.
-    next = __next__
-
     def __call__(self, val=None, time_type=None):
         """
         When called with no arguments, returns the current time value.

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -2,6 +2,7 @@ import inspect
 import functools
 import warnings
 
+from textwrap import dedent
 from threading import get_ident
 
 
@@ -38,7 +39,9 @@ def _deprecated(extra_msg="", warning_cat=ParamDeprecationWarning):
         def inner(*args, **kwargs):
             msg = f"{func.__name__!r} has been deprecated and will be removed in a future version."
             if extra_msg:
-                msg = msg + ' ' + extra_msg
+                em = dedent(extra_msg)
+                em = em.strip().replace('\n', ' ')
+                msg = msg + ' ' + em
             warnings.warn(msg, category=warning_cat, stacklevel=2)
             return func(*args, **kwargs)
         return inner

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -2,6 +2,8 @@ import inspect
 import functools
 import warnings
 
+from threading import get_ident
+
 
 class ParamDeprecationWarning(DeprecationWarning):
     """Param DeprecationWarning"""
@@ -64,3 +66,25 @@ def _deprecate_positional_args(func):
         return func(*args, **kwargs)
 
     return inner
+
+
+# Copy of Python 3.2 reprlib's recursive_repr but allowing extra arguments
+def _recursive_repr(fillvalue='...'):
+    'Decorator to make a repr function return fillvalue for a recursive call'
+
+    def decorating_function(user_function):
+        repr_running = set()
+
+        def wrapper(self, *args, **kwargs):
+            key = id(self), get_ident()
+            if key in repr_running:
+                return fillvalue
+            repr_running.add(key)
+            try:
+                result = user_function(self, *args, **kwargs)
+            finally:
+                repr_running.discard(key)
+            return result
+        return wrapper
+
+    return decorating_function

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3382,8 +3382,8 @@ def pprint(val,imports=None, prefix="\n    ", settings=[],
     elif type(val) in script_repr_reg:
         rep = script_repr_reg[type(val)](val,imports,prefix,settings)
 
-    elif hasattr(val,'_pprint'):
-        rep=val._pprint(imports=imports, prefix=prefix+"    ",
+    elif isinstance(val, Parameterized) or (type(val) is type and issubclass(val, Parameterized)):
+        rep=val.param.pprint(imports=imports, prefix=prefix+"    ",
                         qualify=qualify, unknown_value=unknown_value,
                         separator=separator)
     else:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2873,7 +2873,6 @@ class Parameters:
             elif hasattr(g,'state_pop') and isinstance(g,Parameterized):
                 g.state_pop()
 
-    @_recursive_repr()
     def pprint(self_, imports=None, prefix=" ", unknown_value='<?>',
                qualify=False, separator=""):
         """
@@ -2882,7 +2881,16 @@ class Parameters:
         """
         self = self_.self_or_cls
         if not isinstance(self, Parameterized):
-            raise NotImplementedError('_pprint is not implemented at the class level')
+            raise NotImplementedError('pprint is not implemented at the class level')
+        # Wrapping the staticmethod _pprint with partial to pass `self` as the `_recursive_repr`
+        # decorator expects `self`` to be the pprinted object (not `self_`).
+        return partial(self_._pprint, self, imports=imports, prefix=prefix,
+                       unknown_value=unknown_value, qualify=qualify, separator=separator)()
+
+    @staticmethod
+    @_recursive_repr()
+    def _pprint(self, imports=None, prefix=" ", unknown_value='<?>',
+               qualify=False, separator=""):
         if imports is None:
             imports = [] # would have been simpler to use a set from the start
         imports[:] = list(set(imports))

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3553,18 +3553,6 @@ class Parameterized(metaclass=ParameterizedMetaclass):
         """Return a short representation of the name and class of this object."""
         return f"<{self.__class__.__name__} {self.name}>"
 
-    # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `.param.pprint()`")
-    def script_repr(self,imports=[],prefix="    "):
-        """
-        Deprecated variant of __repr__ designed for generating a runnable script.
-
-        ..deprecated:: 1.12.0
-            Use instead `.param.pprint()`
-        """
-        return self.pprint(imports,prefix, unknown_value=None, qualify=True,
-                           separator="\n")
-
 
 def print_all_param_defaults():
     """Print the default values for all imported Parameters."""
@@ -3754,19 +3742,6 @@ class ParameterizedFunction(Parameterized):
         # __main__. Pretty obscure aspect of pickle.py...
         return (_new_parameterized,(self.__class__,),state)
 
-    # PARAM3_DEPRECATION: Remove this compatibility alias for param 2.0 and later; use self.param.pprint instead
-    @_deprecated()
-    def script_repr(self,imports=[],prefix="    "):
-        """
-        Same as Parameterized.script_repr, except that X.classname(Y
-        is replaced with X.classname.instance(Y
-
-        ..deprecated:: 2.0.0
-        """
-        return self.pprint(imports,prefix,unknown_value='',qualify=True,
-                           separator="\n")
-
-
     def _pprint(self, imports=None, prefix="\n    ",unknown_value='<?>',
                 qualify=False, separator=""):
         """
@@ -3778,7 +3753,6 @@ class ParameterizedFunction(Parameterized):
                               qualify=qualify,separator=separator)
         classname=self.__class__.__name__
         return r.replace(".%s("%classname,".%s.instance("%classname)
-
 
 
 class default_label_formatter(ParameterizedFunction):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -28,7 +28,6 @@ from collections import defaultdict, namedtuple, OrderedDict
 from functools import partial, wraps, reduce
 from html import escape
 from operator import itemgetter, attrgetter
-from threading import get_ident
 from types import FunctionType, MethodType
 
 import logging
@@ -411,27 +410,19 @@ def get_method_owner(method):
     return method.__self__
 
 
+# PARAM3_DEPRECATION
 def recursive_repr(fillvalue='...'):
-    'Decorator to make a repr function return fillvalue for a recursive call'
-    # Copy of Python 3.2 reprlib's recursive_repr but allowing extra arguments
+    """
+    Decorator to make a repr function return fillvalue for a recursive call
 
-    def decorating_function(user_function):
-        repr_running = set()
-
-        @wraps(user_function)
-        def wrapper(self, *args, **kwargs):
-            key = id(self), get_ident()
-            if key in repr_running:
-                return fillvalue
-            repr_running.add(key)
-            try:
-                result = user_function(self, *args, **kwargs)
-            finally:
-                repr_running.discard(key)
-            return result
-        return wrapper
-
-    return decorating_function
+    ..deprecated:: 1.12.0
+    """
+    warnings.warn(
+        'recursive_repr has been deprecated and will be removed in a future version.',
+        category=_ParamDeprecationWarning,
+        stacklevel=2,
+    )
+    return _recursive_repr(fillvalue=fillvalue)
 
 
 @accept_arguments
@@ -1972,7 +1963,7 @@ class Parameters:
         return dep_obj.param._watch(
             mcaller, params, param_dep.what, queued=queued, precedence=-1)
 
-    @recursive_repr()
+    @_recursive_repr()
     def _repr_html_(self_, open=True):
         return _parameterized_repr_html(self_.self_or_cls, open)
 
@@ -3721,7 +3712,7 @@ class Parameterized(metaclass=ParameterizedMetaclass):
         return f"<{self.__class__.__name__} {self.name}>"
 
     @bothmethod
-    @recursive_repr()
+    @_recursive_repr()
     def _repr_html_(self_or_cls, open=True):
         return _parameterized_repr_html(self_or_cls, open)
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3745,7 +3745,7 @@ class ParameterizedFunction(Parameterized):
     def _pprint(self, imports=None, prefix="\n    ",unknown_value='<?>',
                 qualify=False, separator=""):
         """
-        Same as Parameters._pprint, except that X.classname(Y
+        Same as self.param.pprint, except that X.classname(Y
         is replaced with X.classname.instance(Y
         """
         r = self.param.pprint(imports,prefix,

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -94,6 +94,10 @@ class TestDeprecateParameterizedModule:
             @param.parameterized.add_metaclass(MC)
             class Base: pass
 
+    def test_deprecate_recursive_repr(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.parameterized.recursive_repr(lambda: '')
+
 
 class TestDeprecateParameters:
 

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -19,40 +19,184 @@ def specific_filter():
         yield
 
 
-def test_deprecate_posargs_Parameter():
-    with pytest.raises(param._utils.ParamPendingDeprecationWarning):
-        param.Parameter(1, 'doc')
+class TestDeprecateParameter:
+
+    def test_deprecate_posargs_Parameter(self):
+        with pytest.raises(param._utils.ParamPendingDeprecationWarning):
+            param.Parameter(1, 'doc')
+
+    def test_deprecate_List_class_(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.List(class_=int)
+
+    def test_deprecate_Number_set_hook(self):
+        class P(param.Parameterized):
+            n = param.Number(set_hook=lambda obj, val: val)
+
+        p = P()
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.n = 1
 
 
-def test_deprecate_List_class_():
-    with pytest.raises(param._utils.ParamDeprecationWarning):
-        param.List(class_=int)
+class TestDeprecateInitModule:
+
+    def test_deprecate_as_unicode(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.as_unicode(1)
+
+    def test_deprecate_is_ordered_dict(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.is_ordered_dict(dict())
+
+    def test_deprecate_produce_value(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.produce_value(1)
+
+    def test_deprecate_hasbable(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.hashable('s')
+
+    def test_deprecate_named_objs(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.named_objs(dict())
+
+    def test_deprecate_normalize_path(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.normalize_path()
+
+    def test_deprecate_abbreviate_path(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.abbreviate_paths()
 
 
-def test_deprecate_as_unicode():
-    with pytest.raises(param._utils.ParamDeprecationWarning):
-        param.as_unicode(1)
+class TestDeprecateParameterizedModule:
+
+    def test_deprecate_overridable_property(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            class Foo:
+                def _x(self): pass
+                x = param.parameterized.overridable_property(_x)
+
+    def test_deprecate_batch_watch(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            with param.parameterized.batch_watch(p):
+                pass
+
+    def test_deprecate_add_metaclass(self):
+        class MC(type): pass
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            @param.parameterized.add_metaclass(MC)
+            class Base: pass
 
 
-def test_deprecate_is_ordered_dict():
-    with pytest.raises(param._utils.ParamDeprecationWarning):
-        param.is_ordered_dict(dict())
+class TestDeprecateParameters:
 
+    def test_deprecate_print_param_defaults(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
 
-def test_deprecate_Number_set_hook():
-    class P(param.Parameterized):
-        n = param.Number(set_hook=lambda obj, val: val)
+        p = P()
 
-    p = P()
-    with pytest.raises(param._utils.ParamDeprecationWarning):
-        p.n = 1
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.print_param_defaults()
 
+    def test_deprecate_set_default(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
 
-def test_deprecate_overridable_property():
-    with pytest.raises(param._utils.ParamDeprecationWarning):
-        class A:
-            def __init__(self):
-                self._x = 1
-            def _get_x(self):
-                return self._x
-            x = param.parameterized.overridable_property(_get_x)
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            P.param.set_default('x', 1)
+
+    def test_deprecate__add_parameter(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            P.param._add_parameter('y', param.Parameter())
+
+    def test_deprecate_params(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.params()
+
+    def test_deprecate_set_param(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.set_param('x', 1)
+
+    def test_deprecate_get_param_values(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.get_param_values()
+
+    def test_deprecate_params_depended_on(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.params_depended_on()
+
+    def test_deprecate_defaults(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.defaults()
+
+    def test_deprecate_print_param_values(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.print_param_values()
+
+    def test_deprecate_message(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.message('test')
+
+    def test_deprecate_verbose(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.verbose('test')
+
+    def test_deprecate_debug(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        p = P()
+
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            p.param.debug('test')

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -309,10 +309,10 @@ class TestParameterized(unittest.TestCase):
         g._Dynamic_time_fn=None
         assert t.dyn!=t.dyn
         orig = t.dyn
-        t._state_push()
+        t.param._state_push()
         t.dyn
         assert t.param.inspect_value('dyn')!=orig
-        t.state_pop()
+        t.param._state_pop()
         assert t.param.inspect_value('dyn')==orig
 
     def test_label(self):

--- a/tests/testparameterizedrepr.py
+++ b/tests/testparameterizedrepr.py
@@ -131,6 +131,22 @@ class TestParameterizedRepr(unittest.TestCase):
         self.assertEqual(obj.param.pprint(),
                          "E(<?>, q=<?>, a=99)")
 
+    def testparameterizedscriptrepr_recursive(self):
+        class Q(param.Parameterized):
+            a = param.Number(default=39, bounds=(0,50), doc='Number a')
+            b = param.String(default="str", doc='A string')
+
+        class P(Q):
+            c = param.ClassSelector(default=Q(), class_=Q, doc='An instance of Q')
+            e = param.ClassSelector(default=param.Parameterized(), class_=param.Parameterized, doc='A Parameterized instance')
+            f = param.Range(default=(0,1), doc='A range')
+
+        p = P(f=(2,3), name="demo")
+        p.c = P(c=p)
+
+        assert p.param.pprint() == "P(c=P(c=...,     e=Parameterized()), e=Parameterized(), f=(2,3), name='demo')"
+
+
     def test_exceptions(self):
         obj = self.E(10,q='hi',a=99)
         try:


### PR DESCRIPTION
My priority with this PR was to further clean up the Parameterized namespace, following and even going further the dispositions suggested in https://github.com/holoviz/param/issues/543

- I looked through all the holoviz repos + examples for usage of `.pprint` or `._pprint` and found none, so I decided to remove them all together, using `.param.pprint()` was anyway the recommendation in the Version 1.12.0 release notes.
- The same search showed no usage of `.script_repr` that has been deleted from `Parameterized` and also from `ParameterizedFunction`.
- Instead of just deleting `.state_pop` in favor of `._state_pop`, I decided to move it (and `.state_push`) to `.param._state_pop`. This API isn't documented and was planned to be made private, this is why I chose to make it private on the `.param` namespace.

EDIT:
- Removed `Time.next` that was used for compatibility with Python 2