### PR TITLE
Fix regression that ignored `allow_None` set in a selector

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1691,6 +1691,8 @@ class Selector(SelectorBase, _SignatureSelector):
         # Required as Parameter sets allow_None=True if default is None
         if allow_None is Undefined:
             self.allow_None = self._slot_defaults['allow_None']
+        else:
+            self.allow_None = allow_None
         if self.default is not None and self.check_on_set is True:
             self._validate(self.default)
 

--- a/tests/testobjectselector.py
+++ b/tests/testobjectselector.py
@@ -10,6 +10,7 @@ import unittest
 from collections import OrderedDict
 
 import param
+import pytest
 
 from .utils import check_defaults
 
@@ -103,6 +104,51 @@ class TestObjectSelectorParameters(unittest.TestCase):
         s = param.ObjectSelector(objects=[0, 1, 2])
 
         assert s.allow_None is None
+
+    def test_allow_None_set_and_behavior_class(self):
+        class P(param.Parameterized):
+            a = param.ObjectSelector(objects=dict(a=1), allow_None=True)
+            b = param.ObjectSelector(objects=dict(a=1), allow_None=False)
+            c = param.ObjectSelector(default=1, objects=dict(a=1), allow_None=True)
+            d = param.ObjectSelector(default=1, objects=dict(a=1), allow_None=False)
+
+        assert P.param.a.allow_None is True
+        assert P.param.b.allow_None is False
+        assert P.param.c.allow_None is True
+        assert P.param.d.allow_None is False
+
+        P.a = None
+        assert P.a is None
+        with pytest.raises(ValueError):
+            P.b = None
+        P.c = None
+        assert P.c is None
+        with pytest.raises(ValueError):
+            P.d = None
+
+    def test_allow_None_set_and_behavior_instance(self):
+        class P(param.Parameterized):
+            a = param.ObjectSelector(objects=dict(a=1), allow_None=True)
+            b = param.ObjectSelector(objects=dict(a=1), allow_None=False)
+            c = param.ObjectSelector(default=1, objects=dict(a=1), allow_None=True)
+            d = param.ObjectSelector(default=1, objects=dict(a=1), allow_None=False)
+
+        p = P()
+
+        assert p.param.a.allow_None is True
+        assert p.param.b.allow_None is False
+        assert p.param.c.allow_None is True
+        assert p.param.d.allow_None is False
+
+        p.a = None
+        assert p.a is None
+        with pytest.raises(ValueError):
+            p.b = None
+        p.c = None
+        assert p.c is None
+        with pytest.raises(ValueError):
+            p.d = None
+
 
     def test_set_object_constructor(self):
         p = self.P(e=6)

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -9,8 +9,9 @@ import unittest
 from collections import OrderedDict
 
 import param
+import pytest
 
-from.utils import check_defaults
+from .utils import check_defaults
 
 opts=dict(A=[1,2],B=[3,4],C=dict(a=1,b=2))
 
@@ -102,6 +103,50 @@ class TestSelectorParameters(unittest.TestCase):
         assert p.param.i.allow_None is None
         assert p.param.s.allow_None is None
         assert p.param.d.allow_None is None
+
+    def test_allow_None_set_and_behavior_class(self):
+        class P(param.Parameterized):
+            a = param.Selector(objects=dict(a=1), allow_None=True)
+            b = param.Selector(objects=dict(a=1), allow_None=False)
+            c = param.Selector(default=1, objects=dict(a=1), allow_None=True)
+            d = param.Selector(default=1, objects=dict(a=1), allow_None=False)
+
+        assert P.param.a.allow_None is True
+        assert P.param.b.allow_None is False
+        assert P.param.c.allow_None is True
+        assert P.param.d.allow_None is False
+
+        P.a = None
+        assert P.a is None
+        with pytest.raises(ValueError):
+            P.b = None
+        P.c = None
+        assert P.c is None
+        with pytest.raises(ValueError):
+            P.d = None
+
+    def test_allow_None_set_and_behavior_instance(self):
+        class P(param.Parameterized):
+            a = param.Selector(objects=dict(a=1), allow_None=True)
+            b = param.Selector(objects=dict(a=1), allow_None=False)
+            c = param.Selector(default=1, objects=dict(a=1), allow_None=True)
+            d = param.Selector(default=1, objects=dict(a=1), allow_None=False)
+
+        p = P()
+
+        assert p.param.a.allow_None is True
+        assert p.param.b.allow_None is False
+        assert p.param.c.allow_None is True
+        assert p.param.d.allow_None is False
+
+        p.a = None
+        assert p.a is None
+        with pytest.raises(ValueError):
+            p.b = None
+        p.c = None
+        assert p.c is None
+        with pytest.raises(ValueError):
+            p.d = None
 
     def test_autodefault(self):
         class P(param.Parameterized):


### PR DESCRIPTION
Discovered that the sentinel PR introduced a regression, ignoring the value of `allow_None` (which is always a little controversial to use with selectors and you can just add `None` to the objects list) set in the Parameter constructor.