### PR TITLE
Deprecate `._param_watchers` in favor of `.param.watchers`

### DIFF
--- a/examples/user_guide/Dependencies_and_Watchers.ipynb
+++ b/examples/user_guide/Dependencies_and_Watchers.ipynb
@@ -556,6 +556,7 @@
     "- [`batch_call_watchers`](#batch_call_watchers): context manager accumulating and eliding multiple Events to be applied on exit from the context \n",
     "- [`discard_events`](#discard_events): context manager silently discarding events generated while in the context\n",
     "- [`.param.trigger`](#.param.trigger): method to force creation of an Event for this Parameter's Watchers without a corresponding change to the Parameter\n",
+    "- [`.param.watchers`](#.param.watchers): writable property to access the instance watchers\n",
     "- [Event Parameter](#Event-Parameter): Special Parameter type providing triggerable transient Events (like a momentary push button)\n",
     "- [Async executor](#Async-executor): Support for asynchronous processing of Events, e.g. for interfacing to external servers\n",
     "\n",
@@ -715,6 +716,26 @@
    "outputs": [],
    "source": [
     "p.param.trigger('a')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc3cb5ba",
+   "metadata": {},
+   "source": [
+    "### `.param.watchers`\n",
+    "\n",
+    "For more advanced purposes it can be useful to inspect all the watchers set up on an instance, in which case you can use `inst.param.watchers` to obtain a dictionary with the following structure: `{parameter_name: {what: [Watcher(), ...], ...}, ...}`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b2ae598",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p.param.watchers"
    ]
   },
   {

--- a/examples/user_guide/Parameters.ipynb
+++ b/examples/user_guide/Parameters.ipynb
@@ -912,7 +912,7 @@
     "- Private attributes:\n",
     "    - `_param__parameters`: Store the object returned by `.param` on the class\n",
     "    - `_param__private`: Store various internal data on Parameterized class and instances\n",
-    "    - `_param_watchers` (to be removed soon): Store a dictionary of instance watchers"
+    "    - `_param_watchers` (deprecated in Param 2.0 and to be removed soon): Store a dictionary of instance watchers"
    ]
   },
   {

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2556,6 +2556,8 @@ class Parameters:
         outputs = {}
         for cls in classlist(self_.cls):
             for name in dir(cls):
+                if name == '_param_watchers':
+                    continue
                 method = getattr(self_.self_or_cls, name)
                 dinfo = getattr(method, '_dinfo', {})
                 if 'outputs' not in dinfo:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1729,13 +1729,13 @@ class Parameters:
     def watchers(self_):
         """Dictionary of instance watchers."""
         if self_.self is None:
-            raise TypeError()
+            raise TypeError('Accessing `.param.watchers` is only supported on a Parameterized instance, not class.')
         return self_.self._param__private.watchers
 
     @watchers.setter
     def watchers(self_, value):
         if self_.self is None:
-            raise TypeError()
+            raise TypeError('Setting `.param.watchers` is only supported on a Parameterized instance, not class.')
         self_.self._param__private.watchers = value
 
     @property

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1726,9 +1726,17 @@ class Parameters:
         self_.self_or_cls._param__private.parameters_state['watchers'] = value
 
     @property
-    def watchers(self):
-        """Read-only list of watchers on this Parameterized"""
-        return self._watchers
+    def watchers(self_):
+        """Dictionary of instance watchers."""
+        if self_.self is None:
+            raise TypeError()
+        return self_.self._param__private.watchers
+
+    @watchers.setter
+    def watchers(self_, value):
+        if self_.self is None:
+            raise TypeError()
+        self_.self._param__private.watchers = value
 
     @property
     def self_or_cls(self_):
@@ -3792,11 +3800,15 @@ class Parameterized(metaclass=ParameterizedMetaclass):
     def param(self):
         return Parameters(self.__class__, self=self)
 
+    #PARAM3_DEPRECATION
     @property
+    @_deprecated(extra_msg="Use `inst.param.watchers` instead.", warning_cat=UserWarning)
     def _param_watchers(self):
         return self._param__private.watchers
 
+    #PARAM3_DEPRECATION
     @_param_watchers.setter
+    @_deprecated(extra_msg="Use `inst.param.watchers = ...` instead.", warning_cat=UserWarning)
     def _param_watchers(self, value):
         self._param__private.watchers = value
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3804,13 +3804,13 @@ class Parameterized(metaclass=ParameterizedMetaclass):
 
     #PARAM3_DEPRECATION
     @property
-    @_deprecated(extra_msg="Use `inst.param.watchers` instead.", warning_cat=UserWarning)
+    @_deprecated(extra_msg="Use `inst.param.watchers` instead.", warning_cat=FutureWarning)
     def _param_watchers(self):
         return self._param__private.watchers
 
     #PARAM3_DEPRECATION
     @_param_watchers.setter
-    @_deprecated(extra_msg="Use `inst.param.watchers = ...` instead.", warning_cat=UserWarning)
+    @_deprecated(extra_msg="Use `inst.param.watchers = ...` instead.", warning_cat=FutureWarning)
     def _param_watchers(self, value):
         self._param__private.watchers = value
 

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -103,11 +103,11 @@ class TestDeprecateParameterizedModule:
             param.parameterized.all_equal(1, 1)
 
     def test_deprecate_param_watchers(self):
-        with pytest.raises(UserWarning):
+        with pytest.raises(FutureWarning):
             param.parameterized.Parameterized()._param_watchers
 
     def test_deprecate_param_watchers_setter(self):
-        with pytest.raises(UserWarning):
+        with pytest.raises(FutureWarning):
             param.parameterized.Parameterized()._param_watchers = {}
 
 

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -102,6 +102,15 @@ class TestDeprecateParameterizedModule:
         with pytest.raises(param._utils.ParamDeprecationWarning):
             param.parameterized.all_equal(1, 1)
 
+    def test_deprecate_param_watchers(self):
+        with pytest.raises(UserWarning):
+            param.parameterized.Parameterized()._param_watchers
+
+    def test_deprecate_param_watchers_setter(self):
+        with pytest.raises(UserWarning):
+            param.parameterized.Parameterized()._param_watchers = {}
+
+
 class TestDeprecateParameters:
 
     def test_deprecate_print_param_defaults(self):

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1353,6 +1353,7 @@ def test_namespace_class():
     assert _dir(P) == [
         '_param__parameters',
         '_param__private',
+        '_param_watchers',
         'foo',
         'name',
         'param',

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -574,6 +574,47 @@ class TestWatch(unittest.TestCase):
         assert len(args) == 1
         assert args[0].name == 'b'
 
+    def test_watch_watchers_exposed_public(self):
+        obj = SimpleWatchExample()
+
+        obj.param.watch(lambda: '', ['a', 'b'])
+
+        pw = obj.param.watchers
+        assert isinstance(pw, dict)
+        for pname in ('a', 'b'):
+            assert pname in pw
+            assert 'value' in pw[pname]
+            assert isinstance(pw[pname]['value'], list) and len(pw[pname]['value']) == 1
+            assert isinstance(pw[pname]['value'][0], param.parameterized.Watcher)
+
+    def test_watch_watchers_modified_public(self):
+        accumulator = Accumulator()
+        obj = SimpleWatchExample()
+
+        obj.param.watch(accumulator, ['a', 'b'])
+
+        pw = obj.param.watchers
+        del pw['a']
+
+        obj.param.update(a=1, b=1)
+
+        assert accumulator.call_count() == 1
+        args = accumulator.args_for_call(0)
+        assert len(args) == 1
+        assert args[0].name == 'b'
+
+    def test_watch_watchers_setter_public(self):
+        accumulator = Accumulator()
+        obj = SimpleWatchExample()
+
+        obj.param.watch(accumulator, ['a', 'b'])
+
+        obj.param.watchers = {}
+
+        obj.param.update(a=1, b=1)
+
+        assert accumulator.call_count() == 0
+
 
 class TestWatchMethod(unittest.TestCase):
 

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -618,6 +618,20 @@ class TestWatch(unittest.TestCase):
 
         assert accumulator.call_count() == 0
 
+    def test_watch_watchers_class_error(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Accessing `\.param\.watchers` is only supported on a Parameterized instance, not class\."
+        ):
+            SimpleWatchExample.param.watchers
+
+    def test_watch_watchers_class_set_error(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Setting `\.param\.watchers` is only supported on a Parameterized instance, not class\."
+        ):
+            SimpleWatchExample.param.watchers = {}
+
 
 class TestWatchMethod(unittest.TestCase):
 

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -5,6 +5,7 @@ import copy
 import unittest
 
 import param
+import pytest
 
 from param.parameterized import discard_events
 
@@ -550,7 +551,8 @@ class TestWatch(unittest.TestCase):
 
         obj.param.watch(lambda: '', ['a', 'b'])
 
-        pw = obj._param_watchers
+        with pytest.warns(FutureWarning):
+            pw = obj._param_watchers
         assert isinstance(pw, dict)
         for pname in ('a', 'b'):
             assert pname in pw
@@ -564,7 +566,8 @@ class TestWatch(unittest.TestCase):
 
         obj.param.watch(accumulator, ['a', 'b'])
 
-        pw = obj._param_watchers
+        with pytest.warns(FutureWarning):
+            pw = obj._param_watchers
         del pw['a']
 
         obj.param.update(a=1, b=1)


### PR DESCRIPTION
Closes https://github.com/holoviz/param/issues/780

- `.param.watchers` no longer return the transient dict of watchers (breaking change)
- instead it returns what used to be returned by `_param_watchers`
- `_param_watchers` has been turned into a deprecated property

I just ran the unit test suite of Panel with this branch checked out without any problem.