### PR TITLE
Fix issues due to the Parameterized private namespace

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -845,15 +845,6 @@ class Watcher(_Watcher):
             values['precedence'] = 0
         return super().__new__(cls_, **values)
 
-    def __iter__(self):
-        """
-        Backward compatibility layer to allow tuple unpacking without
-        the precedence value. Important for Panel which creates a
-        custom Watcher and uses tuple unpacking. Will be dropped in
-        Param 3.x.
-        """
-        return iter(self[:-1])
-
     def __str__(self):
         cls = type(self)
         attrs = ', '.join([f'{f}={getattr(self, f)!r}' for f in cls._fields])
@@ -3649,6 +3640,13 @@ class _ClassPrivate:
         self.params = {} if params is None else params
         self.values = {} if values is None else params
 
+    def __getstate__(self):
+        return {slot: getattr(self, slot) for slot in self.__slots__}
+
+    def __setstate__(self, state):
+        for k, v in state.items():
+            setattr(self, k, v)
+
 
 class _InstancePrivate:
     """
@@ -3699,6 +3697,13 @@ class _InstancePrivate:
         self.params = {} if params is None else params
         # self.watchers = {} if watchers is None else watchers
         self.values = {} if values is None else values
+
+    def __getstate__(self):
+        return {slot: getattr(self, slot) for slot in self.__slots__}
+
+    def __setstate__(self, state):
+        for k, v in state.items():
+            setattr(self, k, v)
 
 
 class Parameterized(metaclass=ParameterizedMetaclass):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3615,6 +3615,9 @@ class _ClassPrivate:
         Whethe the class has been renamed by a super class
     params: dict
         Dict of parameter_name:parameter
+    values: dict
+        Dict of parameter_name:value, populated when a Parameter is set before
+        super().__init__ is called.
     """
 
     __slots__ = [
@@ -3622,6 +3625,7 @@ class _ClassPrivate:
         'disable_instance_params',
         'renamed',
         'params',
+        'values',
     ]
 
     def __init__(
@@ -3630,6 +3634,7 @@ class _ClassPrivate:
         disable_instance_params=False,
         renamed=False,
         params=None,
+        values=None,
     ):
         if parameters_state is None:
             parameters_state = {
@@ -3642,6 +3647,7 @@ class _ClassPrivate:
         self.disable_instance_params = disable_instance_params
         self.renamed = renamed
         self.params = {} if params is None else params
+        self.values = {} if values is None else params
 
 
 class _InstancePrivate:
@@ -3744,7 +3750,9 @@ class Parameterized(metaclass=ParameterizedMetaclass):
     def __init__(self, **params):
         global object_count
 
-        self._param__private = _InstancePrivate()
+        self._param__private = _InstancePrivate(
+            values=self._param__private.values.copy()
+        )
         self._param_watchers = {}
 
         # Skip generating a custom instance name when a class in the hierarchy

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3755,9 +3755,14 @@ class Parameterized(metaclass=ParameterizedMetaclass):
     def __init__(self, **params):
         global object_count
 
-        self._param__private = _InstancePrivate(
-            values=type(self)._param__private.values.copy()
-        )
+        # Setting a Parameter in an __init__ block before calling super().__init__
+        # fills `values` on the class private namespace, that has to be passed
+        # to the instance private namespace. `values` on the class is cleared
+        # as it's only meant to be transient data.
+        values = type(self)._param__private.values
+        cvalues = values.copy()
+        values.clear()
+        self._param__private = _InstancePrivate(values=cvalues)
         self._param_watchers = {}
 
         # Skip generating a custom instance name when a class in the hierarchy

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3751,7 +3751,7 @@ class Parameterized(metaclass=ParameterizedMetaclass):
         global object_count
 
         self._param__private = _InstancePrivate(
-            values=self._param__private.values.copy()
+            values=type(self)._param__private.values.copy()
         )
         self._param_watchers = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ python_files = "test*.py"
 filterwarnings = [
   "error",
 ]
+xfail_strict = "true"
 
 [tool.coverage.report]
 omit = ["param/version.py"]

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -393,6 +393,62 @@ class TestParameterized(unittest.TestCase):
         with self.assertRaises(ValueError):
             TestPOValidation.value = 10
 
+    def test_instantiation_set_before_super(self):
+        count = 0
+        class P(param.Parameterized):
+
+            x = param.Parameter(0)
+
+            def __init__(self, x=1):
+                self.x = x
+                super().__init__()
+
+            @param.depends('x', watch=True)
+            def cb(self):
+                nonlocal count
+                count += 1
+
+        p = P()
+
+        assert p.x == 1
+        assert count == 0
+
+    @pytest.mark.xfail(
+        raises=AttributeError,
+        reason='Behavior not defined when setting a constant parameter before calling super()',
+    )
+    def test_instantiation_set_before_super_constant(self):
+        count = 0
+        class P(param.Parameterized):
+
+            x = param.Parameter(0, constant=True)
+
+            def __init__(self, x=1):
+                self.x = x
+                super().__init__()
+
+            @param.depends('x', watch=True)
+            def cb(self):
+                nonlocal count
+                count += 1
+
+        p = P()
+
+        assert p.x == 1
+        assert count == 0
+
+    def test_instantiation_set_before_super_readonly(self):
+        class P(param.Parameterized):
+
+            x = param.Parameter(0, readonly=True)
+
+            def __init__(self, x=1):
+                self.x = x
+                super().__init__()
+
+        with pytest.raises(TypeError, match="Read-only parameter 'x' cannot be modified"):
+            P()
+
     def test_values(self):
         """Basic tests of params() method."""
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -412,6 +412,7 @@ class TestParameterized(unittest.TestCase):
 
         assert p.x == 1
         assert count == 0
+        assert not P._param__private.values
 
     @pytest.mark.xfail(
         raises=AttributeError,

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -438,6 +438,20 @@ class TestParameterized(unittest.TestCase):
         b = B()
         assert b.batched is True
 
+    def test_instantiation_param_objects_before_super_subclass(self):
+        # Testing https://github.com/holoviz/param/pull/420
+
+
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+            def __init__(self):
+                objs = self.param.objects(instance='existing')
+                assert isinstance(objs, dict)
+                super().__init__()
+
+        P()
+
     @pytest.mark.xfail(
         raises=AttributeError,
         reason='Behavior not defined when setting a constant parameter before calling super()',

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -449,6 +449,32 @@ class TestParameterized(unittest.TestCase):
         with pytest.raises(TypeError, match="Read-only parameter 'x' cannot be modified"):
             P()
 
+    def test_parameter_constant_iadd_allowed(self):
+        # Testing https://github.com/holoviz/param/pull/400
+        class P(param.Parameterized):
+
+            list = param.List([], constant=True)
+
+        p = P()
+        p.list += [1, 2, 3]
+
+        # Just to make sure that normal setting is still forbidden
+        with pytest.raises(TypeError, match="Constant parameter 'list' cannot be modified"):
+            p.list = [0]
+
+    def test_parameter_constant_same_notallowed(self):
+        L = [0, 1]
+        class P(param.Parameterized):
+
+            list = param.List(L, constant=True)
+
+        p = P()
+
+        # instantiate is set to true internally so a deepcopy is made of L,
+        # it's no longer the same object
+        with pytest.raises(TypeError, match="Constant parameter 'list' cannot be modified"):
+            p.list = L
+
     def test_values(self):
         """Basic tests of params() method."""
 

--- a/tests/testpickle.py
+++ b/tests/testpickle.py
@@ -29,24 +29,27 @@ class P1(param.Parameterized):
     x = param.Parameter()
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_simple_class(pickler):
-    s = pickler.dumps(P1)
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_simple_class(pickler, protocol):
+    s = pickler.dumps(P1, protocol=protocol)
     cls = pickler.loads(s)
     assert cls is P1
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_simple_instance(pickler):
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_simple_instance(pickler, protocol):
     p = P1()
-    s = pickler.dumps(p)
+    s = pickler.dumps(p, protocol=protocol)
     inst = pickler.loads(s)
     assert eq(p, inst)
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_simple_instance_modif_after(pickler):
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_simple_instance_modif_after(pickler, protocol):
     p = P1()
-    s = pickler.dumps(p)
+    s = pickler.dumps(p, protocol=protocol)
     p.x = 'modified'
     inst = pickler.loads(s)
     assert not eq(p, inst)
@@ -88,16 +91,18 @@ class P2(param.Parameterized):
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_all_parameters_class(pickler):
-    s = pickler.dumps(P2)
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_all_parameters_class(pickler, protocol):
+    s = pickler.dumps(P2, protocol=protocol)
     cls = pickler.loads(s)
     assert cls is P2
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_all_parameters_instance(pickler):
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_all_parameters_instance(pickler, protocol):
     p = P2()
-    s = pickler.dumps(p)
+    s = pickler.dumps(p, protocol=protocol)
     inst = pickler.loads(s)
     assert eq(p, inst)
 
@@ -112,17 +117,19 @@ class P3(param.Parameterized):
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_depends_watch_class(pickler):
-    s = pickler.dumps(P3)
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_depends_watch_class(pickler, protocol):
+    s = pickler.dumps(P3, protocol=protocol)
     cls = pickler.loads(s)
     assert cls is P3
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_depends_watch_instance(pickler):
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_depends_watch_instance(pickler, protocol):
     # https://github.com/holoviz/param/issues/757
     p = P3()
-    s = pickler.dumps(p)
+    s = pickler.dumps(p, protocol=protocol)
     inst = pickler.loads(s)
     assert eq(p, inst)
 
@@ -167,27 +174,30 @@ class P4(param.Parameterized):
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_complex_depends_class(pickler):
-    s = pickler.dumps(P4)
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_complex_depends_class(pickler, protocol):
+    s = pickler.dumps(P4, protocol=protocol)
     cls = pickler.loads(s)
     assert cls is P4
 
 
 @pytest.mark.parametrize('pickler', [cloudpickle, pickle], indirect=True)
-def test_pickle_complex_depends_instance(pickler):
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_pickle_complex_depends_instance(pickler, protocol):
     p = P4()
-    s = pickler.dumps(p)
+    s = pickler.dumps(p, protocol=protocol)
     inst = pickler.loads(s)
     assert eq(p, inst)
 
 
 @pytest.mark.skipif(cloudpickle is None, reason='cloudpickle not available')
-def test_issue_757():
+@pytest.mark.parametrize('protocol', [0, pickle.DEFAULT_PROTOCOL, pickle.HIGHEST_PROTOCOL])
+def test_issue_757(protocol):
     # https://github.com/holoviz/param/issues/759
     class P(param.Parameterized):
         a = param.Parameter()
 
     p = P()
-    s = cloudpickle.dumps(p)
+    s = cloudpickle.dumps(p, protocol=protocol)
     inst = cloudpickle.loads(s)
     assert eq(p, inst)


### PR DESCRIPTION
https://github.com/holoviz/param/pull/766 was merged too quickly, running the HoloViews test suite locally revealed a bunch of new errors:

- setting an attribute in the `__init__` **before** calling `super().__init__` wasn't exerted in Param's test suite but leveraged in HoloViews (https://github.com/holoviz/holoviews/blob/a64cfc544acc94b3806d427912047ca660253587/holoviews/plotting/plot.py#L1168). This is now supported again and tested.
- the private namespace broke pickling when the protocol `0` is used which is apparently used by HoloViews in some cases. This PR fixes the support for that protocol, at least in the sense that the HoloViews unit test suite should now pass. To complete that fix, I have had to remove the compatibility code on `Watcher` that allowed to exclude `precedence` while unpacking (added in https://github.com/holoviz/param/pull/557). I believe that compatibility code is no longer required for Panel. The code in Param was released in 1.12.0 and Panel 0.13.0, which depended on Param >= 1.12.0, was released with updated code that no longer required the compatibility code (https://github.com/holoviz/panel/pull/2809). I had to remove that code as, I think, `__iter__` was called both when pickling and unpickling, resulting in the last two attributes being filtered out (error I got: `TypeError: __new__() missing 1 required positional argument: 'queued'`). I would hope no other Param dependents relied on that compatibility code like Panel used to do, and if they did I don't feel too bad breaking that for Param 2.0.
---

Working on these fixes I have stumbled upon this PR https://github.com/holoviz/param/pull/400 which had no tests, I have added some (thinking about another WIP PR that touches constant/instantiate too)