### PR TITLE
Remove Parameter `_internal_name` slot

### DIFF
--- a/examples/user_guide/How_Param_Works.ipynb
+++ b/examples/user_guide/How_Param_Works.ipynb
@@ -66,9 +66,10 @@
     "Using `__slots__` requires special support for operations to copy and restore Parameters (e.g. for Python persistent storage pickling); see `__getstate__` and `__setstate__`. A Parameter defines at least these slots, with additional slots added for each subclass:\n",
     "\n",
     "```\n",
-    "__slots__ = ['name', '_internal_name', 'default', 'doc', 'precedence', \n",
-    "             'instantiate', 'constant', 'readonly', 'pickle_default_value',\n",
-    "             'allow_None', 'per_instance', 'watchers', 'owner', '_label']\n",
+    "__slots__ = ['name', 'default', 'doc',\n",
+    "            'precedence', 'instantiate', 'constant', 'readonly',\n",
+    "            'pickle_default_value', 'allow_None', 'per_instance',\n",
+    "            'watchers', 'owner', '_label']\n",
     "```\n",
     "\n",
     "In most cases, you can just treat a Parameter's existing slots like attributes of the Parameter class; they work just the same as regular attributes except for speed and storage space. However, if you add a _new_ attribute to a Parameter class, you have to make sure that you also add it to the `__slots__` defined for that Parameter class, or you'll either get an error or else the Parameter will get an unnecessary full `__dict__` object just to hold the one new attribute. "

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1093,7 +1093,7 @@ class Parameter(_ParameterBase):
     # attributes.  Using __slots__ requires special support for
     # operations to copy and restore Parameters (e.g. for Python
     # persistent storage pickling); see __getstate__ and __setstate__.
-    __slots__ = ['name', '_internal_name', 'default', 'doc',
+    __slots__ = ['name', 'default', 'doc',
                  'precedence', 'instantiate', 'constant', 'readonly',
                  'pickle_default_value', 'allow_None', 'per_instance',
                  'watchers', 'owner', '_label']
@@ -1101,7 +1101,7 @@ class Parameter(_ParameterBase):
     # Note: When initially created, a Parameter does not know which
     # Parameterized class owns it, nor does it know its names
     # (attribute name, internal name). Once the owning Parameterized
-    # class is created, owner, name, and _internal_name are
+    # class is created, owner, and name are
     # set.
 
     _serializers = {'json': serializer.JSONSerialization}
@@ -1207,7 +1207,6 @@ class Parameter(_ParameterBase):
         self.constant = constant is True or readonly is True # readonly => constant
         self.readonly = readonly
         self._label = label
-        self._internal_name = None
         self._set_instantiate(instantiate)
         self.pickle_default_value = pickle_default_value
         self._set_allow_None(allow_None)
@@ -1472,7 +1471,6 @@ class Parameter(_ParameterBase):
                                  'instance for each new class.'.format(type(self).__name__, self.name,
                                     self.owner.name, attrib_name))
         self.name = attrib_name
-        self._internal_name = "_%s_param_value" % attrib_name
 
     def __getstate__(self):
         """

--- a/tests/testaddparameter.py
+++ b/tests/testaddparameter.py
@@ -40,7 +40,6 @@ def test_add_parameter_class():
     assert 'y' in P.param
     # Check the name is set
     assert P.param.y.name == 'y'
-    assert P.param.y._internal_name == '_y_param_value'
 
 
 def test_add_parameter_instance():
@@ -53,7 +52,6 @@ def test_add_parameter_instance():
 
     assert 'y' in p.param
     assert p.param.y.name == 'y'
-    assert p.param.y._internal_name == '_y_param_value'
 
 
 def test_add_parameter_class_validation():


### PR DESCRIPTION
The private namespace work made this internal slot useless.