### PR TITLE
Regression: Re-set instantiate to True when constant is True

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1240,8 +1240,10 @@ class Parameter(_ParameterBase):
         # having this code avoids needless instantiation.
         if self.readonly:
             self.instantiate = False
+        elif self.constant is True:
+            self.instantiate = True
         elif instantiate is not Undefined:
-            self.instantiate = instantiate or self.constant # pylint: disable-msg=W0201
+            self.instantiate = instantiate
         else:
             # Default value
             self.instantiate = self._slot_defaults['instantiate']

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -122,7 +122,7 @@ class TestParameterized(unittest.TestCase):
     def test_name_overriden(self):
         class P(param.Parameterized):
             name = param.String(default='other')
-        
+
         assert P.name == 'other'
 
         p = P()
@@ -134,10 +134,10 @@ class TestParameterized(unittest.TestCase):
             pass
         class B(param.Parameterized):
             name = param.String(doc='some help')
-        
+
         class C(B):
             pass
-        
+
         assert B.name == 'B'
         assert B.param.name.doc == 'some help'
         assert C.name == 'C'
@@ -146,7 +146,7 @@ class TestParameterized(unittest.TestCase):
     def test_name_overriden_constructor(self):
         class P(param.Parameterized):
             name = param.String(default='other')
-        
+
         p = P(name='another')
 
         assert p.name == 'another'
@@ -154,7 +154,7 @@ class TestParameterized(unittest.TestCase):
     def test_name_overriden_subclasses(self):
         class P(param.Parameterized):
             name = param.String(default='other')
-        
+
         class Q(P):
             pass
 
@@ -185,7 +185,7 @@ class TestParameterized(unittest.TestCase):
     def test_name_overriden_subclasses_name_set(self):
         class P(param.Parameterized):
             name = param.String(default='other')
-        
+
         class Q(P):
             pass
 
@@ -216,14 +216,14 @@ class TestParameterized(unittest.TestCase):
               "is only allowed with a 'String' Parameter."
 
         with pytest.raises(TypeError, match=msg):
-            class P(param.Parameterized):
+            class P(param.Parameterized):  # noqa
                 name = param.Parameter(default='other')
 
     def test_name_complex_hierarchy(self):
         class Mixin1: pass
         class Mixin2: pass
         class Mixin3(param.Parameterized): pass
-        
+
         class A(param.Parameterized, Mixin1): pass
         class B(A): pass
         class C(B, Mixin2): pass
@@ -238,7 +238,7 @@ class TestParameterized(unittest.TestCase):
         class Mixin1: pass
         class Mixin2: pass
         class Mixin3(param.Parameterized): pass
-        
+
         class A(param.Parameterized, Mixin1): pass
         class B(A):
             name = param.String(default='other')
@@ -258,7 +258,7 @@ class TestParameterized(unittest.TestCase):
             name = param.String(default='AA')
         class B(param.Parameterized):
             name = param.String(default='BB')
-        
+
         class C(A, B): pass
 
         assert C.name == 'AA'
@@ -273,6 +273,52 @@ class TestParameterized(unittest.TestCase):
         TestPO.const=9
         testpo = TestPO()
         self.assertEqual(testpo.const,9)
+
+    def test_parameter_constant_instantiate(self):
+        # instantiate is automatically set to True when constant=True
+        assert TestPO.param.const.instantiate is True
+
+        class C(param.Parameterized):
+            # instantiate takes precedence when True
+            a = param.Parameter(instantiate=True, constant=False)
+            b = param.Parameter(instantiate=False, constant=False)
+            c = param.Parameter(instantiate=False, constant=True)
+            d = param.Parameter(constant=True)
+            e = param.Parameter(constant=False)
+            f = param.Parameter()
+
+        assert C.param.a.constant is False
+        assert C.param.a.instantiate is True
+        assert C.param.b.constant is False
+        assert C.param.b.instantiate is False
+        assert C.param.c.constant is True
+        assert C.param.c.instantiate is True
+        assert C.param.d.constant is True
+        assert C.param.d.instantiate is True
+        assert C.param.e.constant is False
+        assert C.param.e.instantiate is False
+        assert C.param.f.constant is False
+        assert C.param.f.instantiate is False
+
+    def test_parameter_constant_instantiate_subclass(self):
+
+        obj = object()
+
+        class A(param.Parameterized):
+            x = param.Parameter(obj)
+
+        class B(param.Parameterized):
+            x = param.Parameter(constant=True)
+
+        assert A.param.x.constant is False
+        assert A.param.x.instantiate is False
+        assert B.param.x.constant is True
+        assert B.param.x.instantiate is True
+
+        a = A()
+        b = B()
+        assert a.x is obj
+        assert b.x is not obj
 
     def test_readonly_parameter(self):
         """Test that you can't set a read-only parameter on construction or as an attribute."""


### PR DESCRIPTION
Another evidence that it's quite easy to break Param despite its own test suite and the test suite of other packages heavily relying on it. This PR fixes a regression introduced in https://github.com/holoviz/param/pull/605, whereby setting constant to `True` was no longer automatically setting `instantiate` to True. I've added tests that would have passed on Param `1.13.0`.