### PR TITLE
Resolve non watched references too to catch bad references

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2898,12 +2898,11 @@ class ParameterizedMetaclass(type):
         for name, method, dinfo in dependers:
             watch = dinfo.get('watch', False)
             on_init = dinfo.get('on_init', False)
-            if not watch:
-                continue
             minfo = MInfo(cls=mcs, inst=None, name=name,
                           method=method)
             deps, dynamic_deps = _params_depended_on(minfo, dynamic=False)
-            _watch.append((name, watch == 'queued', on_init, deps, dynamic_deps))
+            if watch:
+                _watch.append((name, watch == 'queued', on_init, deps, dynamic_deps))
 
         # Resolve dependencies in class hierarchy
         _inherited = []

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -931,17 +931,13 @@ class TestParamDependsFunction(unittest.TestCase):
 
 
 def test_misspelled_parameter_in_depends():
-    class Example(param.Parameterized):
-        xlim = param.Range((0, 10), bounds=(0, 100))
-
-        @param.depends("tlim")  # <- Misspelled xlim
-        def test(self):
-            return True
-
-    example = Example()
     with pytest.raises(AttributeError, match="Attribute 'tlim' could not be resolved on"):
-        # Simulating: pn.panel(example.test)
-        example.param.method_dependencies(example.test.__name__)
+        class Example(param.Parameterized):
+            xlim = param.Range((0, 10), bounds=(0, 100))
+
+            @param.depends("tlim")  # <- Misspelled xlim
+            def test(self):
+                return True
 
 
 def test_misspelled_parameter_in_depends_watch():

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -940,6 +940,16 @@ def test_misspelled_parameter_in_depends():
                 return True
 
 
+def test_misspelled_parameter_in_depends_non_Parameter():
+    with pytest.raises(AttributeError, match="Attribute 'foo' could not be resolved on"):
+        class Example(param.Parameterized):
+            foo = 1
+
+            @param.depends("foo")  # <- Not a Parameter
+            def test(self):
+                return True
+
+
 def test_misspelled_parameter_in_depends_watch():
     with pytest.raises(AttributeError, match="Attribute 'tlim' could not be resolved on"):
         class Example(param.Parameterized):


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/357

@philippjfr I'm very far from being confident with this change.

This example:

```python
import param

class A(param.Parameterized):
    x = param.Number(0)

    @param.depends('y', watch=True)
    def debug(self): pass
```

Would immediately fail at the class creating time with:
```
Traceback (most recent call last):
  File ".mltmess/issue_params.py", line 47, in <module>
    class A(param.Parameterized):
  File "/Users/mliquet/dev/param/param/parameterized.py", line 2903, in __init__
    deps, dynamic_deps = _params_depended_on(minfo, dynamic=False)
  File "/Users/mliquet/dev/param/param/parameterized.py", line 640, in _params_depended_on
    ddeps, ddynamic_deps = (minfo.cls if minfo.inst is None else minfo.inst).param._spec_to_obj(d, dynamic, intermediate)
  File "/Users/mliquet/dev/param/param/parameterized.py", line 2592, in _spec_to_obj
    raise AttributeError(f"Attribute {attr!r} could not be resolved on {src}.")
AttributeError: Attribute 'y' could not be resolved on <class '__main__.A'>.
``` 