### PR TITLE
Fix HTML repr for Parameterized subobjects

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3652,8 +3652,9 @@ def _parameterized_repr_html(p, open):
 }
 """
     openstr = " open" if open else ""
-    contents = "".join(_get_param_repr(key, val, p.param.params(key))
-                       for key, val in p.param.get_param_values())
+    param_values = p.param.values().items()
+    contents = "".join(_get_param_repr(key, val, p.param[key])
+                       for key, val in param_values)
     return (
         f'<style>{tooltip_css}</style>\n'
         f'<details {openstr}>\n'

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3575,11 +3575,10 @@ def _name_if_set(parameterized):
 
 def _get_param_repr(key, val, p, truncate=40):
     """HTML representation for a single Parameter object and its value"""
-    if hasattr(val, "_repr_html_"):
-        try:
-            value = val._repr_html_(open=False)
-        except:
-            value = val._repr_html_()
+    if isinstance(val, Parameterized) or (type(val) is type and issubclass(val, Parameterized)):
+        value = val.param._repr_html_(open=False)
+    elif hasattr(val, "_repr_html_"):
+        value = val._repr_html_()
     else:
         rep = repr(val)
         value = (rep[:truncate] + '..') if len(rep) > truncate else rep

--- a/tests/testparameterizedrepr.py
+++ b/tests/testparameterizedrepr.py
@@ -252,3 +252,48 @@ def test_pprint_signature_overriden():
     )
 
     assert t.param.pprint() == 'T()'
+
+
+# HTML repr
+
+class TestHTMLRepr:
+
+    @pytest.fixture
+    def Sub(self):
+        class Sub(param.Parameterized):
+            xsub = param.Parameter()
+
+        return Sub
+
+    @pytest.fixture
+    def P(self, Sub):
+        class P(param.Parameterized):
+            constant = param.Parameter(constant=True)
+            readonly = param.Parameter(readonly=True)
+            allow_None = param.Parameter(1, allow_None=False)
+            bounds = param.Number(bounds=(-10, 10))
+            objects_list = param.Selector(objects=[1, 2])
+            objects_dict = param.Selector(objects=dict(a=1, b=2))
+            sub = param.ClassSelector(default=Sub(xsub=1), class_=Sub)
+
+        return P
+
+    def test_repr_in_place(self):
+        assert hasattr(param.Parameterized.param, '_repr_html_')
+        assert hasattr(param.Parameterized().param, '_repr_html_')
+
+    def test_html_repr_class_str(self, P):
+        html = P.param._repr_html_()
+        assert isinstance(html, str)
+
+    def test_html_repr_inst_str(self, P):
+        html = P().param._repr_html_()
+        assert isinstance(html, str)
+
+    def test_html_repr_class_sub(self, P):
+        html = P.param._repr_html_()
+        assert '<details >\n <summary style="display:list-item; outline:none;">\n  <tt>Sub' in html
+
+    def test_html_repr_inst_sub(self, P):
+        html = P().param._repr_html_()
+        assert '<details >\n <summary style="display:list-item; outline:none;">\n  <tt>Sub' in html


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/822

This regression was due to having moved `_repr_html_` from `Parameterized` to `Parameters`. I've added a basic test what would have caught it (cherry picked https://github.com/holoviz/param/pull/821/commits/bcb8a4c4a6479dcd70e59778ef3d7045b806adae to avoid some warnings).

<img width="617" alt="image" src="https://github.com/holoviz/param/assets/35924738/e0f64e31-36a0-45b0-83cd-5124c60b073c">
<img width="1035" alt="image" src="https://github.com/holoviz/param/assets/35924738/6224f933-7348-472b-aa3e-df3c392cc590">

```python
import param

class Sub(param.Parameterized):
    xsub = param.Parameter()

class P(param.Parameterized):
    constant = param.Parameter(constant=True)
    readonly = param.Parameter(readonly=True)
    allow_None = param.Parameter(1, allow_None=False)
    bounds = param.Number(bounds=(-10, 10))
    objects_list = param.Selector(objects=[1, 2])
    objects_dict = param.Selector(objects=dict(a=1, b=2))
    sub = param.ClassSelector(default=Sub(xsub=1), class_=Sub)


P().param
```