### PR TITLE
FileSelector: ensure path separators are consistent on Windows

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -23,6 +23,7 @@ import glob
 import re
 import datetime as dt
 import collections
+import pathlib
 import typing
 import warnings
 
@@ -2483,7 +2484,13 @@ class FileSelector(Selector):
             self.update()
 
     def update(self, default=True):
-        self.objects = sorted(glob.glob(self.path))
+        if self.path == "":
+            self.objects = []
+        else:
+            # Convert using os.fspath and pathlib.Path to handle ensure
+            # the path separators are consistent (on Windows in particular)
+            pathpattern = os.fspath(pathlib.Path(self.path))
+            self.objects = sorted(glob.glob(pathpattern))
         if self.default in self.objects:
             return
         if default:

--- a/tests/testfileselector.py
+++ b/tests/testfileselector.py
@@ -135,3 +135,27 @@ class TestFileSelectorParameters(unittest.TestCase):
         p.param.b.update()
         assert p.param.b.objects == [self.fb]
         assert p.param.b.default == self.fb
+
+
+def test_fileselector_glob_parent(tmpdir):
+    # https://github.com/holoviz/param/issues/139
+
+    ncwd = tmpdir / 'folder'
+    data = tmpdir / 'data'
+    data.mkdir()
+    (data / 'foo.txt').write_text('foo', encoding='utf-8')
+    ncwd.mkdir()
+    cwd = os.getcwd()
+    os.chdir(ncwd)
+    try:
+        if os.name == 'nt':
+            default = r'..\data\foo.txt'
+        else:
+            default = '../data/foo.txt'
+        class P(param.Parameterized):
+            fs = param.FileSelector(default, path='../data/*.txt')
+
+        assert len(P.param.fs.objects) == 1
+        assert P.fs == default
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/139