### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ${{ ( github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.ref_type == 'tag' ) ) && fromJSON('["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]') || fromJSON('["3.7", "3.9", "3.11"]') }}
+        python-version: ${{ ( github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.ref_type == 'tag' ) ) && fromJSON('["3.8", "3.9", "3.10", "3.11", "pypy3.9"]') || fromJSON('["3.8", "3.9", "3.11"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Make your Python code clearer and more reliable by declaring Parameters."
 readme = "README.md"
 license = { text = "BSD-3-Clause" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "HoloViz", email = "developers@holoviz.org" },
 ]
@@ -23,7 +23,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -155,7 +154,6 @@ dependencies = [
 
 [[tool.hatch.envs.tests.matrix]]
 python = [
-    "3.7",
     "3.8",
     "3.9",
     "3.10",
@@ -185,8 +183,8 @@ name."^(?!pypy).*".dependencies = [
 # Only install gmpy on Linux on these version
 # Only install tables (deser HDF5) on Linux on these version
 matrix.python.dependencies = [
-    { value = "gmpy", if = ["3.7", "3.8", "3.9", "3.10"], platform = ["linux"] },
-    { value = "tables", if = ["3.7", "3.8", "3.9", "3.10", "3.11"], platform = ["linux"] },
+    { value = "gmpy", if = ["3.8", "3.9", "3.10"], platform = ["linux"] },
+    { value = "tables", if = ["3.8", "3.9", "3.10", "3.11"], platform = ["linux"] },
 ]
 
 [tool.hatch.envs.tests_examples]
@@ -199,7 +197,6 @@ dependencies = [
 
 [[tool.hatch.envs.tests_examples.matrix]]
 python = [
-    "3.7",
     "3.8",
     "3.9",
     "3.10",


### PR DESCRIPTION
Bump the minimum required Python version to 3.8 as 3.7 reached EOL, per HEP1.