### PR TITLE
Materialize default values based on all the parameters available

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1837,19 +1837,13 @@ class Parameters:
         """
         self = self_.param.self
         ## Deepcopy all 'instantiate=True' parameters
-        # (building a set of names first to avoid redundantly
-        # instantiating a later-overridden parent class's parameter)
         params_to_deepcopy = {}
         params_to_ref = {}
-        for class_ in classlist(type(self)):
-            if not issubclass(class_, Parameterized):
-                continue
-            for (k, v) in class_.param._parameters.items():
-                # (avoid replacing name with the default of None)
-                if v.instantiate and k != "name":
-                    params_to_deepcopy[k] = v
-                elif v.constant and k != 'name':
-                    params_to_ref[k] = v
+        for pname, p in self.param.objects(instance=False).items():
+            if p.instantiate and pname != "name":
+                params_to_deepcopy[pname] = p
+            elif p.constant and pname != 'name':
+                params_to_ref[pname] = p
 
         for p in params_to_deepcopy.values():
             self.param._instantiate_param(p)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3058,8 +3058,6 @@ class ParameterizedMetaclass(type):
         parameters = [(n, o) for (n, o) in dict_.items()
                       if isinstance(o, Parameter)]
 
-        mcs._param__parameters._parameters = dict(parameters)
-
         for param_name,param in parameters:
             mcs._initialize_parameter(param_name, param)
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1252,6 +1252,25 @@ def test_inheritance_constant_behavior():
     assert b.param.p.constant is False
 
 
+def test_inheritance_set_Parameter_instantiate_constant_before_instantation():
+    # https://github.com/holoviz/param/issues/760
+    class A(param.Parameterized):
+        p0 = param.Parameter()
+        p1 = param.Parameter(instantiate=True)
+        p2 = param.Parameter(constant=True)
+
+    class B(A):
+        pass
+
+    B.p0 = B.p1 = B.p2 = 2
+
+    b = B()
+
+    assert b.p0 == 2
+    assert b.p1 == 2
+    assert b.p2 == 2
+
+
 def test_inheritance_allow_None_behavior():
     class A(param.Parameterized):
         p = param.Parameter(default=1)


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/760

https://github.com/holoviz/param/issues/760 identified that this regression happened in https://github.com/holoviz/param/pull/424. More precisely I've found out it was due to this change https://github.com/holoviz/param/pull/424/files#diff-c8fc4fb68012b66fbf42ad9e0b4714fd96a3a72b83558bc543130d78bd622eb3R1275-R1279 by which Param would  "instantiate" (i.e. materialize a default Parameter value into an instance) the wrong Parameter default. That happened if a Parameter is inherited and isn't re-declared by the subclass, in which case the "instantiated" value would be the one from the first class above in the hierarchy that declares the Parameter.

Instead of the custom class hierarchy traversal I've opted for leveraging `.param.objects(instance=False)`.