### PR TITLE
Updating `path` on a `File/MultiFileSelector` Parameter updates `objects`

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2577,6 +2577,10 @@ class MultiFileSelector(ListSelector):
     """
     __slots__ = ['path']
 
+    _slot_defaults = _dict_update(
+        Selector._slot_defaults, path="",
+    )
+
     @typing.overload
     def __init__(
         self,
@@ -2588,20 +2592,24 @@ class MultiFileSelector(ListSelector):
         ...
 
     @_deprecate_positional_args
-    def __init__(self, default=Undefined, *, path="", **kwargs):
+    def __init__(self, default=Undefined, *, path=Undefined, **kwargs):
         self.default = default
         self.path = path
-        self.update()
+        self.update(path=path)
         super().__init__(default=default, objects=self.objects, **kwargs)
 
     def _on_set(self, attribute, old, new):
         super()._on_set(attribute, new, old)
         if attribute == 'path':
-            self.update()
+            self.update(path=new)
 
-    def update(self):
-        self.objects = sorted(glob.glob(self.path))
+    def update(self, path=Undefined):
+        if path is Undefined:
+            path = self.path
+        self.objects = sorted(glob.glob(path))
         if self.default and all([o in self.objects for o in self.default]):
+            return
+        elif not self.default:
             return
         self.default = self.objects
 

--- a/tests/testfileselector.py
+++ b/tests/testfileselector.py
@@ -116,6 +116,14 @@ class TestFileSelectorParameters(unittest.TestCase):
         # Default updated but not the value itself
         assert p.b == self.fa
 
+    def test_path_autoupdate(self):
+        p = self.P()
+        p.param.b.path = self.glob2
+        assert p.param.b.objects == [self.fc, self.fd]
+        assert p.param.b.default in [self.fc, self.fd]
+        # Default updated but not the value itself
+        assert p.b == self.fa
+
     def test_get_range(self):
         p = self.P()
         r = p.param.a.get_range()

--- a/tests/testmultifileselector.py
+++ b/tests/testmultifileselector.py
@@ -121,6 +121,14 @@ class TestMultiFileSelectorParameters(unittest.TestCase):
         # Default updated but not the value itself
         assert p.b == [self.fa]
 
+    def test_path_autoupdate(self):
+        p = self.P()
+        p.param.b.path = self.glob2
+        assert sorted(p.param.b.objects) == sorted([self.fc, self.fd])
+        assert sorted(p.param.b.default) == sorted([self.fc, self.fd])
+        # Default updated but not the value itself
+        assert p.b == [self.fa]
+
     def test_get_range(self):
         p = self.P()
         r = p.param.a.get_range()


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/545
Supersedes https://github.com/holoviz/param/pull/546

The issue stated about `FileSelector`:

> FileSelector behaves like Selector and should as such set its value to the first item of objects, objects being the result of a glob on path.

This has been addressed in https://github.com/holoviz/param/pull/801.

About `MultiFileSelector`:

> Also the docs currently state that the default value is all of the matched files, but in practice it's None.

While that's what the docs say, the behavior of `ListSelector` from which `MultiFileSelector` inherits is for `default` to be `None` so I'm not sure we should make this change without also updating `ListSelector`. Also, Panel maps the `MultiFileSelector` parameter to the [FileSelector](https://panel.holoviz.org/reference/widgets/FileSelector.html) widget (the `FileSelector` **Parameter** being mapped to a simple `Select` or `TextInput` widget) and I don't think we'd want all the files to be selected by default.

```python
import param

class P(param.Parameterized):
    ls = param.ListSelector(objects=[1, 2, 3])

a = A()

assert a.ls is None
```