### PR TITLE
Raise a `ValueError` when `Path` is set to `None` while not allowed

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -43,7 +43,12 @@ from .parameterized import shared_parameters # noqa: api import
 from .parameterized import logging_level     # noqa: api import
 from .parameterized import DEBUG, VERBOSE, INFO, WARNING, ERROR, CRITICAL # noqa: api import
 from .parameterized import _identity_hook
-from ._utils import ParamDeprecationWarning as _ParamDeprecationWarning, _deprecate_positional_args, _deprecated
+from ._utils import (
+    ParamDeprecationWarning as _ParamDeprecationWarning,
+    _deprecate_positional_args,
+    _deprecated,
+    _validate_error_prefix,
+)
 
 # Define '__version__'
 try:
@@ -2344,7 +2349,7 @@ class Path(Parameter):
     def _validate(self, val):
         if val is None:
             if not self.allow_None:
-                Parameterized(name=f"{self.owner.name}.{self.name}").param.warning('None is not allowed')
+                raise ValueError(f'{_validate_error_prefix(self)} does not accept None')
         else:
             try:
                 self._resolve(val)

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -114,3 +114,9 @@ def _recursive_repr(fillvalue='...'):
 
 def _is_auto_name(class_name, instance_name):
     return re.match('^'+class_name+'[0-9]{5}$', instance_name)
+
+
+def _validate_error_prefix(parameter):
+    pclass = type(parameter).__name__
+    pname = '' if parameter.name is None else f' {parameter.name!r}'
+    return f'{pclass!r} Parameter{pname}'

--- a/tests/testpathparam.py
+++ b/tests/testpathparam.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import tempfile
 import unittest
@@ -6,7 +7,7 @@ import unittest
 import param
 import pytest
 
-from .utils import warnings_as_excepts, check_defaults
+from .utils import check_defaults
 
 
 class TestPathParameters(unittest.TestCase):
@@ -80,7 +81,8 @@ class TestPathParameters(unittest.TestCase):
 
         assert p.param.b.allow_None is False
         # This should probably raise an error (#708)
-        with warnings_as_excepts(match='None is not allowed'):
+
+        with pytest.raises(ValueError, match=re.escape(r"'Path' Parameter 'b' does not accept None")):
             p.b = None
 
     def test_search_paths(self):
@@ -189,8 +191,7 @@ class TestFilenameParameters(unittest.TestCase):
         p = self.P()
 
         assert p.param.b.allow_None is False
-        # This should probably raise an error (#708)
-        with warnings_as_excepts(match='None is not allowed'):
+        with pytest.raises(ValueError, match=re.escape(r"'Filename' Parameter 'b' does not accept None")):
             p.b = None
 
     def test_search_paths(self):
@@ -269,8 +270,8 @@ class TestFoldernameParameters(unittest.TestCase):
         p = self.P()
 
         assert p.param.b.allow_None is False
-        # This should probably raise an error (#708)
-        with warnings_as_excepts(match='None is not allowed'):
+
+        with pytest.raises(ValueError, match=re.escape(r"'Foldername' Parameter 'b' does not accept None")):
             p.b = None
 
     def test_search_paths(self):


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/708

It used to only emit a warning which was pretty inconsistent with the other Parameters.

---

I've also introduced a small utility to better format the validation errors raised in `__init__`, planning to open another PR to align all the Parameter errors before the Param 2.0 release.