### PR TITLE
Populate `objects` when `check_on_set` is False and `default` is not in `objects`

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1695,6 +1695,15 @@ class Selector(SelectorBase, _SignatureSelector):
             self.allow_None = allow_None
         if self.default is not None and self.check_on_set is True:
             self._validate(self.default)
+        self._update_state()
+
+    def _update_state(self):
+        if (
+            self.check_on_set is False
+            and self.default is not None
+            and self.default not in self.objects
+        ):
+            self.objects.append(self.default)
 
     @property
     def objects(self):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1328,6 +1328,12 @@ class Parameter(_ParameterBase):
         attribute is set.
         """
 
+    def _update_state(self):
+        """
+        Can be overridden on subclasses to update a Parameter state, i.e. slot
+        values, after the slot values have been set in the inheritance procedure.
+        """
+
     def __get__(self, obj, objtype): # pylint: disable-msg=W0613
         """
         Return the value for this Parameter.
@@ -3309,6 +3315,10 @@ class ParameterizedMetaclass(type):
         # (which are only allowed to use static values or results are undefined)
         for slot, fn in callables.items():
             setattr(param, slot, fn(param))
+
+        # Once all the slot values have been set, call _update_state for Parameters
+        # that need updates to make sure they're set up correctly after inheritance.
+        param._update_state()
 
     def get_param_descriptor(mcs,param_name):
         """

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -248,6 +248,38 @@ class TestSelectorParameters(unittest.TestCase):
         else:
             raise AssertionError("Selector created without range.")
 
+    def test_check_on_set_on_init_unbound(self):
+
+        i = param.Selector(default=7, objects=[9], check_on_set=False)
+        h = param.Selector(default=None)
+
+        assert i.objects == [9, 7]
+        assert h.objects == []
+
+    @pytest.mark.xfail(raises=AssertionError)
+    def test_check_on_set_on_init_unbound_unsupported(self):
+        # Tricky to update the objects to contain the default on an unbound
+        # Selector as in that case the objects is always an empty list, that
+        # is returned by the objects factory.
+
+        f = param.Selector(default=10)
+
+        assert f.objects == [10]
+
+    def test_check_on_set_on_init_class(self):
+
+        assert self.P.param.i.objects == [9, 7]
+        assert self.P.param.f.objects == [10]
+        assert self.P.param.h.objects == []
+
+    def test_check_on_set_on_init_instance(self):
+
+        p = self.P()
+
+        assert p.param.i.objects == [9, 7]
+        assert p.param.f.objects == [10]
+        assert p.param.h.objects == []
+
     def test_check_on_set_defined(self):
         class P(param.Parameterized):
             o1 = param.Selector(check_on_set=True)
@@ -382,6 +414,24 @@ class TestSelectorParameters(unittest.TestCase):
         assert b.param.p.objects == [0, 1]
         assert b.param.p.default == 1
         assert b.param.p.check_on_set is True
+
+    def test_inheritance_behavior7(self):
+        class A(param.Parameterized):
+            p = param.Selector(default=0)
+
+        class B(A):
+            p = param.Selector(default=1)
+
+        assert B.param.p.objects == [0, 1]
+        assert B.param.p.default == 1
+        assert B.param.p.check_on_set is False
+
+        b = B()
+
+        assert b.param.p.objects == [0, 1]
+        assert b.param.p.default == 1
+        assert b.param.p.check_on_set is False
+
 
     def test_no_instantiate_when_constant(self):
         # https://github.com/holoviz/param/issues/287


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/693

It's been pretty tricky to implement as `Selector` isn't the easiest Parameter to deal with (its setup is quite dynamic) and handling slot values inheritance for it adds an extra level of complexity. The approach I've opted for is to add a method to `Parameter` that subclasses can implement and that is called only after slot values inheritance has completed, to update the Parameter state. In that case, it's used to add the `default` value to `objects` when `check_on_set` is False and `default` is not in there.

 I haven't managed to get that to work together with the unbound case so I marked that test as xfailed https://github.com/holoviz/param/compare/fix_checkonset_default?expand=1#diff-df60be25aab735646b74b0a737306d420bec4718b0dadd8323fe8e5c31e67995R259-R267

Overall, I'm not quite sure how I feel about this PR. `Selector` has quite a number of issues and it's always easier to add some new behavior rather than removing it. Also, it's easy to miss edge cases with the various combinations of Selector attributes when in an inheritance context. I tend to think that the status-quo is probably a better option, I'm interested in feedback anyway!