### PR TITLE
Don't automatically set instantiate to True when constant is True

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1263,8 +1263,6 @@ class Parameter(_ParameterBase):
         # having this code avoids needless instantiation.
         if self.readonly:
             self.instantiate = False
-        # elif self.constant is True:
-        #     self.instantiate = True
         elif instantiate is not Undefined:
             self.instantiate = instantiate
         else:
@@ -1822,14 +1820,14 @@ class Parameters:
         """
         Initialize default and keyword parameter values.
 
-        First, ensures that all Parameters with 'instantiate=True'
-        (typically used for mutable Parameters) are copied directly
-        into each object, to ensure that there is an independent copy
-        (to avoid surprising aliasing errors).  Then sets each of the
-        keyword arguments, warning when any of them are not defined as
-        parameters.
-
-        Constant Parameters can be set during calls to this method.
+        First, ensures that all Parameters with 'instantiate=True' (typically
+        used for mutable Parameters) are copied directly into each object, to
+        ensure that there is an independent copy (to avoid surprising aliasing
+        errors). Second, ensures that Parameters with 'constant=True' are
+        referenced on the instance, to make sure that setting a constant
+        Parameter on the class doesn't affect already created instances. Then
+        sets each of the keyword arguments, raising when any of them are not
+        defined as parameters.
         """
         self = self_.param.self
         ## Deepcopy all 'instantiate=True' parameters
@@ -1872,8 +1870,9 @@ class Parameters:
         return not Comparator.is_equal(event.old, event.new)
 
     def _instantiate_param(self_, param_obj, dict_=None, key=None, deepcopy=True):
-        # deepcopy param_obj.default into self._param__private.values (or dict_ if supplied)
-        # under the parameter's name (or key if supplied)
+        # deepcopy or store a reference to reference param_obj.default into
+        # self._param__private.values (or dict_ if supplied) under the
+        # parameter's name (or key if supplied)
         instantiator = copy.deepcopy if deepcopy else lambda o: o
         self = self_.self
         dict_ = dict_ or self._param__private.values

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1258,8 +1258,8 @@ class Parameter(_ParameterBase):
         # having this code avoids needless instantiation.
         if self.readonly:
             self.instantiate = False
-        elif self.constant is True:
-            self.instantiate = True
+        # elif self.constant is True:
+        #     self.instantiate = True
         elif instantiate is not Undefined:
             self.instantiate = instantiate
         else:
@@ -1806,17 +1806,22 @@ class Parameters:
         ## Deepcopy all 'instantiate=True' parameters
         # (building a set of names first to avoid redundantly
         # instantiating a later-overridden parent class's parameter)
-        params_to_instantiate = {}
+        params_to_deepcopy = {}
+        params_to_ref = {}
         for class_ in classlist(type(self)):
             if not issubclass(class_, Parameterized):
                 continue
             for (k, v) in class_.param._parameters.items():
                 # (avoid replacing name with the default of None)
                 if v.instantiate and k != "name":
-                    params_to_instantiate[k] = v
+                    params_to_deepcopy[k] = v
+                elif v.constant and k != 'name':
+                    params_to_ref[k] = v
 
-        for p in params_to_instantiate.values():
+        for p in params_to_deepcopy.values():
             self.param._instantiate_param(p)
+        for p in params_to_ref.values():
+            self.param._instantiate_param(p, deepcopy=False)
 
         ## keyword arg setting
         for name, val in params.items():
@@ -1837,9 +1842,10 @@ class Parameters:
         """
         return not Comparator.is_equal(event.old, event.new)
 
-    def _instantiate_param(self_, param_obj, dict_=None, key=None):
+    def _instantiate_param(self_, param_obj, dict_=None, key=None, deepcopy=True):
         # deepcopy param_obj.default into self.__dict__ (or dict_ if supplied)
         # under the parameter's _internal_name (or key if supplied)
+        instantiator = copy.deepcopy if deepcopy else lambda o: o
         self = self_.self
         dict_ = dict_ or self.__dict__
         key = key or param_obj._internal_name
@@ -1848,10 +1854,10 @@ class Parameters:
             if param_key in shared_parameters._shared_cache:
                 new_object = shared_parameters._shared_cache[param_key]
             else:
-                new_object = copy.deepcopy(param_obj.default)
+                new_object = instantiator(param_obj.default)
                 shared_parameters._shared_cache[param_key] = new_object
         else:
-            new_object = copy.deepcopy(param_obj.default)
+            new_object = instantiator(param_obj.default)
 
         dict_[key] = new_object
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -263,6 +263,39 @@ class TestParameterized(unittest.TestCase):
 
         assert C.name == 'AA'
 
+    def test_constant_parameter_modify_class_before(self):
+        """Test you can set on class and the new default is picked up
+        by new instances"""
+        TestPO.const=9
+        testpo = TestPO()
+        self.assertEqual(testpo.const,9)
+
+    def test_constant_parameter_modify_class_after_init(self):
+        """Test that setting the value on the class doesn't update the instance value
+        even when the instance value hasn't yet been set"""
+        oobj = []
+        class P(param.Parameterized):
+            x = param.Parameter(default=oobj, constant=True)
+
+        p1 = P()
+
+        P.x = nobj = [0]
+        assert P.x is nobj
+        assert p1.x == oobj
+        # Because of instantiate=True when constant=True leading to a deepcopy
+        assert p1.x is not oobj
+
+        p2 = P()
+        assert p2.x == nobj
+        # Because of instantiate=True when constant=True leading to a deepcopy
+        assert p2.x is not nobj
+
+    def test_constant_parameter_after_init(self):
+        """Test that you can't set a constant parameter after construction."""
+        testpo = TestPO(const=17)
+        self.assertEqual(testpo.const,17)
+        self.assertRaises(TypeError,setattr,testpo,'const',10)
+
     def test_constant_parameter(self):
         """Test that you can't set a constant parameter after construction."""
         testpo = TestPO(const=17)

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -282,13 +282,11 @@ class TestParameterized(unittest.TestCase):
         P.x = nobj = [0]
         assert P.x is nobj
         assert p1.x == oobj
-        # Because of instantiate=True when constant=True leading to a deepcopy
-        assert p1.x is not oobj
+        assert p1.x is oobj
 
         p2 = P()
         assert p2.x == nobj
-        # Because of instantiate=True when constant=True leading to a deepcopy
-        assert p2.x is not nobj
+        assert p2.x is nobj
 
     def test_constant_parameter_after_init(self):
         """Test that you can't set a constant parameter after construction."""
@@ -307,51 +305,51 @@ class TestParameterized(unittest.TestCase):
         testpo = TestPO()
         self.assertEqual(testpo.const,9)
 
-    def test_parameter_constant_instantiate(self):
-        # instantiate is automatically set to True when constant=True
-        assert TestPO.param.const.instantiate is True
+    # def test_parameter_constant_instantiate(self):
+    #     # instantiate is automatically set to True when constant=True
+    #     assert TestPO.param.const.instantiate is True
 
-        class C(param.Parameterized):
-            # instantiate takes precedence when True
-            a = param.Parameter(instantiate=True, constant=False)
-            b = param.Parameter(instantiate=False, constant=False)
-            c = param.Parameter(instantiate=False, constant=True)
-            d = param.Parameter(constant=True)
-            e = param.Parameter(constant=False)
-            f = param.Parameter()
+    #     class C(param.Parameterized):
+    #         # instantiate takes precedence when True
+    #         a = param.Parameter(instantiate=True, constant=False)
+    #         b = param.Parameter(instantiate=False, constant=False)
+    #         c = param.Parameter(instantiate=False, constant=True)
+    #         d = param.Parameter(constant=True)
+    #         e = param.Parameter(constant=False)
+    #         f = param.Parameter()
 
-        assert C.param.a.constant is False
-        assert C.param.a.instantiate is True
-        assert C.param.b.constant is False
-        assert C.param.b.instantiate is False
-        assert C.param.c.constant is True
-        assert C.param.c.instantiate is True
-        assert C.param.d.constant is True
-        assert C.param.d.instantiate is True
-        assert C.param.e.constant is False
-        assert C.param.e.instantiate is False
-        assert C.param.f.constant is False
-        assert C.param.f.instantiate is False
+    #     assert C.param.a.constant is False
+    #     assert C.param.a.instantiate is True
+    #     assert C.param.b.constant is False
+    #     assert C.param.b.instantiate is False
+    #     assert C.param.c.constant is True
+    #     assert C.param.c.instantiate is True
+    #     assert C.param.d.constant is True
+    #     assert C.param.d.instantiate is True
+    #     assert C.param.e.constant is False
+    #     assert C.param.e.instantiate is False
+    #     assert C.param.f.constant is False
+    #     assert C.param.f.instantiate is False
 
-    def test_parameter_constant_instantiate_subclass(self):
+    # def test_parameter_constant_instantiate_subclass(self):
 
-        obj = object()
+    #     obj = object()
 
-        class A(param.Parameterized):
-            x = param.Parameter(obj)
+    #     class A(param.Parameterized):
+    #         x = param.Parameter(obj)
 
-        class B(param.Parameterized):
-            x = param.Parameter(constant=True)
+    #     class B(param.Parameterized):
+    #         x = param.Parameter(constant=True)
 
-        assert A.param.x.constant is False
-        assert A.param.x.instantiate is False
-        assert B.param.x.constant is True
-        assert B.param.x.instantiate is True
+    #     assert A.param.x.constant is False
+    #     assert A.param.x.instantiate is False
+    #     assert B.param.x.constant is True
+    #     assert B.param.x.instantiate is True
 
-        a = A()
-        b = B()
-        assert a.x is obj
-        assert b.x is not obj
+    #     a = A()
+    #     b = B()
+    #     assert a.x is obj
+    #     assert b.x is not obj
 
     def test_readonly_parameter(self):
         """Test that you can't set a read-only parameter on construction or as an attribute."""

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -305,52 +305,6 @@ class TestParameterized(unittest.TestCase):
         testpo = TestPO()
         self.assertEqual(testpo.const,9)
 
-    # def test_parameter_constant_instantiate(self):
-    #     # instantiate is automatically set to True when constant=True
-    #     assert TestPO.param.const.instantiate is True
-
-    #     class C(param.Parameterized):
-    #         # instantiate takes precedence when True
-    #         a = param.Parameter(instantiate=True, constant=False)
-    #         b = param.Parameter(instantiate=False, constant=False)
-    #         c = param.Parameter(instantiate=False, constant=True)
-    #         d = param.Parameter(constant=True)
-    #         e = param.Parameter(constant=False)
-    #         f = param.Parameter()
-
-    #     assert C.param.a.constant is False
-    #     assert C.param.a.instantiate is True
-    #     assert C.param.b.constant is False
-    #     assert C.param.b.instantiate is False
-    #     assert C.param.c.constant is True
-    #     assert C.param.c.instantiate is True
-    #     assert C.param.d.constant is True
-    #     assert C.param.d.instantiate is True
-    #     assert C.param.e.constant is False
-    #     assert C.param.e.instantiate is False
-    #     assert C.param.f.constant is False
-    #     assert C.param.f.instantiate is False
-
-    # def test_parameter_constant_instantiate_subclass(self):
-
-    #     obj = object()
-
-    #     class A(param.Parameterized):
-    #         x = param.Parameter(obj)
-
-    #     class B(param.Parameterized):
-    #         x = param.Parameter(constant=True)
-
-    #     assert A.param.x.constant is False
-    #     assert A.param.x.instantiate is False
-    #     assert B.param.x.constant is True
-    #     assert B.param.x.instantiate is True
-
-    #     a = A()
-    #     b = B()
-    #     assert a.x is obj
-    #     assert b.x is not obj
-
     def test_readonly_parameter(self):
         """Test that you can't set a read-only parameter on construction or as an attribute."""
         testpo = TestPO()

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -337,3 +337,13 @@ class TestSelectorParameters(unittest.TestCase):
         assert b.param.p.objects == [0, 1]
         assert b.param.p.default == 1
         assert b.param.p.check_on_set is True
+
+    def test_no_instantiate_when_constant(self):
+        # https://github.com/holoviz/param/issues/287
+        objs = [object(), object()]
+
+        class A(param.Parameterized):
+            p = param.Selector(default=objs[0], objects=objs, constant=True)
+
+        a = A()
+        assert a.p is objs[0]


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/287

Pushing this WIP PR to get some feedback on the approach. The idea is that when:
1. `instantiate` is `True` -> deepcopy `default` and assign it to the local cache (pseudo: `parameterized_obj._X_param_value = deepcopy(parameter.default)`)
2. `constant` is `True` -> don't deepcopy, just assign a reference to `default` to the local cache (pseudo: `parameterized_obj._X_param_value = parameter.default`)

With 1. taking precedence over 2.

The test added in https://github.com/holoviz/param/commit/7635d55e265b432417bad4ed5571fe4c84371037 and that is based on the one given in the issue passes with this change.

Of course this means that if the `default` object is mutable, any change made from a reference will be seen by all the other references, all pointing to the same updated object.

```python
import param

class A(param.Parameterized):
    x = param.Number(0)

a = A(name="AAA")

class B(param.Parameterized):
    y = param.ObjectSelector(a, constant=True)

b = B(name="BBB")

B.y.x = 1
print(b.y.x)
# 0 before this PR
# 1 with this PR

b.y.x = 2
print(B.y.x)
# 1 before this PR
# 2 with this PR
```

If reviewers are OK with this approach, I'll need to clean up the code and do some refactoring, it's a bit hacky right now.