### PR TITLE
Only build the fancy docstring when in an IPython context

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -38,11 +38,16 @@ from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
 from ._utils import _deprecated, _deprecate_positional_args, ParamDeprecationWarning as _ParamDeprecationWarning
 
 try:
-    # In case the optional ipython module is unavailable
-    from .ipython import ParamPager
-    param_pager = ParamPager(metaclass=True)  # Generates param description
-except:
+    get_ipython()
+except NameError:
     param_pager = None
+else:
+    # In case the optional ipython module is unavailable
+    try:
+        from .ipython import ParamPager
+        param_pager = ParamPager(metaclass=True)  # Generates param description
+    except:
+        param_pager = None
 
 from inspect import getfullargspec
 


### PR DESCRIPTION
I was a little surprised to see that Param was always building a docstring for IPython even not in an IPython context. This also came with some side-effects as the pager calls `.param.objects()` which leads to the Parameters being cached on the class:

https://github.com/holoviz/param/blob/b96169f0804fea72488914e1fc38e7c3dd9b9828/param/ipython.py#L63

This can only improve the performance of loading modules with lots of Parameterized classes that have lots of Parameters, no idea by how much though!

However, this of course also affects how the docstring look like in a non IPython context, e.g. in the Python REPL.

Before (colorized output):
```
>>> import param
>>> class P(param.Parameterized):
...   """The class docstring"""
...   x = param.Parameter()
... 
>>> p = P()
>>> print(p.__doc__)
params(x=Parameter, name=String)
The class docstring
Parameters of 'P'
=================

Parameters changed from their default values are marked in red.
Soft bound values are marked in cyan.
C/V= Constant/Variable, RO/RW = ReadOnly/ReadWrite, AN=Allow None

NameValue     Type      Mode  

x   None  Parameter  V RW AN 

Parameter docstrings:
=====================

x: < No docstring available >
```

With this change:
```
>>> import param
>>> class P(param.Parameterized):
...   """The class docstring"""
...   x = param.Parameter()
... 
>>> p = P()
>>> print(p.__doc__)
params(x=Parameter, name=String)
The class docstring
```
