### PR TITLE
Ensure Parameter re-validates default if slot changes

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3388,7 +3388,7 @@ class ParameterizedMetaclass(type):
 
         # If the type has changed to a more specific or different type
         # or a slot value has been changed validate the default again.
-        if type_change or slot_overridden:
+        if type_change or slot_overridden and param.default is not None:
             param._validate(param.default)
 
     def get_param_descriptor(mcs,param_name):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3354,7 +3354,7 @@ class ParameterizedMetaclass(type):
                     # If we already know we have to re-validate abort
                     # early to avoid costly lookups
                     if slot_overridden or type_change:
-                        continue
+                        break
                 else:
                     if slot not in param._non_validated_slots:
                         slot_overridden = True

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1161,6 +1161,36 @@ def test_inheritance_default_validation_with_more_specific_type():
     assert "NumericTuple parameter 'B.p' only takes numeric values, not <class 'str'>" in str(excinfo.value)
 
 
+def test_inheritance_with_changing_bounds():
+    class A(param.Parameterized):
+        p = param.Number(default=5)
+
+    with pytest.raises(ValueError) as excinfo:
+        class B(A):
+            p = param.Number(bounds=(1, 3))
+    assert "Number parameter 'p' must be at least 1, not 0.0." in str(excinfo.value)
+
+
+def test_inheritance_with_changing_default():
+    class A(param.Parameterized):
+        p = param.Number(default=5, bounds=(3, 10))
+
+    with pytest.raises(ValueError) as excinfo:
+        class B(A):
+            p = param.Number(default=1)
+    assert "Number parameter 'B.p' must be at least 3, not 1." in str(excinfo.value)
+
+
+def test_inheritance_with_changing_class_():
+    class A(param.Parameterized):
+        p = param.ClassSelector(class_=int, default=5)
+
+    with pytest.raises(ValueError) as excinfo:
+        class B(A):
+            p = param.ClassSelector(class_=str)
+    assert "ClassSelector parameter 'B.p' value must be an instance of str, not 5." in str(excinfo.value)
+
+
 def test_inheritance_from_multiple_params_class():
     class A(param.Parameterized):
         p = param.Parameter(doc='foo')

--- a/tests/testpathparam.py
+++ b/tests/testpathparam.py
@@ -18,7 +18,7 @@ class TestPathParameters(unittest.TestCase):
         tmpdir1 = tempfile.mkdtemp()
 
         self.curdir = os.getcwd()
-        # Chanding the directory to tmpdir1 to test that Path resolves relative
+        # Changing the directory to tmpdir1 to test that Path resolves relative
         # paths to absolute paths automatically.
         os.chdir(tmpdir1)
 
@@ -135,7 +135,6 @@ class TestPathParameters(unittest.TestCase):
         # isn't designed to be run from the tmpdir directory.
         startd = os.getcwd()
         try:
-            os.chdir(self.curdir)
             # a = param.Path()
             # b = param.Path(self.fb)
             # c = param.Path('a.txt', search_paths=[tmpdir1])
@@ -144,6 +143,8 @@ class TestPathParameters(unittest.TestCase):
                 a = param.Path()
                 b = param.Path()
                 c = param.Path()
+
+            os.chdir(self.curdir)
 
             assert B.a is None
             assert B.b == self.fb


### PR DESCRIPTION
This PR adds validation when overriding slot values on a Parameter in a subclass. It does this by checking if a superclass defines a slot value and if that slot value is overridden by the subclass. It attempts to minimize the number of actual lookups by aborting early if we already know that re-validation has to happen and by skipping checks on various slot values which do not affect validation.

Fixes https://github.com/holoviz/param/issues/714