### PR TITLE
Shallow-copy mutable containers in slot values 

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -36,7 +36,7 @@ from . import version  # noqa: api import
 from .parameterized import ( Undefined,
     Parameterized, Parameter, String, ParameterizedFunction, ParamOverrides,
     descendents, get_logger, instance_descriptor, dt_types,
-    _dict_update, _int_types)
+    _int_types)
 
 from .parameterized import (batch_watch, depends, output, script_repr, # noqa: api import
                             discard_events, edit_constant, instance_descriptor)
@@ -48,6 +48,7 @@ from ._utils import (
     ParamDeprecationWarning as _ParamDeprecationWarning,
     _deprecate_positional_args,
     _deprecated,
+    _dict_update,
     _validate_error_prefix,
 )
 

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -6,6 +6,7 @@ import warnings
 
 from textwrap import dedent
 from threading import get_ident
+from collections import abc
 
 DEFAULT_SIGNATURE = inspect.Signature([
     inspect.Parameter('self', inspect.Parameter.POSITIONAL_OR_KEYWORD),
@@ -171,3 +172,8 @@ def _validate_error_prefix(parameter, attribute=None):
         except Exception:
             pass
     return ' '.join(out)
+
+
+def _is_mutable_container(value):
+    """True for mutable containers, which typically need special handling when being copied"""
+    return issubclass(type(value), (abc.MutableSequence, abc.MutableSet, abc.MutableMapping))

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -177,3 +177,12 @@ def _validate_error_prefix(parameter, attribute=None):
 def _is_mutable_container(value):
     """True for mutable containers, which typically need special handling when being copied"""
     return issubclass(type(value), (abc.MutableSequence, abc.MutableSet, abc.MutableMapping))
+
+
+def _dict_update(dictionary, **kwargs):
+    """
+    Small utility to update a copy of a dict with the provided keyword args.
+    """
+    d = dictionary.copy()
+    d.update(kwargs)
+    return d

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1708,11 +1708,16 @@ def _instantiate_param_obj(paramobj, owner=None):
     # Shallow-copy Parameter object, with special handling for watchers
     # (from try/except/finally in Parameters.__getitem__ in https://github.com/holoviz/param/pull/306)
     p = paramobj
-    watchers = p.watchers
-    p.watchers = {}
-    p = copy.copy(p)
+    try:
+        # Do not copy watchers on class parameter
+        watchers = p.watchers
+        p.watchers = {}
+        p = copy.copy(p)
+    except:
+        raise
+    finally:
+        p.watchers = {k: list(v) for k, v in watchers.items()}
 
-    p.watchers = {k: list(v) for k, v in watchers.items()}
     p.owner = owner
 
     # shallow-copy any mutable slot values other than the actual default

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     serializer = None
 
-from collections import defaultdict, namedtuple, OrderedDict, abc
+from collections import defaultdict, namedtuple, OrderedDict
 from functools import partial, wraps, reduce
 from html import escape
 from operator import itemgetter, attrgetter

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1699,7 +1699,7 @@ def _instantiate_param_obj(paramobj, owner=None):
     p.watchers = {}
     p = copy.copy(p)
 
-    p.watchers = copy.copy(watchers)
+    p.watchers = {k: list(v) for k, v in watchers.items()}
     p.owner = owner
 
     # shallow-copy any mutable slot values other than the actual default

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -426,6 +426,9 @@ def instance_descriptor(f):
             params = obj._param__private.params
             instance_param = None if params is None else params.get(self.name)
 
+            if (params is not None and instance_param is None):
+                instance_param = _instantiated_parameter(obj, self)
+
             if instance_param is not None and self is not instance_param:
                 instance_param.__set__(obj, val)
                 return
@@ -1404,7 +1407,7 @@ class Parameter(_ParameterBase):
                 warnings.warn(
                     'Number.set_hook has been deprecated.',
                     category=_ParamDeprecationWarning,
-                    stacklevel=5,
+                    stacklevel=6,
                 )
 
         self._validate(val)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3373,9 +3373,10 @@ class ParameterizedMetaclass(type):
                     setattr(param, slot, default_val)
 
             # Avoid crosstalk between mutable slot values in different Parameter objects
-            v = getattr(param, slot)
-            if (not getattr(param, "constant", False) and _is_mutable_container(v)):
-                setattr(param, slot, copy.copy(v))
+            if slot != "default":
+                v = getattr(param, slot)
+                if _is_mutable_container(v):
+                    setattr(param, slot, copy.copy(v))
 
         # Once all the static slots have been filled in, fill in the dynamic ones
         # (which are only allowed to use static values or results are undefined)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -38,6 +38,7 @@ from ._utils import (
     DEFAULT_SIGNATURE,
     _deprecated,
     _deprecate_positional_args,
+    _dict_update,
     _is_auto_name,
     _recursive_repr,
     _validate_error_prefix,
@@ -735,15 +736,6 @@ def _m_caller(self, method_name, what='value', changed=None, callback=None):
     caller = partial(_caller, what=what, changed=changed, callback=callback, function=function)
     caller._watcher_name = method_name
     return caller
-
-
-def _dict_update(dictionary, **kwargs):
-    """
-    Small utility to update a copy of a dict with the provided keyword args.
-    """
-    d = dictionary.copy()
-    d.update(kwargs)
-    return d
 
 
 def _add_doc(obj, docstring):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -449,12 +449,9 @@ def instance_descriptor(f):
     def _f(self, obj, val):
         # obj is None when the metaclass is setting
         if obj is not None:
-            params = obj._param__private.params
-            instance_param = None if params is None else params.get(self.name)
-
-            if (params is not None and instance_param is None):
+            instance_param = obj._param__private.params.get(self.name)
+            if instance_param is None:
                 instance_param = _instantiated_parameter(obj, self)
-
             if instance_param is not None and self is not instance_param:
                 instance_param.__set__(obj, val)
                 return
@@ -1812,10 +1809,8 @@ class Parameters:
         """
         inst = self_.self
         params = self_ if inst is None else inst.param
-
         p = params.objects(False)[key]
-        return p if inst is None else _instantiated_parameter(inst,p)
-
+        return p if inst is None else _instantiated_parameter(inst, p)
 
     def __dir__(self_):
         """

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -276,7 +276,7 @@ class TestParameterized(unittest.TestCase):
         even when the instance value hasn't yet been set"""
         oobj = []
         class P(param.Parameterized):
-            x = param.Parameter(default=oobj, constant=True, per_instance=False)
+            x = param.Parameter(default=oobj, constant=True)
 
         p1 = P()
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -276,7 +276,7 @@ class TestParameterized(unittest.TestCase):
         even when the instance value hasn't yet been set"""
         oobj = []
         class P(param.Parameterized):
-            x = param.Parameter(default=oobj, constant=True)
+            x = param.Parameter(default=oobj, constant=True, per_instance=False)
 
         p1 = P()
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1347,37 +1347,113 @@ def test_inheritance_class_attribute_behavior():
     # https://github.com/holoviz/param/issues/718
     assert B.p == 1
 
+class TestShallowCopyMutableAttributes:
 
-class CustomParameter(Parameter):
+    @pytest.fixture
+    def foo(self):
+        class Foo:
+            def __init__(self, val):
+                self.val = val
 
-    __slots__ = ['container']
+        return Foo
 
-    _slot_defaults = _dict_update(Parameter._slot_defaults, container=None)
+    @pytest.fixture
+    def custom_param(self):
+        class CustomParameter(Parameter):
 
-    def __init__(self, default=Undefined, *, container=Undefined, **kwargs):
-        super().__init__(default=default, **kwargs)
-        self.container = container
+            __slots__ = ['container']
+
+            _slot_defaults = _dict_update(Parameter._slot_defaults, container=None)
+
+            def __init__(self, default=Undefined, *, container=Undefined, **kwargs):
+                super().__init__(default=default, **kwargs)
+                self.container = container
+
+        return CustomParameter
+
+    def test_shallow_copy_on_class_creation(self, custom_param, foo):
+        clist = [foo(1), foo(2)]
+
+        class P(param.Parameterized):
+            cp = custom_param(container=clist)
 
 
-def test_inheritance_container_slot_shallow_copied():
+        # the mutable container has been shallow-copied
+        assert P.param.cp.container is not clist
+        assert all(cval is val for cval, val in zip(P.param.cp.container, clist))
 
-    clist = [1, 2]
+    def test_shallow_copy_inheritance_each_level(self, custom_param):
 
-    class A(param.Parameterized):
-        p = CustomParameter(container=clist)
+        clist = [1, 2]
 
-    class B(A):
-        p = CustomParameter(default=1)
+        class A(param.Parameterized):
+            p = custom_param(container=clist)
 
-    clist.append(3)
+        class B(A):
+            p = custom_param(default=1)
 
-    assert A.param.p.container == [1, 2]
-    assert B.param.p.container == [1, 2]
+        clist.append(3)
 
-    B.param.p.container.append(4)
+        assert A.param.p.container == [1, 2]
+        assert B.param.p.container == [1, 2]
 
-    assert A.param.p.container == [1, 2]
-    assert B.param.p.container == [1, 2, 4]
+        B.param.p.container.append(4)
+
+        assert A.param.p.container == [1, 2]
+        assert B.param.p.container == [1, 2, 4]
+
+    def test_shallow_copy_on_instance_getitem(self, custom_param, foo):
+        clist = [foo(1), foo(2)]
+
+        class P(param.Parameterized):
+            cp = custom_param(container=clist)
+
+        p = P()
+
+        assert 'cp' not in p._param__private.params
+
+        p.param['cp']
+
+        # the mutable container has been shallow-copied
+        assert 'cp' in p._param__private.params
+        assert P.param.cp.container == p._param__private.params['cp'].container
+        assert P.param.cp.container is not p._param__private.params['cp'].container
+        assert all(cval is val for cval, val in zip(p.param.cp.container, clist))
+
+    def test_shallow_copy_on_instance_set(self, custom_param, foo):
+        clist = [foo(1), foo(2)]
+
+        class P(param.Parameterized):
+            cp = custom_param(container=clist)
+
+        p = P()
+
+        assert 'cp' not in p._param__private.params
+
+        p.cp = 'value'
+
+        # the mutable container has been shallow-copied
+        assert 'cp' in p._param__private.params
+        assert P.param.cp.container == p._param__private.params['cp'].container
+        assert P.param.cp.container is not p._param__private.params['cp'].container
+        assert all(cval is val for cval, val in zip(p.param.cp.container, clist))
+
+    def test_modify_class_container_before_shallow_copy(self, custom_param, foo):
+        clist = [foo(1), foo(2)]
+        clist2 = [foo(3), foo(4)]
+
+        class P(param.Parameterized):
+            cp = custom_param(container=clist)
+
+        p1 = P()
+        p2 = P()
+
+        # Setting the class container will affect instances are the shallow copy
+        # is lazy and has not yet been made.
+        P.param.cp.container = clist2
+
+        assert p1.param.cp.container == clist2
+        assert p2.param.cp.container == clist2
 
 
 @pytest.fixture

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -436,6 +436,7 @@ class TestSelectorParameters(unittest.TestCase):
         assert b.param.p.default == 1
         assert b.param.p.check_on_set is False
 
+
     def test_no_instantiate_when_constant(self):
         # https://github.com/holoviz/param/issues/287
         objs = [object(), object()]

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -436,7 +436,6 @@ class TestSelectorParameters(unittest.TestCase):
         assert b.param.p.default == 1
         assert b.param.p.check_on_set is False
 
-
     def test_no_instantiate_when_constant(self):
         # https://github.com/holoviz/param/issues/287
         objs = [object(), object()]
@@ -446,3 +445,19 @@ class TestSelectorParameters(unittest.TestCase):
 
         a = A()
         assert a.p is objs[0]
+
+    def test_objects_not_shared_in_class_hierarchy(self):
+
+        class A(param.Parameterized):
+            p = param.Selector(objects=[1, 2], check_on_set=False)
+
+        class B(A):
+            p = param.Selector(default=2)
+
+
+        b = B()
+        b.p = 3
+
+        assert A.param.p.objects == [1, 2]
+        assert B.param.p.objects == [1, 2, 3]
+        assert b.param.p.objects == [1, 2, 3]

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -459,5 +459,4 @@ class TestSelectorParameters(unittest.TestCase):
         b.p = 3
 
         assert A.param.p.objects == [1, 2]
-        assert B.param.p.objects == [1, 2, 3]
         assert b.param.p.objects == [1, 2, 3]

--- a/tests/testselector.py
+++ b/tests/testselector.py
@@ -447,7 +447,8 @@ class TestSelectorParameters(unittest.TestCase):
         a = A()
         assert a.p is objs[0]
 
-    def test_objects_not_shared_in_class_hierarchy(self):
+    def test_objects_not_shared_in_class_hierarchy_1(self):
+        # https://github.com/holoviz/param/issues/793
 
         class A(param.Parameterized):
             p = param.Selector(objects=[1, 2], check_on_set=False)
@@ -460,4 +461,36 @@ class TestSelectorParameters(unittest.TestCase):
         b.p = 3
 
         assert A.param.p.objects == [1, 2]
+        assert B.param.p.objects == [1, 2]
         assert b.param.p.objects == [1, 2, 3]
+
+    def test_objects_not_shared_in_class_hierarchy_2(self):
+        # https://github.com/holoviz/param/issues/793
+
+        class A(param.Parameterized):
+            p = param.Selector()
+
+        class B(A):
+            p = param.Selector()
+
+
+        b = B()
+        b.p = 2
+
+        assert A.param.p.objects == []
+
+    def test_objects_not_shared_across_instance_class(self):
+        # https://github.com/holoviz/param/issues/746
+
+        class P(param.Parameterized):
+            s = param.Selector(objects=[1, 2], check_on_set=False)
+
+        p = P()
+
+        p.s = 3
+        assert P.param.s.objects == [1, 2]
+        assert p.param.s.objects == [1, 2, 3]
+
+        P.s = 4
+        assert P.param.s.objects == [1, 2, 4]
+        assert p.param.s.objects == [1, 2 ,3]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -6,6 +6,8 @@ import pytest
 
 from param import guess_param_types, resolve_path
 from param.parameterized import bothmethod
+from param._utils import _is_mutable_container
+
 
 try:
     import numpy as np
@@ -376,3 +378,18 @@ def test_error_prefix_set_instance():
 
     with pytest.raises(ValueError, match="Number parameter 'P.x' only"):
         p.x = 'wrong'
+
+
+@pytest.mark.parametrize(
+        ('obj,ismutable'),
+        [
+            ([1, 2], True),
+            ({1, 2}, True),
+            ({'a': 1, 'b': 2}, True),
+            ((1, 2), False),
+            ('string', False),
+            (frozenset([1, 2]), False)
+        ]
+)
+def test__is_mutable_container(obj, ismutable):
+    assert _is_mutable_container(obj) is ismutable


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/793.
Fixes https://github.com/holoviz/param/issues/746.

Adds shallow copying of mutable slot values when instantiating Parameter objects or inheriting values for slots. Shallow copying is only done when `per_instance` is `True` (the default); if you don't want such copying you can share both Parameter instances and mutable slot values by setting `per_instance=False`.

```python
import param

class A(param.Parameterized):
    p = param.Selector(objects=[1, 2], check_on_set=False)

class B(A):
    p = param.Selector(default=2)


b = B()
b.p = 3

print(A.param.p.objects, B.param.p.objects, b.param.p.objects)
# [1, 2] [1, 2, 3] [1, 2, 3]
```
(previously A's objects list was also [1, 2, 3]; now fixed to be [1, 2])

There are various issues still, as listed below.

## Tests

Needs a test capturing the example above, but I've got to run, so if anyone wants to add that I'd be grateful, or I can do that tomorrow.

## Previous handling of watchers

PR https://github.com/holoviz/param/pull/306 added this logic to Parameters.__getitem__() for shallow-copying watchers:

```python
try:
    # Do not copy watchers on class parameter
    watchers = p.watchers
    p.watchers = {}
    p = copy.copy(p)
except:
    raise
finally:
    p.watchers = {k: list(v) for k, v in watchers.items()}
```

This PR generalizes such copying to apply to all the slot values besides default, but I was unable to determine why the existing code was so complex. First, why `p.watchers = {k: list(v) for k, v in watchers.items()}` instead of just `p.watchers = copy.copy(watchers.items())`? copy.copy is used just a couple of lines before, and when I use it here it seems to work just the same, as I'd expect, so I can't tell why it was a list comprehension that appears to achieve the same as copy.copy.

Second, what's with the try/except/finally? Deleting all that seems to work just fine, and I can't quite imagine a situation when the try block could fail but the watchers are still valid to reconstruct finally. Maybe something in Panel? For now I deleted it as it does not _seem_ to achieve anything.

Third, I've kept the convoluted mechanism for zeroing-out the watchers in the original Parameter object when creating the new one. Simply shallow-copying the watchers after copying the Parameter object leaves an extra set of watchers that causes tests to fail, but I'm not at all sure why it's appropriate to move the watchers to the new Parameter object rather than where they were originally watching. For now I chose to be conservative, but I'm not confident why it was done this way, so if there's a reason, it should have a clear comment added.


## What's mutable and when is it copied?

For now, mutable sequences, mappings, and sets are considered mutable, which covers the list and dict cases that I'm aware of us using in slots. Such values are shallow-copied for all slots _except_ `default`, to ensure that any independent Parameter copies also have independent objects lists, etc. Parameterized objects are also mutable, but I don't know if they are ever used in slots. If they are, we should consider whether they should be shallow-copied, but my guess is that they should not, since it's largely containers that we want shallow-copied, not arbitrary instantiated objects. Maybe `is_mutable` should be renamed `is_mutable_container` to convey that?

The reason for not copying the `default` value is to allow a specific list or dict to be shared across Parameters, which has always been supported. E.g. one could have a few global lists like `search_paths`, `debug_search_paths`, etc., whose values are curated and maintained independently of which particular Parameters have been set to those values. We can revisit whether mutable containers should be copied for `default` too, but if so, it should be a separate PR with its own justification.

I currently check for `default` only when copying the Parameter object, not during inheritance. It might also be appropriate to skip shallow-copying for for inheritance as well, but I haven't found an example where that would come up. Probably worth doing?


## _update_state

After merging this PR, I believe we should be able to remove _update_state as discussed in https://github.com/holoviz/param/issues/807 and https://github.com/holoviz/param/pull/817 . _update_state was needed because we had to wait for param inheritance before adding to the objects lists for Selectors, but now that values get shallow copied, it should be feasible to populate the objects lists (e.g. from the default value) immediately, during the constructor. Doing so should simplify the Selector logic, but I haven't yet tested that this PR's approach will achieve that goal.

My guess is that eliminating _update_state is required, for fixing this remaining bad behavior:

0.

```python
import param

class A(param.Parameterized):
    p = param.Selector(objects=[1, 2], check_on_set=False, per_instance=True)
    
class B(A):
    i = param.Integer(8)

b = B()
b.p = 3

print(A.param.p.objects, B.param.p.objects, b.param.p.objects)
#[1, 2, 3] [1, 2, 3] [1, 2, 3]
```
Here the Parameter object isn't copied into B, and the new value 3 ends up in A's object list, which it should not. I _think_ that may be from _update_state being called on the class's copy of the objects list, not the instance's, since it's called in the metaclass, but I haven't tracked that down.



