### PR TITLE
Remove inferred docstring signature and add basic __signature__ support

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -6,6 +6,10 @@ import warnings
 from textwrap import dedent
 from threading import get_ident
 
+DEFAULT_SIGNATURE = inspect.Signature([
+    inspect.Parameter('self', inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    inspect.Parameter('params', inspect.Parameter.VAR_KEYWORD),
+])
 
 class ParamWarning(Warning):
     """Base Param Warning"""

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3097,7 +3097,7 @@ class ParameterizedMetaclass(type):
         mcs.param._depends = {'watch': _inherited+_watch}
 
         if docstring_signature:
-            mcs.__class_docstring_signature()
+            mcs.__class_docstring()
 
     def __set_name(mcs, name, dict_):
         """
@@ -3129,30 +3129,16 @@ class ParameterizedMetaclass(type):
             if not found_renamed:
                 mcs.name = name
 
-    def __class_docstring_signature(mcs, max_repr_len=15):
+    def __class_docstring(mcs):
         """
-        Autogenerate a keyword signature in the class docstring for
-        all available parameters. This is particularly useful in the
-        IPython Notebook as IPython will parse this signature to allow
-        tab-completion of keywords.
-
-        max_repr_len: Maximum length (in characters) of value reprs.
+        Customize the class docstring with a Parameter table if
+        `docstring_describe_params` and the `param_pager` is available.
         """
-        processed_kws, keyword_groups = set(), []
-        for cls in reversed(mcs.mro()):
-            keyword_group = []
-            for (k,v) in sorted(cls.__dict__.items()):
-                if isinstance(v, Parameter) and k not in processed_kws:
-                    param_type = v.__class__.__name__
-                    keyword_group.append(f"{k}={param_type}")
-                    processed_kws.add(k)
-            keyword_groups.append(keyword_group)
-
-        keywords = [el for grp in reversed(keyword_groups) for el in grp]
-        class_docstr = "\n"+mcs.__doc__ if mcs.__doc__ else ''
-        signature = "params(%s)" % (", ".join(keywords))
-        description = param_pager(mcs) if (docstring_describe_params and param_pager) else ''
-        mcs.__doc__ = signature + class_docstr + '\n' + description
+        if not docstring_describe_params or not param_pager:
+            return
+        class_docstr = mcs.__doc__ if mcs.__doc__ else ''
+        description = param_pager(mcs)
+        mcs.__doc__ = class_docstr + '\n' + description
 
 
     def _initialize_parameter(mcs,param_name,param):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3196,9 +3196,6 @@ class ParameterizedMetaclass(type):
             keyword_groups.append(keyword_group)
 
         keywords = [el for grp in reversed(keyword_groups) for el in grp]
-        # if mcs.name == 'C':
-        #     import pdb; pdb.set_trace()
-        # keywords = [el for grp in keyword_groups for el in grp]
         signature = inspect.Signature([
             inspect.Parameter(k, inspect.Parameter.KEYWORD_ONLY)
             for k in keywords

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1418,7 +1418,6 @@ def test_parameterized_docstring():
     # TODO
     pass
 
-
 def check_signature(parameterized_obj, parameters):
     assert parameterized_obj.__signature__ is not None
     sig = inspect.signature(parameterized_obj)

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1414,10 +1414,6 @@ def test_parameterized_access_param_before_super():
     P()
 
 
-def test_parameterized_docstring():
-    # TODO
-    pass
-
 def check_signature(parameterized_obj, parameters):
     assert parameterized_obj.__signature__ is not None
     sig = inspect.signature(parameterized_obj)

--- a/tests/testparameterizedrepr.py
+++ b/tests/testparameterizedrepr.py
@@ -252,5 +252,3 @@ def test_pprint_signature_overriden():
     )
 
     assert t.param.pprint() == 'T()'
-    # Make sure we haven't messed up with the signature of the base class
-    assert not hasattr(param.Parameterized, '__signature__')


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/371 by:

1. removing the automatically inferred *docstring signature* (e.g. `params(x=Number, name=String)`) as IPython would no longer leverage it for parameter autocompletion (as noted in the issue) and because it was wrong when the class was having an `__init__` method with a signature different than `__init__(self, **params)`
2. implementing `Parameterized.__signature__` as a class property that returns a `Signature` built from the class Parameters, **only** when the class (or its superclasses) doesn't implement an `__init__` method that is different than the default one `__init__(self, **params)`.

<img width="361" alt="image" src="https://github.com/holoviz/param/assets/35924738/35f51778-4bfb-4383-895d-abd3a2aa4c93">

Somewhat surprisingly 2) seemed to have broken only a few tests in Panel and none in HoloViews. The two unit tests that broke in Panel are https://github.com/holoviz/panel/blob/df0b277dca2fd54dd2ae016159adc5c33b61e358/panel/tests/widgets/test_base.py#L25 and https://github.com/holoviz/panel/blob/df0b277dca2fd54dd2ae016159adc5c33b61e358/panel/tests/test_viewable.py#L40, I believe they test that the `__signature__` of some Panel objects is actually *not* modified, as there is some code in Panel that modifies the signature of components. That code in Panel by the way doesn't seem to be tested, given https://github.com/holoviz/panel/blob/df0b277dca2fd54dd2ae016159adc5c33b61e358/panel/tests/conftest.py#L32. Anyway, it seems to me the change done in this PR would not affect Panel, let's double check that however if it's not tested.

I have chosen not to even try to handle custom `__init__` in 2) as I'm not even sure it's possible (@jlstevens raised some good points in the issue) and I believe that a better approach for Param in the future would be to add Parameter attributes to control how the Parameter appears in the signature (e.g. positional, hidden) and provide a post init hook so that users don't have to create an `__init__` in most cases.
