### PR TITLE
Re-validate default when Parameter type changes on subclass

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3153,8 +3153,7 @@ class ParameterizedMetaclass(type):
         # A Parameter has no way to find out the name a
         # Parameterized class has for it
         param._set_names(param_name)
-        mcs.__param_inheritance(param_name,param)
-
+        mcs.__param_inheritance(param_name, param)
 
     # Should use the official Python 2.6+ abstract base classes; see
     # https://github.com/holoviz/param/issues/84
@@ -3249,7 +3248,7 @@ class ParameterizedMetaclass(type):
             if isinstance(value,Parameter):
                 mcs.__param_inheritance(attribute_name,value)
 
-    def __param_inheritance(mcs,param_name,param):
+    def __param_inheritance(mcs, param_name, param):
         """
         Look for Parameter values in superclasses of this
         Parameterized class.
@@ -3281,27 +3280,35 @@ class ParameterizedMetaclass(type):
         # get all relevant slots (i.e. slots defined in all
         # superclasses of this parameter)
         slots = {}
-        for p_class in classlist(type(param))[1::]:
+        p_type = type(param)
+        for i, p_class in enumerate(classlist(p_type)[1::]):
             slots.update(dict.fromkeys(p_class.__slots__))
-
 
         # note for some eventual future: python 3.6+ descriptors grew
         # __set_name__, which could replace this and _set_names
-        setattr(param,'owner',mcs)
+        setattr(param, 'owner', mcs)
         del slots['owner']
 
         # backwards compatibility (see Composite parameter)
         if 'objtype' in slots:
-            setattr(param,'objtype',mcs)
+            setattr(param, 'objtype', mcs)
             del slots['objtype']
 
         supers = classlist(mcs)[::-1]
 
-        # instantiate is handled specially
+        # Explicitly inherit instantiate from super class and
+        # check if type has changed to a more specific or different
+        # Parameter type, requiring extra validation
+        type_change = False
         for superclass in supers:
             super_param = superclass.__dict__.get(param_name)
-            if isinstance(super_param, Parameter) and super_param.instantiate is True:
-                param.instantiate=True
+            if not isinstance(super_param, Parameter):
+                continue
+            if super_param.instantiate is True:
+                param.instantiate = True
+            super_type = type(super_param)
+            if not issubclass(super_type, p_type):
+                type_change = True
         del slots['instantiate']
 
         callables = {}
@@ -3346,6 +3353,11 @@ class ParameterizedMetaclass(type):
         # that need updates to make sure they're set up correctly after inheritance.
         param._update_state()
 
+        # If the type has changed to a more specific or different type
+        # validate the default again.
+        if type_change:
+            param._validate(param.default)
+
     def get_param_descriptor(mcs,param_name):
         """
         Goes up the class hierarchy (starting from the current class)
@@ -3359,7 +3371,6 @@ class ParameterizedMetaclass(type):
             if isinstance(attribute,Parameter):
                 return attribute,c
         return None,None
-
 
 
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3281,7 +3281,7 @@ class ParameterizedMetaclass(type):
         # superclasses of this parameter)
         slots = {}
         p_type = type(param)
-        for i, p_class in enumerate(classlist(p_type)[1::]):
+        for p_class in classlist(p_type)[1::]:
             slots.update(dict.fromkeys(p_class.__slots__))
 
         # note for some eventual future: python 3.6+ descriptors grew

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1051,7 +1051,7 @@ def test_inheritance_attribute_from_non_subclass_not_inherited():
         p = param.String(doc='1')
 
     class B(A):
-        p = param.Number()
+        p = param.Number(default=0.1)
 
     b = B()
 
@@ -1075,24 +1075,23 @@ def test_inheritance_default_is_not_None_in_sub():
         p = param.String(default='1')
 
     class B(A):
-        p = param.Number()
+        p = param.Number(default=0.1)
 
     b = B()
 
-    # Could argue this should not be allowed.
-    assert b.p == '1'
+    assert b.p == 0.1
 
 
 def test_inheritance_default_is_None_in_sub():
     class A(param.Parameterized):
-        p = param.String(default='1')
+        p = param.Tuple(default=(0, 1))
 
     class B(A):
-        p = param.Action()
+        p = param.NumericTuple()
 
     b = B()
 
-    assert b.p == '1'
+    assert b.p == (0, 1)
 
 
 def test_inheritance_diamond_not_supported():
@@ -1171,25 +1170,25 @@ def test_inheritance_from_multiple_params_inst():
         p = param.Parameter(doc='foo')
 
     class B(A):
-        p = param.Action(default=2)
+        p = param.Dict(default={'foo': 'bar'})
 
     class C(B):
-        p = param.Date(instantiate=True)
+        p = param.ClassSelector(class_=object, allow_None=True)
 
     a = A()
     b = B()
     c = C()
 
-    assert a.param.p.instantiate is False
+    assert a.param.p.allow_None is True
     assert a.param.p.default is None
     assert a.param.p.doc == 'foo'
 
-    assert b.param.p.instantiate is False
-    assert b.param.p.default == 2
+    assert b.param.p.allow_None is False
+    assert b.param.p.default == {'foo': 'bar'}
     assert b.param.p.doc == 'foo'
 
-    assert c.param.p.instantiate is True
-    assert c.param.p.default == 2
+    assert c.param.p.allow_None is True
+    assert c.param.p.default == {'foo': 'bar'}
     assert c.param.p.doc == 'foo'
 
 
@@ -1201,12 +1200,12 @@ def test_inheritance_from_multiple_params_intermediate_setting():
     A.param.p.doc = 'bar'
 
     class B(A):
-        p = param.Action(default=2)
+        p = param.Dict(default={'foo': 'bar'})
 
     assert A.param.p.default == 1
     assert A.param.p.doc == 'bar'
 
-    assert B.param.p.default == 2
+    assert B.param.p.default == {'foo': 'bar'}
     assert B.param.p.doc == 'bar'
 
     a = A()
@@ -1215,7 +1214,7 @@ def test_inheritance_from_multiple_params_intermediate_setting():
     assert a.param.p.default == 1
     assert a.param.p.doc == 'bar'
 
-    assert b.param.p.default == 2
+    assert b.param.p.default == {'foo': 'bar'}
     assert b.param.p.doc == 'bar'
 
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1141,6 +1141,26 @@ def test_inheritance_diamond_not_supported():
     assert d.param.p.doc == '11'
 
 
+def test_inheritance_with_incompatible_defaults():
+    class A(param.Parameterized):
+        p = param.String()
+
+    with pytest.raises(ValueError) as excinfo:
+        class B(A):
+            p = param.Number()
+    assert "Parameter 'p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
+
+
+def test_inheritance_default_validation_with_more_specific_type():
+    class A(param.Parameterized):
+        p = param.Tuple(default=('a', 'b'))
+
+    with pytest.raises(ValueError) as excinfo:
+        class B(A):
+            p = param.NumericTuple()
+    assert "NumericTuple parameter 'p' only takes numeric values, not type <class 'str'>" in str(excinfo.value)
+
+
 def test_inheritance_from_multiple_params_class():
     class A(param.Parameterized):
         p = param.Parameter(doc='foo')


### PR DESCRIPTION
This PR re-validates the Parameter default if you override the Parameter type on a subclass to a more specific or completely different type. Technically it should also re-validate when certain slot values change but I wanted to start with a more limited change.

- [x] Fixes https://github.com/holoviz/param/issues/714
- [x] Add tests