### PR TITLE
Improve Parameter error messages

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1811,7 +1811,7 @@ class Selector(SelectorBase, _SignatureSelector):
                     break
             items = '[' + ', '.join(items) + limiter
             raise ValueError(
-                f"{_validate_error_prefix(self)} does not accept {val!r}, "
+                f"{_validate_error_prefix(self)} does not accept {val!r}; "
                 f"valid options include: {items!r}"
             )
 
@@ -1900,7 +1900,7 @@ class ClassSelector(SelectorBase):
         else:
             if not (issubclass(val, class_)):
                 raise ValueError(
-                    f"{_validate_error_prefix(self)} value must be a subclass of {class_name}, not {val.__name__!r}.")
+                    f"{_validate_error_prefix(self)} value must be a subclass of {class_name}, not {val}.")
 
     def get_range(self):
         """
@@ -2024,7 +2024,7 @@ class List(Parameter):
                 continue
             raise TypeError(
                 f"{_validate_error_prefix(self)} items must be instances "
-                f"of {item_type!r}, not {val!r}."
+                f"of {item_type!r}, not {type(v)}."
             )
 
 
@@ -2720,7 +2720,7 @@ class Date(Number):
         if step is not None and not isinstance(step, dt_types):
             raise ValueError(
                 f"{_validate_error_prefix(self, 'step')} can only be None, "
-                f"a datetime or datetime type, not {type(val)}."
+                f"a datetime or datetime type, not {type(step)}."
             )
 
     def _validate_bounds(self, val, bounds, inclusive_bounds):
@@ -2779,7 +2779,7 @@ class CalendarDate(Number):
         if step is not None and not isinstance(step, dt.date):
             raise ValueError(
                 f"{_validate_error_prefix(self, 'step')} can only be None or "
-                "a date type."
+                f"a date type, not {type(step)}."
             )
 
     @classmethod

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2926,10 +2926,14 @@ class Range(NumericTuple):
     def _validate_step(self, val, step):
         if step is not None:
             if not _is_number(step):
-                raise ValueError("Step can only be None or a "
-                                 "numeric value, not type %r." % type(step))
+                raise ValueError(
+                    f"{_validate_error_prefix(self, 'step')} can only be None "
+                    f"or a numeric value, not type {type(step)}."
+                )
             elif step == 0:
-                raise ValueError("Step cannot be 0.")
+                raise ValueError(
+                    f"{_validate_error_prefix(self, 'step')} cannot be 0."
+                )
 
     def _validate_order(self, val, step, allow_None):
         if val is None and allow_None:
@@ -2939,13 +2943,15 @@ class Range(NumericTuple):
 
         start, end = val
         if step is not None and step > 0 and not start <= end:
-            name = "" if self.name is None else " %rs" % self.name
-            raise ValueError("Range parameter%s end %s is less than its start %s with positive step %s."
-                             % (name, end, start, step))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} end {end} is less than its "
+                f"start {start} with positive step {step}."
+            )
         elif step is not None and step < 0 and not start >= end:
-            name = "" if self.name is None else " %rs" % self.name
-            raise ValueError("Range parameter%s start %s is less than its end %s with negative step %s."
-                             % (name, start, end, step))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} start {start} is less than its "
+                f"start {end} with negative step {step}."
+            )
 
     def _validate_bounds(self, val, bounds, inclusive_bounds):
         if bounds is None or (val is None and self.allow_None):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -863,14 +863,19 @@ class Bytes(Parameter):
         if (val is None and self.allow_None):
             return
         if regex is not None and re.match(regex, val) is None:
-            raise ValueError(f"Bytes parameter {self.name!r} value {val!r} does not match regex {regex!r}.")
+            raise ValueError(
+                f"{_validate_error_prefix(self)} value {val!r} "
+                f"does not match regex {regex!r}."
+            )
 
     def _validate_value(self, val, allow_None):
         if allow_None and val is None:
             return
         if not isinstance(val, bytes):
-            raise ValueError("Bytes parameter {!r} only takes a byte string value, "
-                             "not value of type {}.".format(self.name, type(val)))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only takes a byte string value, "
+                f"not value of type {type(val)}."
+            )
 
     def _validate(self, val):
         self._validate_value(val, self.allow_None)
@@ -1044,22 +1049,30 @@ class Number(Dynamic):
         if vmax is not None:
             if incmax is True:
                 if not val <= vmax:
-                    raise ValueError("Parameter {!r} must be at most {}, "
-                                     "not {}.".format(self.name, vmax, val))
+                    raise ValueError(
+                        f"{_validate_error_prefix(self)} must be at most "
+                        f"{vmax}, not {val}."
+                    )
             else:
                 if not val < vmax:
-                    raise ValueError("Parameter {!r} must be less than {}, "
-                                     "not {}.".format(self.name, vmax, val))
+                    raise ValueError(
+                        f"{_validate_error_prefix(self)} must be less than "
+                        f"{vmax}, not {val}."
+                    )
 
         if vmin is not None:
             if incmin is True:
                 if not val >= vmin:
-                    raise ValueError("Parameter {!r} must be at least {}, "
-                                     "not {}.".format(self.name, vmin, val))
+                    raise ValueError(
+                        f"{_validate_error_prefix(self)} must be at least "
+                        f"{vmin}, not {val}."
+                    )
             else:
                 if not val > vmin:
-                    raise ValueError("Parameter {!r} must be greater than {}, "
-                                     "not {}.".format(self.name, vmin, val))
+                    raise ValueError(
+                        f"{_validate_error_prefix(self)} must be greater than "
+                        f"{vmin}, not {val}."
+                    )
 
     def _validate_value(self, val, allow_None):
         if (allow_None and val is None) or callable(val):
@@ -1067,14 +1080,16 @@ class Number(Dynamic):
 
         if not _is_number(val):
             raise ValueError(
-                f'{_validate_error_prefix(self)} only takes numeric values, '
-                f'not type {type(val)!r}.'
+                f"{_validate_error_prefix(self)} only takes numeric values, "
+                f"not type {type(val)!r}."
             )
 
     def _validate_step(self, val, step):
         if step is not None and not _is_number(step):
-            raise ValueError("Step can only be None or a "
-                             "numeric value, not type %r." % type(step))
+            raise ValueError(
+                f"{_validate_error_prefix(self, 'step')} can only be "
+                f"None or a numeric value, not type {type(step)!r}."
+            )
 
     def _validate(self, val):
         """
@@ -1109,13 +1124,17 @@ class Integer(Number):
             return
 
         if not isinstance(val, _int_types):
-            raise ValueError("Integer parameter {!r} must be an integer, "
-                             "not type {!r}.".format(self.name, type(val)))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} must be an integer, "
+                f"not type {type(val)}."
+            )
 
     def _validate_step(self, val, step):
         if step is not None and not isinstance(step, int):
-            raise ValueError("Step can only be None or an "
-                             "integer value, not type %r" % type(step))
+            raise ValueError(
+                f"{_validate_error_prefix(self, 'step')} can only be "
+                f"None or an integer value, not type {type(step)!r}."
+            )
 
 
 
@@ -1163,12 +1182,14 @@ class Boolean(Parameter):
     def _validate_value(self, val, allow_None):
         if allow_None:
             if not isinstance(val, bool) and val is not None:
-                raise ValueError("Boolean parameter {!r} only takes a "
-                                 "Boolean value or None, not {}.".format(self.name, val))
+                raise ValueError(
+                    f"{_validate_error_prefix(self)} only takes a "
+                    f"boolean value or None, not {val!r}."
+                )
         elif not isinstance(val, bool):
-            name = "" if self.name is None else " %r" % self.name
             raise ValueError(
-                f"Boolean parameter{name} must be True or False, not {val}."
+                f"{_validate_error_prefix(self)} must be True or False, "
+                f"not {val!r}."
             )
 
     def _validate(self, val):
@@ -1216,8 +1237,10 @@ class Tuple(Parameter):
         """
         super().__init__(default=default, **params)
         if length is Undefined and self.default is None:
-            raise ValueError("%s: length must be specified if no default is supplied." %
-                             (self.name))
+            raise ValueError(
+                f"{_validate_error_prefix(self, 'length')} must be "
+                "specified if no default is supplied."
+            )
         elif default is not Undefined and default:
             self.length = len(default)
         else:
@@ -1229,17 +1252,20 @@ class Tuple(Parameter):
             return
 
         if not isinstance(val, tuple):
-            raise ValueError("Tuple parameter {!r} only takes a tuple value, "
-                             "not {!r}.".format(self.name, type(val)))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only takes a tuple value, "
+                f"not {type(val)!r}."
+            )
 
     def _validate_length(self, val, length):
         if val is None and self.allow_None:
             return
 
         if not len(val) == length:
-            raise ValueError("Tuple parameter %r is not of the correct "
-                             "length (%d instead of %d)." %
-                             (self.name, len(val), length))
+            raise ValueError(
+                f"{_validate_error_prefix(self, 'length')} is not "
+                f"of the correct length ({len(val)} instead of {length})."
+            )
 
     def _validate(self, val):
         self._validate_value(val, self.allow_None)
@@ -1268,8 +1294,10 @@ class NumericTuple(Tuple):
         for n in val:
             if _is_number(n):
                 continue
-            raise ValueError("NumericTuple parameter {!r} only takes numeric "
-                             "values, not type {!r}.".format(self.name, type(n)))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only takes numeric "
+                f"values, not type {type(n)!r}."
+            )
 
 
 class XYCoordinates(NumericTuple):
@@ -1300,12 +1328,30 @@ class Callable(Parameter):
     2.4, so instantiate must be False for those values.
     """
 
+    @typing.overload
+    def __init__(
+        self,
+        default=None, *,
+        allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+    ):
+        ...
+
+    @_deprecate_positional_args
+    def __init__(self, default=Undefined, **params):
+        super().__init__(default=default, **params)
+        self._validate(self.default)
+
     def _validate_value(self, val, allow_None):
         if (allow_None and val is None) or callable(val):
             return
+        raise ValueError(
+            f"{_validate_error_prefix(self)} only takes a callable object, "
+            f"not objects of type {type(val)!r}."
+        )
 
-        raise ValueError("Callable parameter {!r} only takes a callable object, "
-                         "not objects of type {!r}.".format(self.name, type(val)))
+    def _validate(self, val):
+        self._validate_value(val, self.allow_None)
 
 
 class Action(Callable):
@@ -1383,9 +1429,10 @@ class Composite(Parameter):
     def _validate_attribs(self, val, attribs):
         if len(val) == len(attribs):
             return
-        raise ValueError("Compound parameter %r got the wrong number "
-                         "of values (needed %d, but got %d)." %
-                         (self.name, len(attribs), len(val)))
+        raise ValueError(
+            f"{_validate_error_prefix(self)} got the wrong number "
+            f"of values (needed {len(attribs)}, but got {len(val)})."
+        )
 
     def _validate(self, val):
         self._validate_attribs(val, self.attribs)
@@ -1751,13 +1798,6 @@ class Selector(SelectorBase, _SignatureSelector):
             return
 
         if not (val in self.objects or (self.allow_None and val is None)):
-            # This method can be called before __init__ has called
-            # super's __init__, so there may not be any name set yet.
-            if (hasattr(self, "name") and self.name):
-                attrib_name = " " + self.name
-            else:
-                attrib_name = ""
-
             items = []
             limiter = ']'
             length = 0
@@ -1770,8 +1810,10 @@ class Selector(SelectorBase, _SignatureSelector):
                     limiter = ', ...]'
                     break
             items = '[' + ', '.join(items) + limiter
-            raise ValueError("{} not in parameter{}'s list of possible objects, "
-                             "valid options include {}".format(val, attrib_name, items))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} does not accept {val!r}, "
+                f"valid options include: {items!r}"
+            )
 
     def _ensure_value_is_in_objects(self, val):
         """
@@ -1851,15 +1893,14 @@ class ClassSelector(SelectorBase):
             class_name = ('(%s)' % ', '.join(cl.__name__ for cl in class_))
         else:
             class_name = class_.__name__
-        param_cls = self.__class__.__name__
         if is_instance:
             if not (isinstance(val, class_)):
                 raise ValueError(
-                    f"{param_cls} parameter {self.name!r} value must be an instance of {class_name}, not {val!r}.")
+                    f"{_validate_error_prefix(self)} value must be an instance of {class_name}, not {val!r}.")
         else:
             if not (issubclass(val, class_)):
                 raise ValueError(
-                    f"{param_cls} parameter {self.name!r} must be a subclass of {class_name}, not {val.__name__!r}.")
+                    f"{_validate_error_prefix(self)} value must be a subclass of {class_name}, not {val.__name__!r}.")
 
     def get_range(self):
         """
@@ -1949,19 +1990,31 @@ class List(Parameter):
         l = len(val)
         if min_length is not None and max_length is not None:
             if not (min_length <= l <= max_length):
-                raise ValueError(f"{self.name}: list length must be between {min_length} and {max_length} (inclusive)")
+                raise ValueError(
+                    f"{_validate_error_prefix(self)} length must be between "
+                    f"{min_length} and {max_length} (inclusive), not {l}."
+                )
         elif min_length is not None:
             if not min_length <= l:
-                raise ValueError(f"{self.name}: list length must be at least {min_length}.")
+                raise ValueError(
+                    f"{_validate_error_prefix(self)} length must be at "
+                    f"least {min_length}, not {l}."
+                )
         elif max_length is not None:
             if not l <= max_length:
-                raise ValueError(f"{self.name}: list length must be at most {max_length}.")
+                raise ValueError(
+                    f"{_validate_error_prefix(self)} length must be at "
+                    f"most {max_length}, not {l}."
+                )
 
     def _validate_value(self, val, allow_None):
         if allow_None and val is None:
             return
         if not isinstance(val, list):
-            raise ValueError(f"List parameter {self.name!r} must be a list, not an object of type {type(val)}.")
+            raise ValueError(
+                f"{_validate_error_prefix(self)} must be a list, not an "
+                f"object of type {type(val)}."
+            )
 
     def _validate_item_type(self, val, item_type):
         if item_type is None or (self.allow_None and val is None):
@@ -1969,8 +2022,10 @@ class List(Parameter):
         for v in val:
             if isinstance(v, item_type):
                 continue
-            raise TypeError("List parameter {!r} items must be instances "
-                            "of type {!r}, not {!r}.".format(self.name, item_type, val))
+            raise TypeError(
+                f"{_validate_error_prefix(self)} items must be instances "
+                f"of type {item_type!r}, not {val!r}."
+            )
 
 
 class HookList(List):
@@ -1990,8 +2045,10 @@ class HookList(List):
         for v in val:
             if callable(v):
                 continue
-            raise ValueError("HookList parameter {!r} items must be callable, "
-                             "not {!r}.".format(self.name, v))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} items must be callable, "
+                f"not {v!r}."
+            )
 
 
 class Dict(ClassSelector):
@@ -2094,23 +2151,26 @@ class DataFrame(ClassSelector):
         self._validate(self.default)
 
     def _length_bounds_check(self, bounds, length, name):
-        message = '{name} length {length} does not match declared bounds of {bounds}'
+        message = f'{name} length {length} does not match declared bounds of {bounds}'
         if not isinstance(bounds, tuple):
             if (bounds != length):
-                raise ValueError(message.format(name=name, length=length, bounds=bounds))
+                raise ValueError(f"{_validate_error_prefix(self)}: {message}")
             else:
                 return
         (lower, upper) = bounds
         failure = ((lower is not None and (length < lower))
                    or (upper is not None and length > upper))
         if failure:
-            raise ValueError(message.format(name=name,length=length, bounds=bounds))
+            raise ValueError(f"{_validate_error_prefix(self)}: {message}")
 
     def _validate(self, val):
         super()._validate(val)
 
         if isinstance(self.columns, set) and self.ordered is True:
-            raise ValueError('Columns cannot be ordered when specified as a set')
+            raise ValueError(
+                f'{_validate_error_prefix(self)}: columns cannot be ordered '
+                f'when specified as a set'
+            )
 
         if self.allow_None and val is None:
             return
@@ -2119,23 +2179,27 @@ class DataFrame(ClassSelector):
             pass
         elif (isinstance(self.columns, tuple) and len(self.columns)==2
               and all(isinstance(v, (type(None), numbers.Number)) for v in self.columns)): # Numeric bounds tuple
-            self._length_bounds_check(self.columns, len(val.columns), 'Columns')
+            self._length_bounds_check(self.columns, len(val.columns), 'columns')
         elif isinstance(self.columns, (list, set)):
             self.ordered = isinstance(self.columns, list) if self.ordered is None else self.ordered
             difference = set(self.columns) - {str(el) for el in val.columns}
             if difference:
-                msg = 'Provided DataFrame columns {found} does not contain required columns {expected}'
-                raise ValueError(msg.format(found=list(val.columns), expected=sorted(self.columns)))
+                raise ValueError(
+                    f"{_validate_error_prefix(self)}: provided columns "
+                    f"{list(val.columns)} does not contain required "
+                    f"columns {sorted(self.columns)}"
+                )
         else:
-            self._length_bounds_check(self.columns, len(val.columns), 'Column')
+            self._length_bounds_check(self.columns, len(val.columns), 'column')
 
         if self.ordered:
             if list(val.columns) != list(self.columns):
-                msg = 'Provided DataFrame columns {found} must exactly match {expected}'
-                raise ValueError(msg.format(found=list(val.columns), expected=self.columns))
-
+                raise ValueError(
+                    f"{_validate_error_prefix(self)}: provided columns "
+                    f"{list(val.columns)} must exactly match {self.columns}"
+                )
         if self.rows is not None:
-            self._length_bounds_check(self.rows, len(val), 'Row')
+            self._length_bounds_check(self.rows, len(val), 'row')
 
     @classmethod
     def serialize(cls, value):
@@ -2201,17 +2265,17 @@ class Series(ClassSelector):
         self._validate(self.default)
 
     def _length_bounds_check(self, bounds, length, name):
-        message = '{name} length {length} does not match declared bounds of {bounds}'
+        message = f'{name} length {length} does not match declared bounds of {bounds}'
         if not isinstance(bounds, tuple):
             if (bounds != length):
-                raise ValueError(message.format(name=name, length=length, bounds=bounds))
+                raise ValueError(f"{_validate_error_prefix(self)}: {message}")
             else:
                 return
         (lower, upper) = bounds
         failure = ((lower is not None and (length < lower))
                    or (upper is not None and length > upper))
         if failure:
-            raise ValueError(message.format(name=name,length=length, bounds=bounds))
+            raise ValueError(f"{_validate_error_prefix(self)}: {message}")
 
     def _validate(self, val):
         super()._validate(val)
@@ -2220,7 +2284,7 @@ class Series(ClassSelector):
             return
 
         if self.rows is not None:
-            self._length_bounds_check(self.rows, len(val), 'Row')
+            self._length_bounds_check(self.rows, len(val), 'row')
 
 
 
@@ -2562,8 +2626,10 @@ class ListSelector(Selector):
         if (val is None and self.allow_None):
             return
         if not isinstance(val, list):
-            raise ValueError("ListSelector parameter {!r} only takes list "
-                             "types, not {!r}.".format(self.name, val))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only takes list types, "
+                f"not {val!r}."
+            )
         for o in val:
             super()._validate(o)
 
@@ -2646,15 +2712,15 @@ class Date(Number):
 
         if not isinstance(val, dt_types) and not (allow_None and val is None):
             raise ValueError(
-                "Date parameter {!r} only takes datetime and date types, "
-                "not type {!r}.".format(self.name, type(val))
+                f"{_validate_error_prefix(self)} only takes datetime and "
+                f"date types, not type {type(val)!r}."
             )
 
     def _validate_step(self, val, step):
         if step is not None and not isinstance(step, dt_types):
             raise ValueError(
-                "Step can only be None, a datetime "
-                "or datetime type, not type %r." % type(val)
+                f"{_validate_error_prefix(self, 'step')} can only be None, "
+                f"a datetime or datetime type, not type {type(val)!r}."
             )
 
     def _validate_bounds(self, val, bounds, inclusive_bounds):
@@ -2705,11 +2771,16 @@ class CalendarDate(Number):
             return
 
         if (not isinstance(val, dt.date) or isinstance(val, dt.datetime)) and not (allow_None and val is None):
-            raise ValueError("CalendarDate parameter %r only takes date types." % self.name)
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only takes date types."
+            )
 
     def _validate_step(self, val, step):
         if step is not None and not isinstance(step, dt.date):
-            raise ValueError("Step can only be None or a date type.")
+            raise ValueError(
+                f"{_validate_error_prefix(self, 'step')} can only be None or "
+                "a date type."
+            )
 
     @classmethod
     def serialize(cls, value):
@@ -2794,8 +2865,10 @@ class Color(Parameter):
         if (allow_None and val is None):
             return
         if not isinstance(val, str):
-            raise ValueError("Color parameter {!r} expects a string value, "
-                             "not an object of type {}.".format(self.name, type(val)))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} expects a string value, "
+                f"not an object of type {type(val)}."
+            )
 
     def _validate_allow_named(self, val, allow_named):
         if (val is None and self.allow_None):
@@ -2803,11 +2876,15 @@ class Color(Parameter):
         is_hex = re.match('^#?(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$', val)
         if self.allow_named:
             if not is_hex and val.lower() not in self._named_colors:
-                raise ValueError("Color '{}' only takes RGB hex codes "
-                                 "or named colors, received '{}'.".format(self.name, val))
+                raise ValueError(
+                    f"{_validate_error_prefix(self)} only takes RGB hex codes "
+                    f"or named colors, received '{val}'."
+                )
         elif not is_hex:
-            raise ValueError("Color '{}' only accepts valid RGB hex "
-                             "codes, received '{}'.".format(self.name, val))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only accepts valid RGB hex "
+                f"codes, received '{val}'."
+            )
 
 
 class Range(NumericTuple):
@@ -2853,12 +2930,13 @@ class Range(NumericTuple):
             too_low = (vmin is not None) and (v < vmin if incmin else v <= vmin)
             too_high = (vmax is not None) and (v > vmax if incmax else v >= vmax)
             if too_low or too_high:
-                raise ValueError(f"Range parameter {self.name!r}'s {bound} bound must be in range {self.rangestr()}.")
-
+                raise ValueError(
+                    f"{_validate_error_prefix(self, 'bound')} must be in "
+                    f"range {self.rangestr()!r}."
+                )
 
     def get_soft_bounds(self):
         return get_soft_bounds(self.bounds, self.softbounds)
-
 
     def rangestr(self):
         vmin, vmax = self.bounds
@@ -2888,18 +2966,24 @@ class DateRange(Range):
             return
 
         if not isinstance(val, tuple):
-            raise ValueError("DateRange parameter {!r} only takes a tuple value, "
-                             "not {}.".format(self.name, type(val).__name__))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only takes a tuple value, "
+                f"not {type(val).__name__!r}."
+            )
         for n in val:
             if isinstance(n, dt_types):
                 continue
-            raise ValueError("DateRange parameter {!r} only takes date/datetime "
-                             "values, not type {}.".format(self.name, type(n).__name__))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} only takes date/datetime "
+                f"values, not type {type(n).__name__!r}."
+            )
 
         start, end = val
         if not end >= start:
-            raise ValueError("DateRange parameter {!r}'s end datetime {} "
-                             "is before start datetime {}.".format(self.name, val[1], val[0]))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} end datetime {val[1]} "
+                f"is before start datetime {val[0]}."
+            )
 
     @classmethod
     def serialize(cls, value):
@@ -2943,13 +3027,17 @@ class CalendarDateRange(Range):
 
         for n in val:
             if not isinstance(n, dt.date):
-                raise ValueError("CalendarDateRange parameter {!r} only "
-                                 "takes date types, not {}.".format(self.name, val))
+                raise ValueError(
+                    f"{_validate_error_prefix(self)} only takes date types, "
+                    f"not {val}."
+                )
 
         start, end = val
         if not end >= start:
-            raise ValueError("CalendarDateRange parameter {!r}'s end date "
-                             "{} is before start date {}.".format(self.name, val[1], val[0]))
+            raise ValueError(
+                f"{_validate_error_prefix(self)} end date {val[1]} is before "
+                f"start date {val[0]}."
+            )
 
     @classmethod
     def serialize(cls, value):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1347,7 +1347,7 @@ class Callable(Parameter):
             return
         raise ValueError(
             f"{_validate_error_prefix(self)} only takes a callable object, "
-            f"not objects of type {type(val)!r}."
+            f"not objects of {type(val)}."
         )
 
     def _validate(self, val):
@@ -2024,7 +2024,7 @@ class List(Parameter):
                 continue
             raise TypeError(
                 f"{_validate_error_prefix(self)} items must be instances "
-                f"of type {item_type!r}, not {val!r}."
+                f"of {item_type!r}, not {val!r}."
             )
 
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1065,8 +1065,10 @@ class Number(Dynamic):
             return
 
         if not _is_number(val):
-            raise ValueError("Parameter {!r} only takes numeric values, "
-                             "not type {!r}.".format(self.name, type(val)))
+            raise ValueError(
+                f'{_validate_error_prefix(self)} only takes numeric values, '
+                f'not type {type(val)!r}.'
+            )
 
     def _validate_step(self, val, step):
         if step is not None and not _is_number(step):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2720,7 +2720,7 @@ class Date(Number):
         if step is not None and not isinstance(step, dt_types):
             raise ValueError(
                 f"{_validate_error_prefix(self, 'step')} can only be None, "
-                f"a datetime or datetime type, not {type(step)}."
+                f"a datetime or date type, not {type(step)}."
             )
 
     def _validate_bounds(self, val, bounds, inclusive_bounds):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -874,7 +874,7 @@ class Bytes(Parameter):
         if not isinstance(val, bytes):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes a byte string value, "
-                f"not value of type {type(val)}."
+                f"not value of {type(val)}."
             )
 
     def _validate(self, val):
@@ -1081,14 +1081,14 @@ class Number(Dynamic):
         if not _is_number(val):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes numeric values, "
-                f"not type {type(val)!r}."
+                f"not {type(val)}."
             )
 
     def _validate_step(self, val, step):
         if step is not None and not _is_number(step):
             raise ValueError(
                 f"{_validate_error_prefix(self, 'step')} can only be "
-                f"None or a numeric value, not type {type(step)!r}."
+                f"None or a numeric value, not {type(step)}."
             )
 
     def _validate(self, val):
@@ -1126,14 +1126,14 @@ class Integer(Number):
         if not isinstance(val, _int_types):
             raise ValueError(
                 f"{_validate_error_prefix(self)} must be an integer, "
-                f"not type {type(val)}."
+                f"not {type(val)}."
             )
 
     def _validate_step(self, val, step):
         if step is not None and not isinstance(step, int):
             raise ValueError(
                 f"{_validate_error_prefix(self, 'step')} can only be "
-                f"None or an integer value, not type {type(step)!r}."
+                f"None or an integer value, not {type(step)}."
             )
 
 
@@ -1254,7 +1254,7 @@ class Tuple(Parameter):
         if not isinstance(val, tuple):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes a tuple value, "
-                f"not {type(val)!r}."
+                f"not {type(val)}."
             )
 
     def _validate_length(self, val, length):
@@ -1296,7 +1296,7 @@ class NumericTuple(Tuple):
                 continue
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes numeric "
-                f"values, not type {type(n)!r}."
+                f"values, not {type(n)}."
             )
 
 
@@ -2013,7 +2013,7 @@ class List(Parameter):
         if not isinstance(val, list):
             raise ValueError(
                 f"{_validate_error_prefix(self)} must be a list, not an "
-                f"object of type {type(val)}."
+                f"object of {type(val)}."
             )
 
     def _validate_item_type(self, val, item_type):
@@ -2713,14 +2713,14 @@ class Date(Number):
         if not isinstance(val, dt_types) and not (allow_None and val is None):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes datetime and "
-                f"date types, not type {type(val)!r}."
+                f"date types, not {type(val)}."
             )
 
     def _validate_step(self, val, step):
         if step is not None and not isinstance(step, dt_types):
             raise ValueError(
                 f"{_validate_error_prefix(self, 'step')} can only be None, "
-                f"a datetime or datetime type, not type {type(val)!r}."
+                f"a datetime or datetime type, not {type(val)}."
             )
 
     def _validate_bounds(self, val, bounds, inclusive_bounds):
@@ -2867,7 +2867,7 @@ class Color(Parameter):
         if not isinstance(val, str):
             raise ValueError(
                 f"{_validate_error_prefix(self)} expects a string value, "
-                f"not an object of type {type(val)}."
+                f"not an object of {type(val)}."
             )
 
     def _validate_allow_named(self, val, allow_named):
@@ -2883,7 +2883,7 @@ class Color(Parameter):
         elif not is_hex:
             raise ValueError(
                 f"{_validate_error_prefix(self)} only accepts valid RGB hex "
-                f"codes, received '{val}'."
+                f"codes, received {val!r}."
             )
 
 
@@ -2928,7 +2928,7 @@ class Range(NumericTuple):
             if not _is_number(step):
                 raise ValueError(
                     f"{_validate_error_prefix(self, 'step')} can only be None "
-                    f"or a numeric value, not type {type(step)}."
+                    f"or a numeric value, not {type(step)}."
                 )
             elif step == 0:
                 raise ValueError(
@@ -3000,14 +3000,14 @@ class DateRange(Range):
         if not isinstance(val, tuple):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes a tuple value, "
-                f"not {type(val).__name__!r}."
+                f"not {type(val)}."
             )
         for n in val:
             if isinstance(n, dt_types):
                 continue
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes date/datetime "
-                f"values, not type {type(n).__name__!r}."
+                f"values, not {type(n)}."
             )
 
         start, end = val

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -133,7 +133,7 @@ def _find_pname(pclass):
             return match.group(1)
 
 
-def _validate_error_prefix(parameter):
+def _validate_error_prefix(parameter, attribute=None):
     """
     Generate an error prefix suitable for Parameters when they raise a validation
     error.
@@ -153,7 +153,10 @@ def _validate_error_prefix(parameter):
     else:
         powner = None
     pname = parameter.name
-    out = [f'{pclass} parameter']
+    out = []
+    if attribute:
+        out.append(f'Attribute {attribute!r} of')
+    out.append(f'{pclass} parameter')
     if pname:
         if powner:
             desc = f'{powner}.{pname}'

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1556,7 +1556,7 @@ class String(Parameter):
         if not isinstance(val, str):
             raise ValueError(
                 f'{_validate_error_prefix(self)} only takes a string value, '
-                f'not value of type {type(val)}.'
+                f'not value of {type(val)}.'
             )
 
     def _validate(self, val):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -40,6 +40,7 @@ from ._utils import (
     _deprecate_positional_args,
     _is_auto_name,
     _recursive_repr,
+    _validate_error_prefix,
     ParamDeprecationWarning as _ParamDeprecationWarning,
 )
 
@@ -1544,14 +1545,19 @@ class String(Parameter):
         if (val is None and self.allow_None):
             return
         if regex is not None and re.match(regex, val) is None:
-            raise ValueError(f"String parameter {self.name!r} value {val!r} does not match regex {regex!r}.")
+            raise ValueError(
+                f'{_validate_error_prefix(self)} value {val!r} does not '
+                f'match regex {regex!r}.'
+            )
 
     def _validate_value(self, val, allow_None):
         if allow_None and val is None:
             return
         if not isinstance(val, str):
-            raise ValueError("String parameter {!r} only takes a string value, "
-                             "not value of type {}.".format(self.name, type(val)))
+            raise ValueError(
+                f'{_validate_error_prefix(self)} only takes a string value, '
+                f'not value of type {type(val)}.'
+            )
 
     def _validate(self, val):
         self._validate_value(val, self.allow_None)

--- a/tests/testaddparameter.py
+++ b/tests/testaddparameter.py
@@ -61,7 +61,7 @@ def test_add_parameter_class_validation():
 
     P.param.add_parameter('y', param.Number())
 
-    with pytest.raises(ValueError, match=r"Parameter 'y' only takes numeric values, not type <class 'str'>."):
+    with pytest.raises(ValueError, match=r"Number parameter 'P.y' only takes numeric values, not type <class 'str'>."):
         P.y = 'test'
 
 
@@ -74,7 +74,7 @@ def test_add_parameter_instance_validation():
 
     p = P()
 
-    with pytest.raises(ValueError, match=r"Parameter 'y' only takes numeric values, not type <class 'str'>."):
+    with pytest.raises(ValueError, match=r"Number parameter 'P.y' only takes numeric values, not type <class 'str'>."):
         p.y = 'test'
 
 

--- a/tests/testaddparameter.py
+++ b/tests/testaddparameter.py
@@ -61,7 +61,7 @@ def test_add_parameter_class_validation():
 
     P.param.add_parameter('y', param.Number())
 
-    with pytest.raises(ValueError, match=r"Number parameter 'P.y' only takes numeric values, not type <class 'str'>."):
+    with pytest.raises(ValueError, match=r"Number parameter 'P.y' only takes numeric values, not <class 'str'>."):
         P.y = 'test'
 
 
@@ -74,7 +74,7 @@ def test_add_parameter_instance_validation():
 
     p = P()
 
-    with pytest.raises(ValueError, match=r"Number parameter 'P.y' only takes numeric values, not type <class 'str'>."):
+    with pytest.raises(ValueError, match=r"Number parameter 'P.y' only takes numeric values, not <class 'str'>."):
         p.y = 'test'
 
 

--- a/tests/testbooleanparam.py
+++ b/tests/testbooleanparam.py
@@ -56,7 +56,7 @@ class TestBooleanParameters(unittest.TestCase):
     def test_raise_None_when_not_allowed(self):
         p = self.P()
 
-        msg = r"Boolean parameter 'e' must be True or False, not None"
+        msg = r"Boolean parameter 'P.e' must be True or False, not None"
         with self.assertRaisesRegex(ValueError, msg):
             p.e = None
 
@@ -64,7 +64,7 @@ class TestBooleanParameters(unittest.TestCase):
             self.P.e = None
 
     def test_bad_type(self):
-        msg = r"Boolean parameter 'e' must be True or False, not test"
+        msg = r"Boolean parameter 'P.e' must be True or False, not 'test'"
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = 'test'
@@ -78,7 +78,7 @@ class TestBooleanParameters(unittest.TestCase):
             p.e = 'test'
 
     def test_bad_default_type(self):
-        msg = r"Boolean parameter must be True or False, not test."
+        msg = r"Boolean parameter 'b' must be True or False, not 'test'\."
 
         with self.assertRaisesRegex(ValueError, msg):
             class A(param.Parameterized):
@@ -137,7 +137,7 @@ class TestEventParameters(unittest.TestCase):
     def test_raise_None_when_not_allowed(self):
         p = self.P()
 
-        msg = r"Boolean parameter 'e' must be True or False, not None"
+        msg = r"Event parameter 'P.e' must be True or False, not None"
         with self.assertRaisesRegex(ValueError, msg):
             p.e = None
 
@@ -145,7 +145,7 @@ class TestEventParameters(unittest.TestCase):
             self.P.e = None
 
     def test_bad_type(self):
-        msg = r"Boolean parameter 'e' must be True or False, not test"
+        msg = r"Event parameter 'P.e' must be True or False, not 'test'"
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = 'test'

--- a/tests/testbytesparam.py
+++ b/tests/testbytesparam.py
@@ -67,7 +67,7 @@ class TestBytesParameters(unittest.TestCase):
 
         a = A()
 
-        exception = "Bytes parameter 'A.s' only takes a byte string value, not value of type <class 'NoneType'>."
+        exception = "Bytes parameter 'A.s' only takes a byte string value, not value of <class 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 

--- a/tests/testbytesparam.py
+++ b/tests/testbytesparam.py
@@ -67,7 +67,7 @@ class TestBytesParameters(unittest.TestCase):
 
         a = A()
 
-        exception = "Bytes parameter 's' only takes a byte string value, not value of type <class 'NoneType'>."
+        exception = "Bytes parameter 'A.s' only takes a byte string value, not value of type <class 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 
@@ -85,13 +85,13 @@ class TestBytesParameters(unittest.TestCase):
 
         a = A()
 
-        exception = "Bytes parameter 's' value b'123.123.0.256' does not match regex %r."  % ip_regex
+        exception = "Bytes parameter 'A.s' value b'123.123.0.256' does not match regex %r."  % ip_regex
         with self.assertRaises(ValueError) as e:
             a.s = b'123.123.0.256'
         self.assertEqual(str(e.exception), exception)
 
     def test_regex_incorrect_default(self):
-        exception = f"Bytes parameter None value b'' does not match regex {ip_regex!r}."
+        exception = f"Bytes parameter 's' value b'' does not match regex {ip_regex!r}."
         with self.assertRaises(ValueError) as e:
             class A(param.Parameterized):
                 s = param.Bytes(regex=ip_regex)  # default value '' does not match regular expression

--- a/tests/testcalendardateparam.py
+++ b/tests/testcalendardateparam.py
@@ -2,6 +2,7 @@
 Unit test for CalendarDate parameters.
 """
 import datetime as dt
+import re
 import unittest
 
 import pytest
@@ -43,38 +44,26 @@ class TestDateTimeParameters(unittest.TestCase):
         self._check_defaults(d)
 
     def test_initialization_out_of_bounds(self):
-        try:
+        with pytest.raises(ValueError):
             class Q(param.Parameterized):
                 q = param.CalendarDate(dt.date(2017,2,27),
                                        bounds=(dt.date(2017,2,1),
                                                dt.date(2017,2,26)))
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on out-of-bounds date")
 
     def test_set_out_of_bounds(self):
         class Q(param.Parameterized):
             q = param.CalendarDate(bounds=(dt.date(2017,2,1),
                                            dt.date(2017,2,26)))
-        try:
+        with pytest.raises(ValueError):
             Q.q = dt.date(2017,2,27)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on out-of-bounds date")
 
     def test_set_exclusive_out_of_bounds(self):
         class Q(param.Parameterized):
             q = param.CalendarDate(bounds=(dt.date(2017,2,1),
                                            dt.date(2017,2,26)),
                                    inclusive_bounds=(True, False))
-        try:
+        with pytest.raises(ValueError):
             Q.q = dt.date(2017,2,26)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on out-of-bounds date")
 
     def test_get_soft_bounds(self):
         q = param.CalendarDate(dt.date(2017,2,25),
@@ -86,10 +75,12 @@ class TestDateTimeParameters(unittest.TestCase):
                                                dt.date(2017,2,25)))
 
     def test_datetime_not_accepted(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=re.escape('CalendarDate parameter only takes date types.')):
             param.CalendarDate(dt.datetime(2021, 8, 16, 10))
 
     def test_step_invalid_type_parameter(self):
-        exception = "Step can only be None or a date type"
-        with self.assertRaisesRegex(ValueError, exception):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Attribute 'step' of CalendarDate parameter can only be None or a date type.")
+        ):
             param.CalendarDate(dt.date(2017,2,27), step=3.2)

--- a/tests/testcalendardateparam.py
+++ b/tests/testcalendardateparam.py
@@ -81,6 +81,6 @@ class TestDateTimeParameters(unittest.TestCase):
     def test_step_invalid_type_parameter(self):
         with pytest.raises(
             ValueError,
-            match=re.escape("Attribute 'step' of CalendarDate parameter can only be None or a date type.")
+            match=re.escape("Attribute 'step' of CalendarDate parameter can only be None or a date type, not <class 'float'>.")
         ):
             param.CalendarDate(dt.date(2017,2,27), step=3.2)

--- a/tests/testcalendardaterangeparam.py
+++ b/tests/testcalendardaterangeparam.py
@@ -2,9 +2,11 @@
 Unit tests for CalendarDateRange parameter.
 """
 import datetime as dt
+import re
 import unittest
 
 import param
+import pytest
 
 # Assuming tests of range parameter cover most of what's needed to
 # test date range.
@@ -42,65 +44,59 @@ class TestDateTimeRange(unittest.TestCase):
     bad_range = (dt.date(2017,2,27),dt.date(2017,2,26))
 
     def test_wrong_type_default(self):
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("CalendarDateRange parameter 'a' only takes date types, not (1.0, 2.0).")
+        ):
             class Q(param.Parameterized):
                 a = param.CalendarDateRange(default=(1.0,2.0))
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date type was accepted.")
 
     def test_wrong_type_init(self):
         class Q(param.Parameterized):
             a = param.CalendarDateRange()
 
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("CalendarDateRange parameter 'Q.a' end date 2017-02-26 is before start date 2017-02-27.")
+        ):
             Q(a=self.bad_range)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date type was accepted.")
 
     def test_wrong_type_set(self):
         class Q(param.Parameterized):
             a = param.CalendarDateRange()
         q = Q()
 
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("CalendarDateRange parameter 'Q.a' end date 2017-02-26 is before start date 2017-02-27.")
+        ):
             q.a = self.bad_range
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date type was accepted.")
 
     def test_start_before_end_default(self):
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("CalendarDateRange parameter 'a' end date 2017-02-26 is before start date 2017-02-27.")
+        ):
             class Q(param.Parameterized):
                 a = param.CalendarDateRange(default=self.bad_range)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date range was accepted.")
 
     def test_start_before_end_init(self):
         class Q(param.Parameterized):
             a = param.CalendarDateRange()
 
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("CalendarDateRange parameter 'Q.a' end date 2017-02-26 is before start date 2017-02-27.")
+        ):
             Q(a=self.bad_range)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date range was accepted.")
 
     def test_start_before_end_set(self):
         class Q(param.Parameterized):
             a = param.CalendarDateRange()
 
         q = Q()
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("CalendarDateRange parameter 'Q.a' end date 2017-02-26 is before start date 2017-02-27.")
+        ):
             q.a = self.bad_range
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Bad date range was accepted.")

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -5,6 +5,6 @@ import pytest
 def test_callable_validate():
     with pytest.raises(
         ValueError,
-        match=r"Callable parameter 'c' only takes a callable object, not objects of type <class 'str'>\."
+        match=r"Callable parameter 'c' only takes a callable object, not objects of <class 'str'>\."
     ):
         c = param.Callable('wrong')  # noqa

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -1,0 +1,10 @@
+import param
+import pytest
+
+
+def test_callable_validate():
+    with pytest.raises(
+        ValueError,
+        match=r"Callable parameter 'c' only takes a callable object, not objects of type <class 'str'>\."
+    ):
+        c = param.Callable('wrong')  # noqa

--- a/tests/testclassselector.py
+++ b/tests/testclassselector.py
@@ -57,7 +57,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.e, 6)
 
     def test_single_class_instance_error(self):
-        exception = "ClassSelector parameter 'e' value must be an instance of int, not 'a'."
+        exception = "ClassSelector parameter 'P.e' value must be an instance of int, not 'a'."
         with self.assertRaisesRegex(ValueError, exception):
             self.P(e='a')
 
@@ -66,7 +66,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.f, float)
 
     def test_single_class_type_error(self):
-        exception = "ClassSelector parameter 'f' must be a subclass of Number, not 'str'."
+        exception = "ClassSelector parameter 'P.f' value must be a subclass of Number, not 'str'."
         with self.assertRaisesRegex(ValueError, exception):
             self.P(f=str)
 
@@ -79,7 +79,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.g, 'A')
 
     def test_multiple_class_instance_error(self):
-        exception = r"ClassSelector parameter 'g' value must be an instance of \(int, str\), not 3.0."
+        exception = r"ClassSelector parameter 'P.g' value must be an instance of \(int, str\), not 3.0."
         with self.assertRaisesRegex(ValueError, exception):
             self.P(g=3.0)
 
@@ -98,7 +98,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertIn('str', classes)
 
     def test_multiple_class_type_error(self):
-        exception = r"ClassSelector parameter 'h' must be a subclass of \(int, str\), not 'float'."
+        exception = r"ClassSelector parameter 'P.h' value must be a subclass of \(int, str\), not 'float'."
         with self.assertRaisesRegex(ValueError, exception):
             self.P(h=float)
 
@@ -152,6 +152,6 @@ class TestDictParameters(unittest.TestCase):
             items = param.Dict(valid_dict)
 
         test = Test()
-        exception = "Dict parameter 'items' value must be an instance of dict, not 3."
+        exception = "Dict parameter 'Test.items' value must be an instance of dict, not 3."
         with self.assertRaisesRegex(ValueError, exception):
             test.items = 3

--- a/tests/testclassselector.py
+++ b/tests/testclassselector.py
@@ -66,7 +66,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.f, float)
 
     def test_single_class_type_error(self):
-        exception = "ClassSelector parameter 'P.f' value must be a subclass of Number, not 'str'."
+        exception = "ClassSelector parameter 'P.f' value must be a subclass of Number, not <class 'str'>."
         with self.assertRaisesRegex(ValueError, exception):
             self.P(f=str)
 
@@ -98,7 +98,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertIn('str', classes)
 
     def test_multiple_class_type_error(self):
-        exception = r"ClassSelector parameter 'P.h' value must be a subclass of \(int, str\), not 'float'."
+        exception = r"ClassSelector parameter 'P.h' value must be a subclass of \(int, str\), not <class 'float'>."
         with self.assertRaisesRegex(ValueError, exception):
             self.P(h=float)
 

--- a/tests/testcolorparameter.py
+++ b/tests/testcolorparameter.py
@@ -42,7 +42,7 @@ class TestColorParameters(unittest.TestCase):
     def test_wrong_type(self):
         with pytest.raises(
             ValueError,
-            match=re.escape("Color parameter 'q' expects a string value, not an object of type <class 'int'>.")
+            match=re.escape("Color parameter 'q' expects a string value, not an object of <class 'int'>.")
         ):
             q = param.Color(1)  # noqa
 

--- a/tests/testcolorparameter.py
+++ b/tests/testcolorparameter.py
@@ -1,11 +1,13 @@
 """
 Unit test for Color parameters.
 """
+import re
 import unittest
 
 from .utils import check_defaults
 
 import param
+import pytest
 
 
 class TestColorParameters(unittest.TestCase):
@@ -37,44 +39,48 @@ class TestColorParameters(unittest.TestCase):
         check_defaults(c, label=None)
         self._check_defaults(c)
 
+    def test_wrong_type(self):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Color parameter 'q' expects a string value, not an object of type <class 'int'>.")
+        ):
+            q = param.Color(1)  # noqa
+
     def test_initialization_invalid_string(self):
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Color parameter 'q' only accepts valid RGB hex codes, received 'red'."),
+        ):
             class Q(param.Parameterized):
                 q = param.Color('red', allow_named=False)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on invalid color")
 
     def test_set_invalid_string(self):
         class Q(param.Parameterized):
             q = param.Color(allow_named=False)
-        try:
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Color parameter 'Q.q' only accepts valid RGB hex codes, received 'red'."),
+        ):
             Q.q = 'red'
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on invalid color")
 
     def test_set_invalid_named_color(self):
         class Q(param.Parameterized):
             q = param.Color(allow_named=True)
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Color parameter 'Q.q' only takes RGB hex codes or named colors, received 'razzmatazz'."),
+        ):
             Q.q = 'razzmatazz'
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on invalid color")
 
     def test_invalid_long_hex(self):
         class Q(param.Parameterized):
             q = param.Color()
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Color parameter 'Q.q' only takes RGB hex codes or named colors, received '#gfffff'.")
+        ):
             Q.q = '#gfffff'
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on invalid color")
 
     def test_valid_long_hex(self):
         class Q(param.Parameterized):

--- a/tests/testdateparam.py
+++ b/tests/testdateparam.py
@@ -3,6 +3,7 @@ Unit test for Date parameters.
 """
 import datetime as dt
 import json
+import re
 import unittest
 
 import param
@@ -49,38 +50,35 @@ class TestDateParameters(unittest.TestCase):
         self._check_defaults(d)
 
     def test_initialization_out_of_bounds(self):
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Date parameter 'q' must be at most 2017-02-26 00:00:00, not 2017-02-27 00:00:00.")
+        ):
             class Q(param.Parameterized):
                 q = param.Date(dt.datetime(2017,2,27),
                                bounds=(dt.datetime(2017,2,1),
                                        dt.datetime(2017,2,26)))
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on out-of-bounds date")
 
     def test_set_out_of_bounds(self):
         class Q(param.Parameterized):
             q = param.Date(bounds=(dt.datetime(2017,2,1),
                                    dt.datetime(2017,2,26)))
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Date parameter 'Q.q' must be at most 2017-02-26 00:00:00, not 2017-02-27 00:00:00.")
+        ):
             Q.q = dt.datetime(2017,2,27)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on out-of-bounds date")
 
     def test_set_exclusive_out_of_bounds(self):
         class Q(param.Parameterized):
             q = param.Date(bounds=(dt.datetime(2017,2,1),
                                    dt.datetime(2017,2,26)),
                            inclusive_bounds=(True, False))
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Date parameter 'Q.q' must be less than 2017-02-26 00:00:00, not 2017-02-26 00:00:00.")
+        ):
             Q.q = dt.datetime(2017,2,26)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on out-of-bounds date")
 
     def test_get_soft_bounds(self):
         q = param.Date(dt.datetime(2017,2,25),
@@ -91,9 +89,16 @@ class TestDateParameters(unittest.TestCase):
         self.assertEqual(q.get_soft_bounds(), (dt.datetime(2017,2,1),
                                                dt.datetime(2017,2,25)))
 
+    def test_wrong_type(self):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Date parameter 'q' only takes datetime and date types, not type <class 'str'>.")
+        ):
+            q = param.Date('wrong')  # noqa
+
     def test_step_invalid_type_datetime_parameter(self):
-        exception = "Step can only be None, a datetime or datetime type"
-        with self.assertRaisesRegex(ValueError, exception):
+        exception = re.escape("Attribute 'step' of Date parameter can only be None, a datetime or datetime type, not type <class 'datetime.datetime'>.")
+        with pytest.raises(ValueError, match=exception):
             param.Date(dt.datetime(2017,2,27), step=3.2)
 
     @pytest.mark.skipif(np is None, reason='NumPy is not available')

--- a/tests/testdateparam.py
+++ b/tests/testdateparam.py
@@ -92,12 +92,12 @@ class TestDateParameters(unittest.TestCase):
     def test_wrong_type(self):
         with pytest.raises(
             ValueError,
-            match=re.escape("Date parameter 'q' only takes datetime and date types, not type <class 'str'>.")
+            match=re.escape("Date parameter 'q' only takes datetime and date types, not <class 'str'>.")
         ):
             q = param.Date('wrong')  # noqa
 
     def test_step_invalid_type_datetime_parameter(self):
-        exception = re.escape("Attribute 'step' of Date parameter can only be None, a datetime or datetime type, not type <class 'datetime.datetime'>.")
+        exception = re.escape("Attribute 'step' of Date parameter can only be None, a datetime or datetime type, not <class 'datetime.datetime'>.")
         with pytest.raises(ValueError, match=exception):
             param.Date(dt.datetime(2017,2,27), step=3.2)
 

--- a/tests/testdateparam.py
+++ b/tests/testdateparam.py
@@ -97,7 +97,7 @@ class TestDateParameters(unittest.TestCase):
             q = param.Date('wrong')  # noqa
 
     def test_step_invalid_type_datetime_parameter(self):
-        exception = re.escape("Attribute 'step' of Date parameter can only be None, a datetime or datetime type, not <class 'float'>.")
+        exception = re.escape("Attribute 'step' of Date parameter can only be None, a datetime or date type, not <class 'float'>.")
         with pytest.raises(ValueError, match=exception):
             param.Date(dt.datetime(2017,2,27), step=3.2)
 

--- a/tests/testdateparam.py
+++ b/tests/testdateparam.py
@@ -97,7 +97,7 @@ class TestDateParameters(unittest.TestCase):
             q = param.Date('wrong')  # noqa
 
     def test_step_invalid_type_datetime_parameter(self):
-        exception = re.escape("Attribute 'step' of Date parameter can only be None, a datetime or datetime type, not <class 'datetime.datetime'>.")
+        exception = re.escape("Attribute 'step' of Date parameter can only be None, a datetime or datetime type, not <class 'float'>.")
         with pytest.raises(ValueError, match=exception):
             param.Date(dt.datetime(2017,2,27), step=3.2)
 

--- a/tests/testdaterangeparam.py
+++ b/tests/testdaterangeparam.py
@@ -56,7 +56,7 @@ class TestDateRange(unittest.TestCase):
     def test_wrong_type_default(self):
         with pytest.raises(
             ValueError,
-            match=re.escape("DateRange parameter 'a' only takes a tuple value, not 'str'.")
+            match=re.escape("DateRange parameter 'a' only takes a tuple value, not <class 'str'>.")
         ):
             class Q(param.Parameterized):
                 a = param.DateRange(default='wrong')
@@ -64,7 +64,7 @@ class TestDateRange(unittest.TestCase):
     def test_wrong_inner_type_default(self):
         with pytest.raises(
             ValueError,
-            match=re.escape("DateRange parameter 'a' only takes date/datetime values, not type 'float'.")
+            match=re.escape("DateRange parameter 'a' only takes date/datetime values, not <class 'float'>.")
         ):
             class Q(param.Parameterized):
                 a = param.DateRange(default=(1.0,2.0))
@@ -74,7 +74,7 @@ class TestDateRange(unittest.TestCase):
             a = param.DateRange()
         with pytest.raises(
             ValueError,
-            match=re.escape("DateRange parameter 'Q.a' only takes date/datetime values, not type 'float'.")
+            match=re.escape("DateRange parameter 'Q.a' only takes date/datetime values, not <class 'float'>.")
         ):
             Q(a=(1.0, 2.0))
 
@@ -84,7 +84,7 @@ class TestDateRange(unittest.TestCase):
         q = Q()
         with pytest.raises(
             ValueError,
-            match=re.escape("DateRange parameter 'Q.a' only takes date/datetime values, not type 'float'.")
+            match=re.escape("DateRange parameter 'Q.a' only takes date/datetime values, not <class 'float'>.")
         ):
             q.a = (1.0, 2.0)
 
@@ -93,7 +93,7 @@ class TestDateRange(unittest.TestCase):
             a = param.DateRange()
         with pytest.raises(
             ValueError,
-            match=re.escape("DateRange parameter 'Q.a' only takes a tuple value, not 'str'.")
+            match=re.escape("DateRange parameter 'Q.a' only takes a tuple value, not <class 'str'>.")
         ):
             Q(a='wrong')
 
@@ -103,7 +103,7 @@ class TestDateRange(unittest.TestCase):
         q = Q()
         with pytest.raises(
             ValueError,
-            match=re.escape("DateRange parameter 'Q.a' only takes a tuple value, not 'str'.")
+            match=re.escape("DateRange parameter 'Q.a' only takes a tuple value, not <class 'str'>.")
         ):
             q.a = 'wrong'
 

--- a/tests/testdaterangeparam.py
+++ b/tests/testdaterangeparam.py
@@ -2,6 +2,7 @@
 Unit tests for DateRange parameter.
 """
 import datetime as dt
+import re
 import unittest
 
 import param
@@ -55,7 +56,7 @@ class TestDateRange(unittest.TestCase):
     def test_wrong_type_default(self):
         with pytest.raises(
             ValueError,
-            match="DateRange parameter None only takes a tuple value, not str."
+            match=re.escape("DateRange parameter 'a' only takes a tuple value, not 'str'.")
         ):
             class Q(param.Parameterized):
                 a = param.DateRange(default='wrong')
@@ -63,7 +64,7 @@ class TestDateRange(unittest.TestCase):
     def test_wrong_inner_type_default(self):
         with pytest.raises(
             ValueError,
-            match='DateRange parameter None only takes date/datetime values, not type float.'
+            match=re.escape("DateRange parameter 'a' only takes date/datetime values, not type 'float'.")
         ):
             class Q(param.Parameterized):
                 a = param.DateRange(default=(1.0,2.0))
@@ -73,7 +74,7 @@ class TestDateRange(unittest.TestCase):
             a = param.DateRange()
         with pytest.raises(
             ValueError,
-            match="DateRange parameter 'a' only takes date/datetime values, not type float."
+            match=re.escape("DateRange parameter 'Q.a' only takes date/datetime values, not type 'float'.")
         ):
             Q(a=(1.0, 2.0))
 
@@ -83,7 +84,7 @@ class TestDateRange(unittest.TestCase):
         q = Q()
         with pytest.raises(
             ValueError,
-            match="DateRange parameter 'a' only takes date/datetime values, not type float."
+            match=re.escape("DateRange parameter 'Q.a' only takes date/datetime values, not type 'float'.")
         ):
             q.a = (1.0, 2.0)
 
@@ -92,7 +93,7 @@ class TestDateRange(unittest.TestCase):
             a = param.DateRange()
         with pytest.raises(
             ValueError,
-            match="DateRange parameter 'a' only takes a tuple value, not str."
+            match=re.escape("DateRange parameter 'Q.a' only takes a tuple value, not 'str'.")
         ):
             Q(a='wrong')
 
@@ -102,14 +103,14 @@ class TestDateRange(unittest.TestCase):
         q = Q()
         with pytest.raises(
             ValueError,
-            match="DateRange parameter 'a' only takes a tuple value, not str."
+            match=re.escape("DateRange parameter 'Q.a' only takes a tuple value, not 'str'.")
         ):
             q.a = 'wrong'
 
     def test_start_before_end_default(self):
         with pytest.raises(
             ValueError,
-            match="DateRange parameter None's end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00."
+            match=re.escape("DateRange parameter 'a' end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00.")
         ):
             class Q(param.Parameterized):
                 a = param.DateRange(default=self.bad_range)
@@ -119,7 +120,7 @@ class TestDateRange(unittest.TestCase):
             a = param.DateRange()
         with pytest.raises(
             ValueError,
-            match="DateRange parameter 'a''s end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00."
+            match=re.escape("DateRange parameter 'Q.a' end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00.")
         ):
             Q(a=self.bad_range)
 
@@ -129,7 +130,7 @@ class TestDateRange(unittest.TestCase):
         q = Q()
         with pytest.raises(
             ValueError,
-            match="DateRange parameter 'a''s end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00."
+            match=re.escape("DateRange parameter 'Q.a' end datetime 2017-02-26 00:00:00 is before start datetime 2017-02-27 00:00:00.")
         ):
             q.a = self.bad_range
 
@@ -191,7 +192,7 @@ class TestDateRange(unittest.TestCase):
     def test_numpy_start_before_end_default(self):
         with pytest.raises(
             ValueError,
-            match="DateRange parameter None's end datetime 2022-01-01T00:00 is before start datetime 2022-10-01T00:00."
+            match=re.escape("DateRange parameter 'a' end datetime 2022-01-01T00:00 is before start datetime 2022-10-01T00:00.")
         ):
             class Q(param.Parameterized):
                 a = param.DateRange(default=(np.datetime64('2022-10-01T00:00'), np.datetime64('2022-01-01T00:00')))

--- a/tests/testlist.py
+++ b/tests/testlist.py
@@ -90,7 +90,7 @@ class TestListParameters(unittest.TestCase):
         p = self.P()
         with pytest.raises(
             TypeError,
-            match=re.escape("List parameter 'P.e' items must be instances of type <class 'int'>, not ['s'].")
+            match=re.escape("List parameter 'P.e' items must be instances of <class 'int'>, not ['s'].")
         ):
             p.e=['s']
 
@@ -98,7 +98,7 @@ class TestListParameters(unittest.TestCase):
         p = self.P(e=[6])
         with pytest.raises(
             ValueError,
-            match=re.escape("List parameter 'P.e' must be a list, not an object of type <class 'NoneType'>.")
+            match=re.escape("List parameter 'P.e' must be a list, not an object of <class 'NoneType'>.")
         ):
             p.e = None
 

--- a/tests/testlist.py
+++ b/tests/testlist.py
@@ -1,6 +1,8 @@
+import re
 import unittest
 
 import param
+import pytest
 
 from .utils import check_defaults
 # TODO: I copied the tests from testobjectselector, although I
@@ -17,6 +19,8 @@ class TestListParameters(unittest.TestCase):
         class P(param.Parameterized):
             e = param.List([5,6,7], item_type=int)
             l = param.List(["red","green","blue"], item_type=str, bounds=(0,10))
+            m = param.List([1, 2, 3], bounds=(3, None))
+            n = param.List([1], bounds=(None, 3))
 
         self.P = P
 
@@ -60,30 +64,43 @@ class TestListParameters(unittest.TestCase):
 
     def test_set_object_outside_bounds(self):
         p = self.P()
-        try:
-            p.l=[6]*11
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Object set outside range.")
+        with pytest.raises(
+            ValueError,
+            match=re.escape("List parameter 'P.l' length must be between 0 and 10 (inclusive), not 11.")
+        ):
+            p.l = [6] * 11
+
+    def test_set_object_outside_lower_bounds(self):
+        p = self.P()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("List parameter 'P.m' length must be at least 3, not 2.")
+        ):
+            p.m = [6, 7]
+
+    def test_set_object_outside_upper_bounds(self):
+        p = self.P()
+        with pytest.raises(
+            ValueError,
+            match=re.escape("List parameter 'P.n' length must be at most 3, not 4.")
+        ):
+            p.n = [6] * 4
 
     def test_set_object_wrong_type(self):
         p = self.P()
-        try:
+        with pytest.raises(
+            TypeError,
+            match=re.escape("List parameter 'P.e' items must be instances of type <class 'int'>, not ['s'].")
+        ):
             p.e=['s']
-        except TypeError:
-            pass
-        else:
-            raise AssertionError("Object allowed of wrong type.")
 
     def test_set_object_not_None(self):
         p = self.P(e=[6])
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("List parameter 'P.e' must be a list, not an object of type <class 'NoneType'>.")
+        ):
             p.e = None
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Object set outside range.")
 
     def test_inheritance_behavior1(self):
         class A(param.Parameterized):
@@ -246,27 +263,18 @@ class TestHookListParameters(unittest.TestCase):
 
     def test_set_object_outside_bounds(self):
         p = self.P()
-        try:
-            p.l = [abs]*11
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Object set outside range.")
+        with pytest.raises(ValueError):
+            p.l = [abs] * 11
 
     def test_set_object_wrong_type_foo(self):
         p = self.P()
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("HookList parameter 'P.e' items must be callable, not 's'.")
+        ):
             p.e = ['s']
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Object allowed of wrong type.")
 
     def test_set_object_not_None(self):
         p = self.P()
-        try:
+        with pytest.raises(ValueError):
             p.e = None
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("Object set outside range.")

--- a/tests/testlist.py
+++ b/tests/testlist.py
@@ -90,7 +90,7 @@ class TestListParameters(unittest.TestCase):
         p = self.P()
         with pytest.raises(
             TypeError,
-            match=re.escape("List parameter 'P.e' items must be instances of <class 'int'>, not ['s'].")
+            match=re.escape("List parameter 'P.e' items must be instances of <class 'int'>, not <class 'str'>.")
         ):
             p.e=['s']
 

--- a/tests/testlistselector.py
+++ b/tests/testlistselector.py
@@ -1,6 +1,8 @@
+import re
 import unittest
 
 import param
+import pytest
 
 from .utils import check_defaults
 # TODO: I copied the tests from testobjectselector, although I
@@ -151,12 +153,18 @@ class TestListSelectorParameters(unittest.TestCase):
     ### new tests (not copied from testobjectselector)
 
     def test_bad_default(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("ListSelector parameter 'r' only takes list types, not 6."),
+        ):
             class Q(param.Parameterized):
                 r = param.ListSelector(default=6,check_on_set=True)
 
     def test_implied_check_on_set(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape("ListSelector parameter 'r' only takes list types, not 7."),
+        ):
             class Q(param.Parameterized):
                 r = param.ListSelector(default=7,objects=[7,8])
 

--- a/tests/testnumberparameter.py
+++ b/tests/testnumberparameter.py
@@ -70,7 +70,7 @@ class TestNumberParameters(unittest.TestCase):
         self.P.d = None
         assert self.P.d is None
 
-        exception = "Number parameter 'P.b' only takes numeric values, not type <(class|type) 'NoneType'>."
+        exception = "Number parameter 'P.b' only takes numeric values, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.b = None
 
@@ -81,7 +81,7 @@ class TestNumberParameters(unittest.TestCase):
         p.d = None
         assert p.d is None
 
-        exception = "Number parameter 'P.b' only takes numeric values, not type <(class|type) 'NoneType'>."
+        exception = "Number parameter 'P.b' only takes numeric values, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             p.b = None
 
@@ -232,7 +232,7 @@ class TestNumberParameters(unittest.TestCase):
         class Q(param.Parameterized):
             q = param.Number(default=lambda: 'test')
 
-        exception = "Number parameter 'Q.q' only takes numeric values, not type <(class|type) 'str'>."
+        exception = "Number parameter 'Q.q' only takes numeric values, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, exception):
             Q.q
 
@@ -405,7 +405,7 @@ class TestIntegerParameters(unittest.TestCase):
         self.P.d = None
         assert self.P.d is None
 
-        exception = "Integer parameter 'P.b' must be an integer, not type <(class|type) 'NoneType'>."
+        exception = "Integer parameter 'P.b' must be an integer, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.b = None
 
@@ -416,7 +416,7 @@ class TestIntegerParameters(unittest.TestCase):
         p.d = None
         assert p.d is None
 
-        exception = "Integer parameter 'P.b' must be an integer, not type <(class|type) 'NoneType'>."
+        exception = "Integer parameter 'P.b' must be an integer, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             p.b = None
 
@@ -579,7 +579,7 @@ class TestIntegerParameters(unittest.TestCase):
         class Q(param.Parameterized):
             q = param.Integer(default=lambda: 'test')
 
-        exception = "Integer parameter 'Q.q' must be an integer, not type <(class|type) 'str'>."
+        exception = "Integer parameter 'Q.q' must be an integer, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, exception):
             Q.q
 

--- a/tests/testnumberparameter.py
+++ b/tests/testnumberparameter.py
@@ -70,7 +70,7 @@ class TestNumberParameters(unittest.TestCase):
         self.P.d = None
         assert self.P.d is None
 
-        exception = "Parameter 'b' only takes numeric values, not type <(class|type) 'NoneType'>."
+        exception = "Number parameter 'P.b' only takes numeric values, not type <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.b = None
 
@@ -81,7 +81,7 @@ class TestNumberParameters(unittest.TestCase):
         p.d = None
         assert p.d is None
 
-        exception = "Parameter 'b' only takes numeric values, not type <(class|type) 'NoneType'>."
+        exception = "Number parameter 'P.b' only takes numeric values, not type <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             p.b = None
 
@@ -100,12 +100,12 @@ class TestNumberParameters(unittest.TestCase):
         self.assertEqual(p.param['f'].step, 0.5)
 
     def test_step_invalid_type_number_parameter(self):
-        exception = "Step can only be None or a numeric value"
+        exception = "Attribute 'step' of Number parameter can only be None or a numeric value"
         with self.assertRaisesRegex(ValueError, exception):
             param.Number(step='invalid value')
 
     def test_outside_bounds(self):
-        exception = "Parameter 'h' must be at most 2, not 10."
+        exception = "Number parameter 'P.h' must be at most 2, not 10."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.h = 10
 
@@ -118,14 +118,14 @@ class TestNumberParameters(unittest.TestCase):
         self.P.m = 10
         assert self.P.m == 10
 
-        exception = "Parameter 'm' must be at least -1, not -10."
+        exception = "Number parameter 'P.m' must be at least -1, not -10."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.m = -10
 
         self.P.n = -10
         assert self.P.n == -10
 
-        exception = "Parameter 'n' must be at most 1, not 10."
+        exception = "Number parameter 'P.n' must be at most 1, not 10."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.n = 10
 
@@ -135,14 +135,14 @@ class TestNumberParameters(unittest.TestCase):
         p.m = 10
         assert p.m == 10
 
-        exception = "Parameter 'm' must be at least -1, not -10."
+        exception = "Number parameter 'P.m' must be at least -1, not -10."
         with self.assertRaisesRegex(ValueError, exception):
             p.m = -10
 
         p.n = -10
         assert p.n == -10
 
-        exception = "Parameter 'n' must be at most 1, not 10."
+        exception = "Number parameter 'P.n' must be at most 1, not 10."
         with self.assertRaisesRegex(ValueError, exception):
             p.n = 10
 
@@ -173,52 +173,52 @@ class TestNumberParameters(unittest.TestCase):
 
     def test_inclusive_bounds_error_on_bounds(self):
         p = self.P()
-        exception = "Parameter 'j' must be greater than -1, not -1."
+        exception = "Number parameter 'P.j' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.j = -1
         with self.assertRaisesRegex(ValueError, exception):
             p.j = -1
 
-        exception = "Parameter 'k' must be less than 1, not 1."
+        exception = "Number parameter 'P.k' must be less than 1, not 1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.k = 1
         with self.assertRaisesRegex(ValueError, exception):
             p.k = 1
 
-        exception = "Parameter 'l' must be greater than -1, not -1."
+        exception = "Number parameter 'P.l' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.l = -1
         with self.assertRaisesRegex(ValueError, exception):
             p.l = -1
-        exception = "Parameter 'l' must be less than 1, not 1."
+        exception = "Number parameter 'P.l' must be less than 1, not 1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.l = 1
         with self.assertRaisesRegex(ValueError, exception):
             p.l = 1
 
     def test_inclusive_bounds_error_on_bounds_post(self):
-        exception = "Parameter None must be greater than -1, not -1."
+        exception = "Number parameter 'j' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             class P(param.Parameterized):
                 j = param.Number(default=-1, bounds=(-1, 1), inclusive_bounds=(False, True))
 
-        exception = "Parameter None must be less than 1, not 1"
+        exception = "Number parameter 'j' must be less than 1, not 1"
         with self.assertRaisesRegex(ValueError, exception):
             class Q(param.Parameterized):
                 j = param.Number(default=1, bounds=(-1, 1), inclusive_bounds=(True, False))
 
-        exception = "Parameter None must be greater than -1, not -1."
+        exception = "Number parameter 'j' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             class R(param.Parameterized):
                 j = param.Number(default=-1, bounds=(-1, 1), inclusive_bounds=(False, False))
 
-        exception = "Parameter None must be less than 1, not 1."
+        exception = "Number parameter 'j' must be less than 1, not 1."
         with self.assertRaisesRegex(ValueError, exception):
             class S(param.Parameterized):
                 j = param.Number(default=1, bounds=(-1, 1), inclusive_bounds=(False, False))
 
     def test_invalid_default_for_bounds(self):
-        exception = "Parameter None must be at least 10, not 0.0."
+        exception = "Number parameter 'n' must be at least 10, not 0.0."
         with self.assertRaisesRegex(ValueError, exception):
             class P(param.Parameterized):
                 n = param.Number(bounds=(10, 20))
@@ -232,7 +232,7 @@ class TestNumberParameters(unittest.TestCase):
         class Q(param.Parameterized):
             q = param.Number(default=lambda: 'test')
 
-        exception = "Parameter 'q' only takes numeric values, not type <(class|type) 'str'>."
+        exception = "Number parameter 'Q.q' only takes numeric values, not type <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, exception):
             Q.q
 
@@ -245,7 +245,7 @@ class TestNumberParameters(unittest.TestCase):
         class Q(param.Parameterized):
             q = param.Number(default=lambda: 2, bounds=(0, 1))
 
-        exception = "Parameter 'q' must be at most 1, not 2."
+        exception = "Number parameter 'Q.q' must be at most 1, not 2."
         with self.assertRaisesRegex(ValueError, exception):
             Q.q
 
@@ -405,7 +405,7 @@ class TestIntegerParameters(unittest.TestCase):
         self.P.d = None
         assert self.P.d is None
 
-        exception = "Integer parameter 'b' must be an integer, not type <(class|type) 'NoneType'>."
+        exception = "Integer parameter 'P.b' must be an integer, not type <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.b = None
 
@@ -416,7 +416,7 @@ class TestIntegerParameters(unittest.TestCase):
         p.d = None
         assert p.d is None
 
-        exception = "Integer parameter 'b' must be an integer, not type <(class|type) 'NoneType'>."
+        exception = "Integer parameter 'P.b' must be an integer, not type <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             p.b = None
 
@@ -442,17 +442,17 @@ class TestIntegerParameters(unittest.TestCase):
         self.assertEqual(p.param['f'].step, 1)
 
     def test_step_invalid_type_number_parameter(self):
-        exception = "Step can only be None or an integer value"
+        exception = "Attribute 'step' of Integer parameter can only be None or an integer value"
         with self.assertRaisesRegex(ValueError, exception):
             param.Integer(step='invalid value')
 
     def test_step_invalid_type_integer_parameter(self):
-        exception = "Step can only be None or an integer value"
+        exception = "Attribute 'step' of Integer parameter can only be None or an integer value"
         with self.assertRaisesRegex(ValueError, exception):
             param.Integer(step=3.4)
 
     def test_outside_bounds(self):
-        exception = "Parameter 'h' must be at most 2, not 10."
+        exception = "Integer parameter 'P.h' must be at most 2, not 10."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.h = 10
 
@@ -465,14 +465,14 @@ class TestIntegerParameters(unittest.TestCase):
         self.P.m = 10
         assert self.P.m == 10
 
-        exception = "Parameter 'm' must be at least -1, not -10."
+        exception = "Integer parameter 'P.m' must be at least -1, not -10."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.m = -10
 
         self.P.n = -10
         assert self.P.n == -10
 
-        exception = "Parameter 'n' must be at most 1, not 10."
+        exception = "Integer parameter 'P.n' must be at most 1, not 10."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.n = 10
 
@@ -482,14 +482,14 @@ class TestIntegerParameters(unittest.TestCase):
         p.m = 10
         assert p.m == 10
 
-        exception = "Parameter 'm' must be at least -1, not -10."
+        exception = "Integer parameter 'P.m' must be at least -1, not -10."
         with self.assertRaisesRegex(ValueError, exception):
             p.m = -10
 
         p.n = -10
         assert p.n == -10
 
-        exception = "Parameter 'n' must be at most 1, not 10."
+        exception = "Integer parameter 'P.n' must be at most 1, not 10."
         with self.assertRaisesRegex(ValueError, exception):
             p.n = 10
 
@@ -520,52 +520,52 @@ class TestIntegerParameters(unittest.TestCase):
 
     def test_inclusive_bounds_error_on_bounds(self):
         p = self.P()
-        exception = "Parameter 'j' must be greater than -1, not -1."
+        exception = "Integer parameter 'P.j' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.j = -1
         with self.assertRaisesRegex(ValueError, exception):
             p.j = -1
 
-        exception = "Parameter 'k' must be less than 1, not 1."
+        exception = "Integer parameter 'P.k' must be less than 1, not 1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.k = 1
         with self.assertRaisesRegex(ValueError, exception):
             p.k = 1
 
-        exception = "Parameter 'l' must be greater than -1, not -1."
+        exception = "Integer parameter 'P.l' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.l = -1
         with self.assertRaisesRegex(ValueError, exception):
             p.l = -1
-        exception = "Parameter 'l' must be less than 1, not 1."
+        exception = "Integer parameter 'P.l' must be less than 1, not 1."
         with self.assertRaisesRegex(ValueError, exception):
             self.P.l = 1
         with self.assertRaisesRegex(ValueError, exception):
             p.l = 1
 
     def test_inclusive_bounds_error_on_bounds_post(self):
-        exception = "Parameter None must be greater than -1, not -1."
+        exception = "Integer parameter 'j' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             class P(param.Parameterized):
                 j = param.Integer(default=-1, bounds=(-1, 1), inclusive_bounds=(False, True))
 
-        exception = "Parameter None must be less than 1, not 1"
+        exception = "Integer parameter 'j' must be less than 1, not 1"
         with self.assertRaisesRegex(ValueError, exception):
             class Q(param.Parameterized):
                 j = param.Integer(default=1, bounds=(-1, 1), inclusive_bounds=(True, False))
 
-        exception = "Parameter None must be greater than -1, not -1."
+        exception = "Integer parameter 'j' must be greater than -1, not -1."
         with self.assertRaisesRegex(ValueError, exception):
             class R(param.Parameterized):
                 j = param.Integer(default=-1, bounds=(-1, 1), inclusive_bounds=(False, False))
 
-        exception = "Parameter None must be less than 1, not 1."
+        exception = "Integer parameter 'j' must be less than 1, not 1."
         with self.assertRaisesRegex(ValueError, exception):
             class S(param.Parameterized):
                 j = param.Integer(default=1, bounds=(-1, 1), inclusive_bounds=(False, False))
 
     def test_invalid_default_for_bounds(self):
-        exception = "Parameter None must be at least 10, not 0."
+        exception = "Integer parameter 'n' must be at least 10, not 0."
         with self.assertRaisesRegex(ValueError, exception):
             class P(param.Parameterized):
                 n = param.Integer(bounds=(10, 20))
@@ -579,7 +579,7 @@ class TestIntegerParameters(unittest.TestCase):
         class Q(param.Parameterized):
             q = param.Integer(default=lambda: 'test')
 
-        exception = "Integer parameter 'q' must be an integer, not type <(class|type) 'str'>."
+        exception = "Integer parameter 'Q.q' must be an integer, not type <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, exception):
             Q.q
 
@@ -592,7 +592,7 @@ class TestIntegerParameters(unittest.TestCase):
         class Q(param.Parameterized):
             q = param.Integer(default=lambda: 2, bounds=(0, 1))
 
-        exception = "Parameter 'q' must be at most 1, not 2."
+        exception = "Integer parameter 'Q.q' must be at most 1, not 2."
         with self.assertRaisesRegex(ValueError, exception):
             Q.q
 

--- a/tests/testobjectselector.py
+++ b/tests/testobjectselector.py
@@ -5,6 +5,7 @@ Originally implemented as doctests in Topographica in the file
 testEnumerationParameter.txt
 """
 
+import re
 import unittest
 
 from collections import OrderedDict
@@ -231,7 +232,10 @@ class TestObjectSelectorParameters(unittest.TestCase):
         p = self.P()
         p.param.e.objects = [8, 9]
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(r"ObjectSelector parameter 'P.e' does not accept 7, valid options include: '[8, 9]'")
+        ):
             p.e = 7
 
         self.assertEqual(p.param.e.objects, [8, 9])
@@ -374,7 +378,10 @@ class TestObjectSelectorParameters(unittest.TestCase):
         p = self.P()
         p.param.s.objects = {'seven': 7, 'eight': 8}
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(r"ObjectSelector parameter 'P.s' does not accept 1, valid options include: '[7, 8]'")
+        ):
             p.s = 1
 
         self.assertEqual(p.param.s.objects, [7, 8])

--- a/tests/testobjectselector.py
+++ b/tests/testobjectselector.py
@@ -234,7 +234,7 @@ class TestObjectSelectorParameters(unittest.TestCase):
 
         with pytest.raises(
             ValueError,
-            match=re.escape(r"ObjectSelector parameter 'P.e' does not accept 7, valid options include: '[8, 9]'")
+            match=re.escape(r"ObjectSelector parameter 'P.e' does not accept 7; valid options include: '[8, 9]'")
         ):
             p.e = 7
 
@@ -380,7 +380,7 @@ class TestObjectSelectorParameters(unittest.TestCase):
 
         with pytest.raises(
             ValueError,
-            match=re.escape(r"ObjectSelector parameter 'P.s' does not accept 1, valid options include: '[7, 8]'")
+            match=re.escape(r"ObjectSelector parameter 'P.s' does not accept 1; valid options include: '[7, 8]'")
         ):
             p.s = 1
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1148,7 +1148,7 @@ def test_inheritance_with_incompatible_defaults():
     with pytest.raises(ValueError) as excinfo:
         class B(A):
             p = param.Number()
-    assert "Number parameter 'B.p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
+    assert "Number parameter 'B.p' only takes numeric values, not <class 'str'>" in str(excinfo.value)
 
 
 def test_inheritance_default_validation_with_more_specific_type():
@@ -1158,7 +1158,7 @@ def test_inheritance_default_validation_with_more_specific_type():
     with pytest.raises(ValueError) as excinfo:
         class B(A):
             p = param.NumericTuple()
-    assert "NumericTuple parameter 'B.p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
+    assert "NumericTuple parameter 'B.p' only takes numeric values, not <class 'str'>" in str(excinfo.value)
 
 
 def test_inheritance_from_multiple_params_class():

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1148,7 +1148,7 @@ def test_inheritance_with_incompatible_defaults():
     with pytest.raises(ValueError) as excinfo:
         class B(A):
             p = param.Number()
-    assert "Parameter 'p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
+    assert "Number parameter 'B.p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
 
 
 def test_inheritance_default_validation_with_more_specific_type():
@@ -1158,7 +1158,7 @@ def test_inheritance_default_validation_with_more_specific_type():
     with pytest.raises(ValueError) as excinfo:
         class B(A):
             p = param.NumericTuple()
-    assert "NumericTuple parameter 'p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
+    assert "NumericTuple parameter 'B.p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
 
 
 def test_inheritance_from_multiple_params_class():

--- a/tests/testpathparam.py
+++ b/tests/testpathparam.py
@@ -99,7 +99,7 @@ class TestPathParameters(unittest.TestCase):
         assert p.param.b.allow_None is False
         # This should probably raise an error (#708)
 
-        with pytest.raises(ValueError, match=re.escape(r"'Path' Parameter 'b' does not accept None")):
+        with pytest.raises(ValueError, match=re.escape(r"Path parameter 'P.b' does not accept None")):
             p.b = None
 
     def test_relative_cwd_class(self):
@@ -300,7 +300,7 @@ class TestFilenameParameters(unittest.TestCase):
         p = self.P()
 
         assert p.param.b.allow_None is False
-        with pytest.raises(ValueError, match=re.escape(r"'Filename' Parameter 'b' does not accept None")):
+        with pytest.raises(ValueError, match=re.escape(r"Filename parameter 'P.b' does not accept None")):
             p.b = None
 
     def test_search_paths(self):
@@ -421,7 +421,7 @@ class TestFoldernameParameters(unittest.TestCase):
 
         assert p.param.b.allow_None is False
 
-        with pytest.raises(ValueError, match=re.escape(r"'Foldername' Parameter 'b' does not accept None")):
+        with pytest.raises(ValueError, match=re.escape(r"Foldername parameter 'P.b' does not accept None")):
             p.b = None
 
     def test_search_paths(self):

--- a/tests/testrangeparameter.py
+++ b/tests/testrangeparameter.py
@@ -157,7 +157,7 @@ class TestRangeParameters(unittest.TestCase):
         self.assertEqual(q.get_soft_bounds(), (1, 9))
 
     def test_validate_step(self):
-        msg = r"Step can only be None or a numeric value, not type <class 'str'>."
+        msg = re.escape("Attribute 'step' of Range parameter can only be None or a numeric value, not type <class 'str'>.")
 
         p = param.Range((1, 2), bounds=(0, 10), step=1)
         assert p.step == 1
@@ -166,7 +166,7 @@ class TestRangeParameters(unittest.TestCase):
             param.Range((1, 2), bounds=(0, 10), step="1")
 
     def test_validate_order_on_val_with_positive_step(self):
-        msg = r"Range parameter 'q's end 1 is less than its start 2 with positive step 1."
+        msg = re.escape("Range parameter 'Q.q' end 1 is less than its start 2 with positive step 1.")
 
         class Q(param.Parameterized):
             q = param.Range(bounds=(0, 10), step=1)
@@ -175,7 +175,7 @@ class TestRangeParameters(unittest.TestCase):
             Q.q = (2, 1)
 
     def test_validate_order_on_val_with_negative_step(self):
-        msg = r"Range parameter 'q's start -4 is less than its end -2 with negative step -1."
+        msg = re.escape("Range parameter 'Q.q' start -4 is less than its start -2 with negative step -1.")
 
         class Q(param.Parameterized):
             q = param.Range(bounds=(-5, -1), step=-1)
@@ -184,7 +184,7 @@ class TestRangeParameters(unittest.TestCase):
             Q.q = (-4, -2)
 
     def test_validate_step_order_cannot_be_0(self):
-        msg = r"Step cannot be 0."
+        msg = re.escape("Attribute 'step' of Range parameter cannot be 0.")
 
         with self.assertRaisesRegex(ValueError, msg):
             param.Range(bounds=(0, 10), step=0)

--- a/tests/testrangeparameter.py
+++ b/tests/testrangeparameter.py
@@ -157,7 +157,7 @@ class TestRangeParameters(unittest.TestCase):
         self.assertEqual(q.get_soft_bounds(), (1, 9))
 
     def test_validate_step(self):
-        msg = re.escape("Attribute 'step' of Range parameter can only be None or a numeric value, not type <class 'str'>.")
+        msg = re.escape("Attribute 'step' of Range parameter can only be None or a numeric value, not <class 'str'>.")
 
         p = param.Range((1, 2), bounds=(0, 10), step=1)
         assert p.step == 1

--- a/tests/testrangeparameter.py
+++ b/tests/testrangeparameter.py
@@ -1,9 +1,11 @@
 """
 Unit test for Range parameters.
 """
+import re
 import unittest
 
 import param
+import pytest
 
 
 class TestRangeParameters(unittest.TestCase):
@@ -51,29 +53,29 @@ class TestRangeParameters(unittest.TestCase):
 
     def test_raise_not_2_tuple(self):
         p = self.P()
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of Range parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             p.e = (1, 2, 3)
 
     def test_raise_if_value_bad_length_constructor(self):
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of Range parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             self.P(e=(1, 1, 1))
 
     def test_raise_if_value_bad_length_setattr(self):
         p = self.P()
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of Range parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             p.e = (1, 1, 1)
 
     def test_raise_if_default_is_None_and_no_length(self):
-        msg = "length must be specified if no default is supplied"
+        msg = "Attribute 'length' of NumericTuple parameter 't' must be specified if no default is supplied"
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 t = param.NumericTuple(default=None)
 
     def test_bad_type(self):
-        msg = r"Tuple parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"Range parameter 'P.e' only takes a tuple value, not <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = 'test'
@@ -86,10 +88,10 @@ class TestRangeParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = 'test'
 
-        msg = r"Tuple parameter None only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"Range parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
-                e = param.NumericTuple(default='test')
+                e = param.Range(default='test')
 
     def test_support_allow_None_True(self):
         p = self.P()
@@ -105,22 +107,20 @@ class TestRangeParameters(unittest.TestCase):
 
     def test_support_allow_None_False(self):
         p = self.P()
-        msg = "Tuple parameter 'g' only takes a tuple value, not <(class|type) 'NoneType'>."
+        msg = "Range parameter 'P.g' only takes a tuple value, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, msg):
             p.g = None
 
-        msg = "Tuple parameter 'g' only takes a tuple value, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, msg):
             self.P.g = None
 
     def test_initialization_out_of_bounds(self):
-        try:
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Attribute 'bound' of Range parameter 'q' must be in range '[0, 1]'.")
+        ):
             class Q(param.Parameterized):
                 q = param.Range((0, 2), bounds=(0, 1))
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("No exception raised on out-of-bounds date")
 
     def test_set_exclusive_out_of_bounds_upper(self):
         class Q(param.Parameterized):

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -121,7 +121,7 @@ class TestSelectorParameters(unittest.TestCase):
         assert P.a is None
         with pytest.raises(
             ValueError,
-            match=re.escape(r"Selector parameter 'P.b' does not accept None, valid options include: '[1]'")
+            match=re.escape(r"Selector parameter 'P.b' does not accept None; valid options include: '[1]'")
         ):
             P.b = None
         P.c = None

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -4,6 +4,7 @@ Unit test for object selector parameters.
 Originally implemented as doctests in Topographica in the file
 testEnumerationParameter.txt
 """
+import re
 import unittest
 
 from collections import OrderedDict
@@ -118,7 +119,10 @@ class TestSelectorParameters(unittest.TestCase):
 
         P.a = None
         assert P.a is None
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(r"Selector parameter 'P.b' does not accept None, valid options include: '[1]'")
+        ):
             P.b = None
         P.c = None
         assert P.c is None

--- a/tests/teststringparam.py
+++ b/tests/teststringparam.py
@@ -52,7 +52,7 @@ class TestStringParameters(unittest.TestCase):
 
         a = A()
 
-        exception = "String parameter 'A.s' only takes a string value, not value of type <class 'NoneType'>."
+        exception = "String parameter 'A.s' only takes a string value, not value of <class 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 

--- a/tests/teststringparam.py
+++ b/tests/teststringparam.py
@@ -52,7 +52,7 @@ class TestStringParameters(unittest.TestCase):
 
         a = A()
 
-        exception = "String parameter 's' only takes a string value, not value of type <class 'NoneType'>."
+        exception = "String parameter 'A.s' only takes a string value, not value of type <class 'NoneType'>."
         with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 
@@ -70,13 +70,13 @@ class TestStringParameters(unittest.TestCase):
 
         a = A()
 
-        exception = "String parameter 's' value '123.123.0.256' does not match regex '%s'."  % ip_regex
+        exception = "String parameter 'A.s' value '123.123.0.256' does not match regex '%s'."  % ip_regex
         with self.assertRaises(ValueError) as e:
             a.s = '123.123.0.256'
         self.assertEqual(str(e.exception), exception.replace('\\', '\\\\'))
 
     def test_regex_incorrect_default(self):
-        exception = "String parameter None value '' does not match regex '%s'." % ip_regex
+        exception = "String parameter 's' value '' does not match regex '%s'." % ip_regex
         with self.assertRaises(ValueError) as e:
             class A(param.Parameterized):
                 s = param.String(regex=ip_regex)  # default value '' does not match regular expression

--- a/tests/testtupleparam.py
+++ b/tests/testtupleparam.py
@@ -327,7 +327,7 @@ class TestNumericTupleParameters(unittest.TestCase):
         assert P.h == (1, 1)
 
     def test_raise_on_non_numeric_values(self):
-        msg = r"NumericTuple parameter 'P.e' only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"NumericTuple parameter 'P.e' only takes numeric values, not <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = ('bad', 1)
@@ -340,7 +340,7 @@ class TestNumericTupleParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = ('bad', 1)
 
-        msg = r"NumericTuple parameter 'e' only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"NumericTuple parameter 'e' only takes numeric values, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 e = param.NumericTuple(default=('bad', 1))
@@ -442,7 +442,7 @@ class TestXYCoordinatesParameters(unittest.TestCase):
             self.P.g = None
 
     def test_raise_on_non_numeric_values(self):
-        msg = r"XYCoordinates parameter 'P.e' only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"XYCoordinates parameter 'P.e' only takes numeric values, not <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = ('bad', 1)
@@ -455,7 +455,7 @@ class TestXYCoordinatesParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = ('bad', 1)
 
-        msg = r"XYCoordinates parameter 'e' only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"XYCoordinates parameter 'e' only takes numeric values, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 e = param.XYCoordinates(default=('bad', 1))

--- a/tests/testtupleparam.py
+++ b/tests/testtupleparam.py
@@ -70,18 +70,18 @@ class TestTupleParameters(unittest.TestCase):
         assert p.param.f.length == 3
 
     def test_raise_if_value_bad_length_constructor(self):
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of Tuple parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             self.P(e=(1, 1, 'extra'))
 
     def test_raise_if_value_bad_length_setattr(self):
         p = self.P()
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of Tuple parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             p.e = (1, 1, 'extra')
 
     def test_raise_if_default_is_None_and_no_length(self):
-        msg = "length must be specified if no default is supplied"
+        msg = "Attribute 'length' of Tuple parameter 't' must be specified if no default is supplied"
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 t = param.Tuple(default=None)
@@ -93,7 +93,7 @@ class TestTupleParameters(unittest.TestCase):
         assert p.param.g.allow_None
 
     def test_raise_if_default_is_None_and_bad_length(self):
-        msg = r"Tuple parameter 'g' is not of the correct length \(2 instead of 3\)."
+        msg = r"Attribute 'length' of Tuple parameter 'P.g' is not of the correct length \(2 instead of 3\)."
         with self.assertRaisesRegex(ValueError, msg):
             p = self.P(g=(0, 0))
 
@@ -102,7 +102,7 @@ class TestTupleParameters(unittest.TestCase):
             p.g = (0, 0)
 
     def test_bad_type(self):
-        msg = r"Tuple parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"Tuple parameter 'P.e' only takes a tuple value, not <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = 'test'
@@ -115,7 +115,7 @@ class TestTupleParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = 'test'
 
-        msg = r"Tuple parameter None only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"Tuple parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 e = param.Tuple(default='test')
@@ -262,18 +262,18 @@ class TestNumericTupleParameters(unittest.TestCase):
         assert p.param.f.length == 3
 
     def test_raise_if_value_bad_length_constructor(self):
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of NumericTuple parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             self.P(e=(1, 1, 1))
 
     def test_raise_if_value_bad_length_setattr(self):
         p = self.P()
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of NumericTuple parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             p.e = (1, 1, 1)
 
     def test_raise_if_default_is_None_and_no_length(self):
-        msg = "length must be specified if no default is supplied"
+        msg = "Attribute 'length' of NumericTuple parameter 't' must be specified if no default is supplied"
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 t = param.NumericTuple(default=None)
@@ -285,7 +285,7 @@ class TestNumericTupleParameters(unittest.TestCase):
         assert p.param.g.allow_None
 
     def test_raise_if_default_is_None_and_bad_length(self):
-        msg = r"Tuple parameter 'g' is not of the correct length \(2 instead of 3\)."
+        msg = r"Attribute 'length' of NumericTuple parameter 'P.g' is not of the correct length \(2 instead of 3\)."
         with self.assertRaisesRegex(ValueError, msg):
             p = self.P(g=(0, 0))
 
@@ -294,7 +294,7 @@ class TestNumericTupleParameters(unittest.TestCase):
             p.g = (0, 0)
 
     def test_bad_type(self):
-        msg = r"Tuple parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"NumericTuple parameter 'P.e' only takes a tuple value, not <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = 'test'
@@ -307,7 +307,7 @@ class TestNumericTupleParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = 'test'
 
-        msg = r"Tuple parameter None only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"NumericTuple parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 e = param.NumericTuple(default='test')
@@ -327,7 +327,7 @@ class TestNumericTupleParameters(unittest.TestCase):
         assert P.h == (1, 1)
 
     def test_raise_on_non_numeric_values(self):
-        msg = r"NumericTuple parameter 'e' only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"NumericTuple parameter 'P.e' only takes numeric values, not type <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = ('bad', 1)
@@ -340,7 +340,7 @@ class TestNumericTupleParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = ('bad', 1)
 
-        msg = r"NumericTuple parameter None only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"NumericTuple parameter 'e' only takes numeric values, not type <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
                 e = param.NumericTuple(default=('bad', 1))
@@ -390,18 +390,18 @@ class TestXYCoordinatesParameters(unittest.TestCase):
         self.assertEqual(p.e, (2, 2))
 
     def test_raise_if_value_bad_length_constructor(self):
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of XYCoordinates parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             self.P(e=(1, 1, 1))
 
     def test_raise_if_value_bad_length_setattr(self):
         p = self.P()
-        msg = r"Tuple parameter 'e' is not of the correct length \(3 instead of 2\)"
+        msg = r"Attribute 'length' of XYCoordinates parameter 'P.e' is not of the correct length \(3 instead of 2\)"
         with self.assertRaisesRegex(ValueError, msg):
             p.e = (1, 1, 1)
 
     def test_bad_type(self):
-        msg = r"Tuple parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"XYCoordinates parameter 'P.e' only takes a tuple value, not <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = 'test'
@@ -414,10 +414,10 @@ class TestXYCoordinatesParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = 'test'
 
-        msg = r"Tuple parameter None only takes a tuple value, not <(class|type) 'str'>."
+        msg = r"XYCoordinates parameter 'e' only takes a tuple value, not <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
-                e = param.NumericTuple(default='test')
+                e = param.XYCoordinates(default='test')
 
     def test_support_allow_None_True(self):
         p = self.P()
@@ -433,16 +433,16 @@ class TestXYCoordinatesParameters(unittest.TestCase):
 
     def test_support_allow_None_False(self):
         p = self.P()
-        msg = "Tuple parameter 'g' only takes a tuple value, not <(class|type) 'NoneType'>."
+        msg = "XYCoordinates parameter 'P.g' only takes a tuple value, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, msg):
             p.g = None
 
-        msg = "Tuple parameter 'g' only takes a tuple value, not <(class|type) 'NoneType'>."
+        msg = "XYCoordinates parameter 'P.g' only takes a tuple value, not <(class|type) 'NoneType'>."
         with self.assertRaisesRegex(ValueError, msg):
             self.P.g = None
 
     def test_raise_on_non_numeric_values(self):
-        msg = r"NumericTuple parameter 'e' only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"XYCoordinates parameter 'P.e' only takes numeric values, not type <(class|type) 'str'>."
 
         with self.assertRaisesRegex(ValueError, msg):
             self.P.e = ('bad', 1)
@@ -455,10 +455,10 @@ class TestXYCoordinatesParameters(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             p.e = ('bad', 1)
 
-        msg = r"NumericTuple parameter None only takes numeric values, not type <(class|type) 'str'>."
+        msg = r"XYCoordinates parameter 'e' only takes numeric values, not type <(class|type) 'str'>."
         with self.assertRaisesRegex(ValueError, msg):
             class P(param.Parameterized):
-                e = param.NumericTuple(default=('bad', 1))
+                e = param.XYCoordinates(default=('bad', 1))
 
     @pytest.mark.skipif(np is None, reason='NumPy is not available')
     def test_support_numpy_values(self):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -335,3 +335,44 @@ def test_both_method():
     a = A()
 
     assert a.method() is a
+
+
+def test_error_prefix_unbound_defined():
+    with pytest.raises(ValueError, match="Number parameter 'x' only"):
+        x = param.Number('wrong')  # noqa
+
+
+def test_error_prefix_unbound_unexpected_pattern():
+    from param import Number
+    with pytest.raises(ValueError, match="Number parameter only"):
+        Number('wrong')
+
+
+def test_error_prefix_before_class_creation():
+    with pytest.raises(ValueError, match="Number parameter 'x' only"):
+        class P(param.Parameterized):
+            x = param.Number('wrong')
+
+
+def test_error_prefix_set_class():
+    class P(param.Parameterized):
+        x = param.Number()
+    with pytest.raises(ValueError, match="Number parameter 'P.x' only"):
+        P.x = 'wrong'
+
+
+def test_error_prefix_instantiate():
+    class P(param.Parameterized):
+        x = param.Number()
+    with pytest.raises(ValueError, match="Number parameter 'P.x' only"):
+        P(x='wrong')
+
+
+def test_error_prefix_set_instance():
+    class P(param.Parameterized):
+        x = param.Number()
+
+    p = P()
+
+    with pytest.raises(ValueError, match="Number parameter 'P.x' only"):
+        p.x = 'wrong'


### PR DESCRIPTION
The error messages raised by Parameters are pretty inconsistent and often lack context.

For now with this PR I'm just seeking feedback on a utility I've added that builds a message supposed to prefix most of (if not all) the errors raised by Parameters. I've just adapted the type validation performed by `Number` to show the error messages emitted in various situations:

<img width="701" alt="image" src="https://github.com/holoviz/param/assets/35924738/3f1a6b9a-3edc-42dd-8941-ab1475d93217">

(I'd hope to get this into the 2.0 release.)