### PR TITLE
Avoid storing ListProxy in *FileSelector

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -2568,7 +2568,7 @@ class FileSelector(Selector):
         self.update(path=path)
         if default is not Undefined:
             self.default = default
-        super().__init__(default=self.default, objects=self.objects, **kwargs)
+        super().__init__(default=self.default, objects=self._objects, **kwargs)
 
     def _on_set(self, attribute, old, new):
         super()._on_set(attribute, new, old)
@@ -2677,7 +2677,7 @@ class MultiFileSelector(ListSelector):
         self.default = default
         self.path = path
         self.update(path=path)
-        super().__init__(default=default, objects=self.objects, **kwargs)
+        super().__init__(default=default, objects=self._objects, **kwargs)
 
     def _on_set(self, attribute, old, new):
         super()._on_set(attribute, new, old)


### PR DESCRIPTION
FileSelector and MultiFileSelector have logic to compute a list of objects from the files on a file system, which they then pass into their Selector superclass as if it had been provided in the constructor. Probably from not being updated when ListProxy was added and `objects` became a property, what ended up being passed to the superclass was a ListProxy, which the superclass then dutifully stored into the _objects attribute behind the objects property. The result was that these two classes ended up with a ListProxy of a ListProxy of a list, which is surely not what was intended. This PR passes the _objects list to the superclass as I believe was intended. The filenames are a plain list, not a dictionary, so the `names` portion of the property that's used by ListProxy isn't needed.

The tests pass locally before and after this change, and some other work I was doing avoids weird recursion errors as a result, but it's not something really worth putting into the tests since storing a ListProxy would be a weird thing for normal code to do.