### PR TITLE
Fix watchers support when the Parameterized instance is falsey

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -619,7 +619,7 @@ def _params_depended_on(minfo, dynamic=True, intermediate=True):
     deps, dynamic_deps = [], []
     dinfo = getattr(minfo.method, "_dinfo", {})
     for d in dinfo.get('dependencies', list(minfo.cls.param)):
-        ddeps, ddynamic_deps = (minfo.inst or minfo.cls).param._spec_to_obj(d, dynamic, intermediate)
+        ddeps, ddynamic_deps = (minfo.inst if minfo.inst is not None else minfo.cls).param._spec_to_obj(d, dynamic, intermediate)
         dynamic_deps += ddynamic_deps
         for dep in ddeps:
             if isinstance(dep, PInfo):
@@ -1859,7 +1859,7 @@ class Parameters:
                     init_methods.append(m)
             elif dynamic:
                 for w in obj._dynamic_watchers.pop(method, []):
-                    (w.inst or w.cls).param.unwatch(w)
+                    (w.inst if w.inst is not None else w.cls).param.unwatch(w)
             else:
                 continue
 
@@ -1894,7 +1894,7 @@ class Parameters:
             subobj = getattr(subobj, subpath.split(':')[0], None)
             subobjs.append(subobj)
 
-        dep_obj = (param_dep.inst or param_dep.cls)
+        dep_obj = param_dep.inst if param_dep.inst is not None else param_dep.cls
         if dep_obj not in subobjs[:-1]:
             return None, None, param_dep.what
 
@@ -1930,7 +1930,7 @@ class Parameters:
         on the old subobject and create watchers on the new subobject.
         """
         dynamic_dep, param_dep = group[0]
-        dep_obj = (param_dep.inst or param_dep.cls)
+        dep_obj = param_dep.inst if param_dep.inst is not None else param_dep.cls
         params = []
         for _, g in group:
             if g.name not in params:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1930,7 +1930,7 @@ class Parameters:
         on the old subobject and create watchers on the new subobject.
         """
         dynamic_dep, param_dep = group[0]
-        dep_obj = param_dep.cls if param_dep.inst is None else param_dep.inst 
+        dep_obj = param_dep.cls if param_dep.inst is None else param_dep.inst
         params = []
         for _, g in group:
             if g.name not in params:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -619,7 +619,7 @@ def _params_depended_on(minfo, dynamic=True, intermediate=True):
     deps, dynamic_deps = [], []
     dinfo = getattr(minfo.method, "_dinfo", {})
     for d in dinfo.get('dependencies', list(minfo.cls.param)):
-        ddeps, ddynamic_deps = (minfo.inst if minfo.inst is not None else minfo.cls).param._spec_to_obj(d, dynamic, intermediate)
+        ddeps, ddynamic_deps = (minfo.cls if minfo.inst is None else minfo.inst).param._spec_to_obj(d, dynamic, intermediate)
         dynamic_deps += ddynamic_deps
         for dep in ddeps:
             if isinstance(dep, PInfo):
@@ -1859,7 +1859,7 @@ class Parameters:
                     init_methods.append(m)
             elif dynamic:
                 for w in obj._dynamic_watchers.pop(method, []):
-                    (w.inst if w.inst is not None else w.cls).param.unwatch(w)
+                    (w.cls if w.inst is None else w.inst).param.unwatch(w)
             else:
                 continue
 
@@ -1894,7 +1894,7 @@ class Parameters:
             subobj = getattr(subobj, subpath.split(':')[0], None)
             subobjs.append(subobj)
 
-        dep_obj = param_dep.inst if param_dep.inst is not None else param_dep.cls
+        dep_obj = param_dep.cls if param_dep.inst is None else param_dep.inst
         if dep_obj not in subobjs[:-1]:
             return None, None, param_dep.what
 
@@ -1930,7 +1930,7 @@ class Parameters:
         on the old subobject and create watchers on the new subobject.
         """
         dynamic_dep, param_dep = group[0]
-        dep_obj = param_dep.inst if param_dep.inst is not None else param_dep.cls
+        dep_obj = param_dep.cls if param_dep.inst is None else param_dep.inst 
         params = []
         for _, g in group:
             if g.name not in params:

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -820,6 +820,27 @@ class TestParamDepends(unittest.TestCase):
         assert method1_count == 0
         assert method2_count == 1
 
+    def test_param_depends_class_with_len(self):
+        # https://github.com/holoviz/param/issues/747
+
+        count = 0
+
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+            @param.depends('x', watch=True)
+            def debug(self):
+                nonlocal count
+                count += 1
+
+            # bool(P()) evaluates to False
+            def __len__(self):
+                return 0
+
+        p = P()
+        p.x = 1
+        assert count == 1
+
 
 class TestParamDependsFunction(unittest.TestCase):
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/747

`inst or cls` was used to select `cls` when `inst` was None, except that this fails when `inst` is not None and `inst` is falsey evaluates, as in the example reported in the issue where `__len__` is defined on a Parameterized class and returns `0`. This PR fixes a few occurrences of this bug.