### PR TITLE
`FileSelector` defaults to the first globbed path

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2462,20 +2462,23 @@ class FileSelector(Selector):
     def __init__(self, default=Undefined, *, path="", **kwargs):
         self.default = default
         self.path = path
-        self.update()
-        super().__init__(default=default, objects=self.objects,
-                         empty_default=True, **kwargs)
+        if default is Undefined:
+            self.update()
+        else:
+            self.update(default=False)
+        super().__init__(default=self.default, objects=self.objects, **kwargs)
 
     def _on_set(self, attribute, old, new):
         super()._on_set(attribute, new, old)
         if attribute == 'path':
             self.update()
 
-    def update(self):
+    def update(self, default=True):
         self.objects = sorted(glob.glob(self.path))
         if self.default in self.objects:
             return
-        self.default = self.objects[0] if self.objects else None
+        if default:
+            self.default = self.objects[0] if self.objects else None
 
     def get_range(self):
         return _abbreviate_paths(self.path,super().get_range())

--- a/tests/testfileselector.py
+++ b/tests/testfileselector.py
@@ -76,10 +76,9 @@ class TestFileSelectorParameters(unittest.TestCase):
         check_defaults(s, label=None)
         self._check_defaults(s)
 
-    def test_default_is_None(self):
+    def test_default_to_first(self):
         p = self.P()
-        assert p.a is None
-        assert p.param.a.default is None
+        assert p.a == p.param.a.objects[0]
 
     def test_default_is_honored(self):
         p = self.P()


### PR DESCRIPTION
Addresses the first issue raised https://github.com/holoviz/param/issues/545, i.e. that the `FileSelector` parameter is not updating its default value to the first path found in `objects`, which is inconsistent with how `Selector` works.
