### PR TITLE
Fix `param.pprint` for `Array` parameters by replacing `all_equal` with `Comparator.is_equal` in `values()`

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -1,5 +1,6 @@
 import inspect
 import functools
+import re
 import warnings
 
 from textwrap import dedent
@@ -109,3 +110,7 @@ def _recursive_repr(fillvalue='...'):
         return wrapper
 
     return decorating_function
+
+
+def _is_auto_name(class_name, instance_name):
+    return re.match('^'+class_name+'[0-9]{5}$', instance_name)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -287,6 +287,8 @@ def get_occupied_slots(instance):
             if hasattr(instance,slot)]
 
 
+# PARAM3_DEPRECATION
+@_deprecated()
 def all_equal(arg1,arg2):
     """
     Return a single boolean for arg1==arg2, even for numpy arrays

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -98,6 +98,9 @@ class TestDeprecateParameterizedModule:
         with pytest.raises(param._utils.ParamDeprecationWarning):
             param.parameterized.recursive_repr(lambda: '')
 
+    def test_deprecate_all_equal(self):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
+            param.parameterized.all_equal(1, 1)
 
 class TestDeprecateParameters:
 

--- a/tests/testnumpy.py
+++ b/tests/testnumpy.py
@@ -73,3 +73,10 @@ class TestNumpy(unittest.TestCase):
 
         z = Z(z=numpy.array([1,2]))
         _is_array_and_equal(z.z,[1,2])
+
+    def test_array_pprint(self):
+        class MatParam(param.Parameterized):
+            mat = param.Array(numpy.zeros((2, 2)))
+
+        mp = MatParam()
+        mp.param.pprint()

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -391,7 +391,7 @@ class TestParameterized(unittest.TestCase):
         assert 'inst' in TestPO.param.values()
         assert 'notinst' in TestPO.param.values()
 
-    def test_values_name_ignored_for_intances_and_onlychanged(self):
+    def test_values_name_ignored_for_instances_and_onlychanged(self):
         default_inst = param.Parameterized()
         assert 'Parameterized' in default_inst.name
         # name ignored when automatically computed (behavior inherited from all_equal)

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -391,6 +391,14 @@ class TestParameterized(unittest.TestCase):
         assert 'inst' in TestPO.param.values()
         assert 'notinst' in TestPO.param.values()
 
+    def test_values_name_ignored_for_intances_and_onlychanged(self):
+        default_inst = param.Parameterized()
+        assert 'Parameterized' in default_inst.name
+        # name ignored when automatically computed (behavior inherited from all_equal)
+        assert 'name' not in default_inst.param.values(onlychanged=True)
+        # name not ignored when set
+        assert param.Parameterized(name='foo').param.values(onlychanged=True)['name'] == 'foo'
+
     def test_param_iterator(self):
         self.assertEqual(set(TestPO.param), {'name', 'inst', 'notinst', 'const', 'dyn',
                                              'ro', 'ro2', 'ro_label', 'ro_format'})


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/606
Fixes https://github.com/holoviz/param/issues/179
Supersedes https://github.com/holoviz/param/pull/437

I chose to replace `all_equals` in `.param.values` by `Comparator.is_equal`, which then needed to be extended to deal with objects that have the `_infinitely_iterable` attribute (`Time`). I've had to change the code in `is_equal` a little to fix the support for `predicate: equality`.

As a reminder (https://github.com/holoviz/param/issues/179#issuecomment-362818251), `all_equal` has this weird behavior that `all_equal('aaaa', 'aa')` is True. That behavior is relied upon (intentionally I guess) by `.param.values(onlychanged=True)` so that the Parameterized instance auto-generated name is filtered out of the returned values. I copied code from https://github.com/holoviz/param/pull/437 to make sure that this behavior is preserved. Because it's no longer used, I have deprecated `all_equals`.

https://github.com/holoviz/param/pull/437 was discussing a bit more some API to decide whether you want to auto-suppress `name` or not. I have decided not to deal with that in this PR that is focused on fixing the linked issues.

https://github.com/holoviz/param/pull/437 also discussed how to deal with comparing numpy arrays. As indeed if `.param.pprint()` now works with `Array` Parameters it will always include the default array, as the comparator doesn't handle this object type.  I actually started to work on that and later realized this is a can of worms :)