### PR TITLE
Validate that `'self'` is present in the init signature of a Parameterized class

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2911,9 +2911,9 @@ class Parameters:
         changed_params = self.param.values(onlychanged=script_repr_suppress_defaults)
         values = self.param.values()
         spec = getfullargspec(type(self).__init__)
-        if 'self' not in spec.args:
-            raise KeyError(f"'{type(self).__name__}.__init__.__signature__' must contain a 'self' Parameter.")
-        args = spec.args[1:] if spec.args[0] == 'self' else spec.args
+        if 'self' not in spec.args or spec.args[0] != 'self':
+            raise KeyError(f"'{type(self).__name__}.__init__.__signature__' must contain 'self' as its first Parameter.")
+        args = spec.args[1:]
 
         if spec.defaults is not None:
             posargs = spec.args[:-len(spec.defaults)]

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2910,8 +2910,10 @@ class Parameters:
 
         changed_params = self.param.values(onlychanged=script_repr_suppress_defaults)
         values = self.param.values()
-        spec = getfullargspec(self.__init__)
-        args = spec.args[1:] if ('self' in spec.args and spec.args[0] == 'self') else spec.args
+        spec = getfullargspec(type(self).__init__)
+        if 'self' not in spec.args:
+            raise KeyError(f"'{type(self).__name__}.__init__.__signature__' must contain a 'self' Parameter.")
+        args = spec.args[1:] if spec.args[0] == 'self' else spec.args
 
         if spec.defaults is not None:
             posargs = spec.args[:-len(spec.defaults)]

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2911,7 +2911,7 @@ class Parameters:
         changed_params = self.param.values(onlychanged=script_repr_suppress_defaults)
         values = self.param.values()
         spec = getfullargspec(self.__init__)
-        args = spec.args[1:] if spec.args[0] == 'self' else spec.args
+        args = spec.args[1:] if ('self' in spec.args and spec.args[0] == 'self') else spec.args
 
         if spec.defaults is not None:
             posargs = spec.args[:-len(spec.defaults)]

--- a/tests/testparameterizedrepr.py
+++ b/tests/testparameterizedrepr.py
@@ -230,8 +230,8 @@ def test_pprint_signature_overriden():
 
     t = T()
 
-    # This is actually setting the signature of param.Parameterized.__init__
-    # as P doesn't define __init__
+    # This is actually setting the signature of P.__init__
+    # as T doesn't define __init__
 
     # bad
     T.__init__.__signature__ = inspect.Signature(

--- a/tests/testparameterizedrepr.py
+++ b/tests/testparameterizedrepr.py
@@ -1,6 +1,7 @@
 """
 Unit test for the repr and pprint of parameterized objects, and for pprint/script_repr.
 """
+import inspect
 import unittest
 
 import param
@@ -217,3 +218,23 @@ def test_script_repr_parameterized_instance(P):
 
 def test_script_repr_parameterized_other():
     assert param.script_repr('2') == "\n\n'2'"
+
+
+def test_pprint_signature_overriden():
+    # https://github.com/holoviz/param/issues/785
+
+    class P(param.Parameterized): pass
+    class T(param.Parameterized): pass
+
+    try:
+        # This is actually setting the signature of param.Parameterized.__init__
+        # as P doesn't define __init__
+        P.__init__.__signature__ = inspect.Signature(
+            [inspect.Parameter('test', inspect.Parameter.KEYWORD_ONLY)]
+        )
+
+        # So T inherits that change
+        t = T()
+        assert t.param.pprint() == 'T()'
+    finally:
+        del param.Parameterized.__init__.__signature__

--- a/tests/testparameterizedrepr.py
+++ b/tests/testparameterizedrepr.py
@@ -225,16 +225,31 @@ def test_pprint_signature_overriden():
 
     class P(param.Parameterized): pass
     class T(param.Parameterized): pass
+    t = T()
 
     try:
         # This is actually setting the signature of param.Parameterized.__init__
         # as P doesn't define __init__
+
+        # bad
         P.__init__.__signature__ = inspect.Signature(
-            [inspect.Parameter('test', inspect.Parameter.KEYWORD_ONLY)]
+            [
+                inspect.Parameter('test', inspect.Parameter.KEYWORD_ONLY),
+            ]
         )
 
-        # So T inherits that change
-        t = T()
+        with pytest.raises(KeyError, match="'T.__init__.__signature__' must contain a 'self' Parameter."):
+            t.param.pprint()
+
+        # good
+        P.__init__.__signature__ = inspect.Signature(
+            [
+                inspect.Parameter('self', inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                inspect.Parameter('test', inspect.Parameter.KEYWORD_ONLY),
+            ]
+        )
+
         assert t.param.pprint() == 'T()'
+
     finally:
         del param.Parameterized.__init__.__signature__


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/785