### PR TITLE
Make the rich repr only available on the `.param` namespace

### DIFF
--- a/examples/user_guide/Parameters.ipynb
+++ b/examples/user_guide/Parameters.ipynb
@@ -795,7 +795,7 @@
     "\n",
     "- `Parameterized.__str__()`: A concise, non-executable representation of the name and class of this object\n",
     "- `Parameterized.__repr__()`: A representation of this object and its parameter values as if it were Python code calling the constructor (`classname(parameter1=x,parameter2=y,...)`)\n",
-    "- `Parameterized._repr_html_()` and `Parameterize.param._repr_html_()`: A rich HTML representation of the object with its parameters listed in a table together with their metadata.\n",
+    "- `Parameterize.param._repr_html_()`: A rich HTML representation of the object with its parameters listed in a table together with their metadata.\n",
     "- `Parameterized.param.pprint()`: Customizable, hierarchical pretty-printed representation of this Parameterized and (recursively) any of its parameters that are Parameterized objects. See [Serialization and Persistence](Serialization_and_Persistence.ipynb) for details on customizing `pprint`."
    ]
   },
@@ -845,7 +845,7 @@
    "id": "799c1eeb-71c2-40a3-ad06-fd3ed8eda501",
    "metadata": {},
    "source": [
-    "The HTML representation of a `Parameterized` instance is automatically displayed in a Notebook. If the object you are displaying has overriden the `Parameterized._repr_html()` method to implement its own rich display - which is for instance the case for Panel components - call `.param` on your object to see its Param rich display."
+    "The HTML representation of a `Parameterized` instance or class is displayed when you call `<obj>.param` in a Notebook."
    ]
   },
   {
@@ -855,7 +855,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p  # or p.param"
+    "p.param"
    ]
   },
   {
@@ -865,7 +865,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "P  # or P.param"
+    "P.param"
    ]
   },
   {

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3719,11 +3719,6 @@ class Parameterized(metaclass=ParameterizedMetaclass):
         """Return a short representation of the name and class of this object."""
         return f"<{self.__class__.__name__} {self.name}>"
 
-    @bothmethod
-    @_recursive_repr()
-    def _repr_html_(self_or_cls, open=True):
-        return _parameterized_repr_html(self_or_cls, open)
-
 
 def print_all_param_defaults():
     """Print the default values for all imported Parameters."""


### PR DESCRIPTION
Following the discussion in https://github.com/holoviz/param/pull/425.