### PR TITLE
Validate dependencies in constructor

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2607,6 +2607,14 @@ class Parameters:
         elif not dynamic:
             return [], [DInfo(spec=spec)]
         else:
+            if not hasattr(self_.self_or_cls, obj.split('.')[1]):
+                raise AttributeError(
+                    f'Dependency {obj[1:]!r} could not be resolved, {self_.self_or_cls} '
+                    f'has no parameter or attribute {obj.split(".")[1]!r}. Ensure '
+                    'the object being depended on is declared before calling the '
+                    'Parameterized constructor.'
+                )
+
             src = _getattrr(self_.self_or_cls, obj[1::], None)
             if src is None:
                 path = obj[1:].split('.')

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -1300,3 +1300,22 @@ def test_misspelled_parameter_in_depends_watch():
             @param.depends("tlim", watch=True)  # <- Misspelled xlim
             def test(self):
                 return True
+
+def test_param_depends_on_undefined_attribute():
+    class P2(param.Parameterized):
+        value = param.String()
+
+    class P1(param.Parameterized):
+
+        def __init__(self, **params):
+            super().__init__(**params)
+            self.p2 = P2()
+
+        @param.depends('p2.value', watch=True)
+        def cb(self):
+            print('fired')
+
+    with pytest.raises(AttributeError) as excinfo:
+        P1()
+
+    assert "Dependency '.p2' could not be resolved" in str(excinfo.value)

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -1318,4 +1318,4 @@ def test_param_depends_on_undefined_attribute():
     with pytest.raises(AttributeError) as excinfo:
         P1()
 
-    assert "Dependency '.p2' could not be resolved" in str(excinfo.value)
+    assert "Dependency 'p2' could not be resolved" in str(excinfo.value)


### PR DESCRIPTION
The dynamic resolution of dependencies loosened the validation for dependencies. However this was only intended to allow dynamic dependency resolution of the leafs or branches of nested dependencies, i.e. the root of a nested dependency has to be declared. This adds validation to ensure that the root dependency can be resolved and adds an error otherwise.

- [x] Fixes https://github.com/holoviz/param/issues/566
- [x] Add test(s)