### PR TITLE
Listselectordefault

### DIFF
--- a/numbergen/__init__.py
+++ b/numbergen/__init__.py
@@ -320,7 +320,7 @@ class TimeAwareRandomState(TimeAware):
     random_generator = param.Parameter(
         default=random.Random(c_size_t(hash((500,500))).value), doc=
         """
-        Random state used by the object. This may may be an instance
+        Random state used by the object. This may be an instance
         of random.Random from the Python standard library or an
         instance of numpy.random.RandomState.
 
@@ -458,9 +458,9 @@ class UniformRandom(RandomDistribution):
     See the random module for further details.
     """
 
-    lbound = param.Number(default=0.0,doc="inclusive lower bound")
+    lbound = param.Number(default=0.0,doc="Inclusive lower bound.")
 
-    ubound = param.Number(default=1.0,doc="exclusive upper bound")
+    ubound = param.Number(default=1.0,doc="Exclusive upper bound.")
 
 
     def __call__(self):
@@ -500,8 +500,8 @@ class UniformRandomInt(RandomDistribution):
     See the randint function in the random module for further details.
     """
 
-    lbound = param.Number(default=0,doc="inclusive lower bound")
-    ubound = param.Number(default=1000,doc="inclusive upper bound")
+    lbound = param.Number(default=0,doc="Inclusive lower bound.")
+    ubound = param.Number(default=1000,doc="Inclusive upper bound.")
 
 
     def __call__(self):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1792,7 +1792,7 @@ class Selector(SelectorBase, _SignatureSelector):
         self._validate_value(val)
 
     def _validate_value(self, val):
-        if self.check_on_set and not (self.allow_None and val is None) and not val in self.objects:
+        if self.check_on_set and not (self.allow_None and val is None) and val not in self.objects:
             items = []
             limiter = ']'
             length = 0

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2645,8 +2645,7 @@ class ListSelector(Selector):
     def _update_state(self):
         if self.check_on_set is False and self.default is not None:
             for o in self.default:
-                if o not in self.objects:
-                    self.objects.append(o)
+                self._ensure_value_is_in_objects(o)
 
 
 class MultiFileSelector(ListSelector):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1666,7 +1666,7 @@ _compute_selector_checking_default = __compute_selector_checking_default()
 
 
 class _SignatureSelector(Parameter):
-
+    # Needs docstring; why is this a separate mixin?
     _slot_defaults = _dict_update(
         SelectorBase._slot_defaults, _objects=_compute_selector_default,
         compute_default_fn=None, check_on_set=_compute_selector_checking_default,
@@ -1748,8 +1748,8 @@ class Selector(SelectorBase, _SignatureSelector):
             self.allow_None = self._slot_defaults['allow_None']
         else:
             self.allow_None = allow_None
-        if self.default is not None and self.check_on_set is True:
-            self._validate(self.default)
+        if self.default is not None:
+            self._validate_value(self.default)
         self._update_state()
 
     def _update_state(self):
@@ -1790,14 +1790,14 @@ class Selector(SelectorBase, _SignatureSelector):
                 self.objects.append(self.default)
 
     def _validate(self, val):
-        """
-        val must be None or one of the objects in self.objects.
-        """
         if not self.check_on_set:
             self._ensure_value_is_in_objects(val)
             return
 
-        if not (val in self.objects or (self.allow_None and val is None)):
+        self._validate_value(val)
+
+    def _validate_value(self, val):
+        if self.check_on_set and not (self.allow_None and val is None) and not val in self.objects:
             items = []
             limiter = ']'
             length = 0
@@ -1822,7 +1822,8 @@ class Selector(SelectorBase, _SignatureSelector):
         to check each item instead.
         """
         if not (val in self.objects):
-            self._objects.append(val)
+            # self._objects.append(val) doesn't work when _objects is []
+            self._objects = self._objects + [val]
 
     def get_range(self):
         """
@@ -2623,16 +2624,35 @@ class ListSelector(Selector):
                     self.objects.append(o)
 
     def _validate(self, val):
+        self._validate_type(val)
+
+        if self.check_on_set:
+            self._validate_value(val)
+        else:
+            self._ensure_value_is_in_objects(val)
+
+
+    def _validate_type(self, val):
         if (val is None and self.allow_None):
             return
+
         if not isinstance(val, list):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes list types, "
                 f"not {val!r}."
             )
-        for o in val:
-            super()._validate(o)
 
+    def _validate_value(self, val):
+        self._validate_type(val)
+        if val is not None:
+            for o in val:
+                super()._validate_value(o)
+
+    def _update_state(self):
+        if self.check_on_set is False and self.default is not None:
+            for o in self.default:
+                if o not in self.objects:
+                    self.objects.append(o)
 
 
 class MultiFileSelector(ListSelector):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1753,12 +1753,8 @@ class Selector(SelectorBase, _SignatureSelector):
         self._update_state()
 
     def _update_state(self):
-        if (
-            self.check_on_set is False
-            and self.default is not None
-            and self.default not in self.objects
-        ):
-            self.objects.append(self.default)
+        if self.check_on_set is False and self.default is not None:
+            self._ensure_value_is_in_objects(self.default)
 
     @property
     def objects(self):
@@ -1786,8 +1782,7 @@ class Selector(SelectorBase, _SignatureSelector):
         """
         if self.default is None and callable(self.compute_default_fn):
             self.default = self.compute_default_fn()
-            if self.default not in self.objects:
-                self.objects.append(self.default)
+            self._ensure_value_is_in_objects(self.default)
 
     def _validate(self, val):
         if not self.check_on_set:

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1822,8 +1822,7 @@ class Selector(SelectorBase, _SignatureSelector):
         to check each item instead.
         """
         if not (val in self.objects):
-            # self._objects.append(val) doesn't work when _objects is []
-            self._objects = self._objects + [val]
+            self._objects.append(val)
 
     def get_range(self):
         """

--- a/tests/testlistselector.py
+++ b/tests/testlistselector.py
@@ -18,7 +18,7 @@ class TestListSelectorParameters(unittest.TestCase):
         super().setUp()
         class P(param.Parameterized):
             e = param.ListSelector(default=[5],objects=[5,6,7])
-            f = param.ListSelector(default=10)
+            f = param.ListSelector(default=[10])
             h = param.ListSelector(default=None)
             g = param.ListSelector(default=None,objects=[7,8])
             i = param.ListSelector(default=[7],objects=[9],check_on_set=False)
@@ -173,16 +173,17 @@ class TestListSelectorParameters(unittest.TestCase):
             r = param.ListSelector(default=[6])
 
     ##########################
-    # CEBALERT: not sure it makes sense for ListSelector to be set to
-    # a non-iterable value (except None). I.e. I think this first test
-    # should fail.
     def test_default_not_checked_to_be_iterable(self):
-        class Q(param.Parameterized):
-            r = param.ListSelector(default=6)
+        with pytest.raises(
+            ValueError,
+            match=re.escape("ListSelector parameter 'r' only takes list types, not 6."),
+        ):
+            class Q(param.Parameterized):
+                r = param.ListSelector(default=6)
 
     def test_set_checked_to_be_iterable(self):
         class Q(param.Parameterized):
-            r = param.ListSelector(default=6,check_on_set=False)
+            r = param.ListSelector(default=[6],check_on_set=False)
 
         with self.assertRaises(ValueError):
             Q.r = 6


### PR DESCRIPTION
Fixes #807. Makes _update_state from #794 aware of list-type defaults so that it adds the items on the list to the objects, not the entire default value as a sublist. This change does seem to be successful, avoiding `objects=1, 2, 3, [1, 2]]`:

<img width="633" alt="image" src="https://github.com/holoviz/param/assets/1695496/696e15c4-3817-4aa0-92cb-1809e3bd182a">

Regarding the discussion in #807:

> Actually I'm even thinking that https://github.com/holoviz/param/issues/693 is a silly usage of Param and I'm no longer sure we should "fix" it. That's the example I shared in https://github.com/holoviz/param/issues/693, why would you not include 3 in the objects?? On top of that check_on_set is pretty clearly worded with on_set and not on_init.

After looking into it I agree. We definitely shouldn't do any extra work to make this code legal:

```python
import param

class P(param.Parameterized):
    s = param.Selector(default=3, objects=[1, 2], check_on_set=False)

p = P()
```

If people wanted 3 on the objects list, they should have put it there, since they supplied an objects list.  This code is currently accepted by this PR, yielding `p.params.objects=[1, 2, 3]`, but if it weren't, I'd be equally happy.

Less clear is what should happen when no objects list is supplied:

<img width="464" alt="image" src="https://github.com/holoviz/param/assets/1695496/e0646326-2b18-4849-8662-dd634d3bece1">

In this case, it does seem appropriate to be adding the default value to the objects list, and supporting this case automatically makes the above less-important case work.

The way it works still depends on Maxime's _update_state approach, which I can now appreciate. I had previously suggested trying to eliminate _update_state, but the problem (of which I'm sure @maximlt is aware) is that using the Sentinel approach for slot values means that the _objects list doesn't get a concrete value until after the constructor completes and returns control to the metaclass. By that point it's too late for the constructor to add items to the list based on the default, hence needing a new _update_state method to fill it in later. 

So if we want to eliminate _update_state (which is a worthwhile goal), I think we'd have to require the objects list to include the default value, which seems like a big disruption to previous usage. If Panel developers are ok with that, sure, but otherwise I guess we are stuck with _update_state.
