### PR TITLE
Ensure class watchers are not inherited by instance parameter

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2693,17 +2693,15 @@ class Parameters:
                 raise ValueError("{} parameter was not found in list of "
                                  "parameters of class {}".format(parameter_name, self_.cls.__name__))
 
-            inst = self_.self
-            if inst is not None and what == "value":
-                watchers = inst._param__private.watchers
+            if self_.self is not None and what == "value":
+                watchers = self_.self._param__private.watchers
                 if parameter_name not in watchers:
                     watchers[parameter_name] = {}
                 if what not in watchers[parameter_name]:
                     watchers[parameter_name][what] = []
                 getattr(watchers[parameter_name][what], action)(watcher)
             else:
-                param_obj = self_[parameter_name]
-                watchers = param_obj.watchers
+                watchers = self_[parameter_name].watchers
                 if what not in watchers:
                     watchers[what] = []
                 getattr(watchers[what], action)(watcher)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -419,13 +419,13 @@ def _instantiate_param_obj(paramobj, owner=None):
     return p
 
 
-def _instantiated_parameter(parameterized, param, force=False):
+def _instantiated_parameter(parameterized, param):
     """
     Given a Parameterized object and one of its class Parameter objects,
     return the appropriate Parameter object for this instance, instantiating
     it if need be.
     """
-    if ((getattr(parameterized._param__private, 'initialized', False) or force) and param.per_instance and
+    if (getattr(parameterized._param__private, 'initialized', False) and param.per_instance and
         not getattr(type(parameterized)._param__private, 'disable_instance_params', False)):
         key = param.name
 
@@ -2702,11 +2702,7 @@ class Parameters:
                     watchers[parameter_name][what] = []
                 getattr(watchers[parameter_name][what], action)(watcher)
             else:
-                # If watcher is registered before instance is set up
-                # we must force instance parameter creation
                 param_obj = self_[parameter_name]
-                if action == 'append' and inst is not None and not inst._param__private.initialized:
-                    param_obj = _instantiated_parameter(inst, param_obj, force=True)
                 watchers = param_obj.watchers
                 if what not in watchers:
                     watchers[what] = []
@@ -3867,9 +3863,9 @@ class Parameterized(metaclass=ParameterizedMetaclass):
         self.param._setup_params(**params)
         object_count += 1
 
-        self.param._update_deps(init=True)
-
         self._param__private.initialized = True
+
+        self.param._update_deps(init=True)
 
     @property
     def param(self):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -403,20 +403,13 @@ def iscoroutinefunction(function):
 def _instantiate_param_obj(paramobj, owner=None):
     """Return a Parameter object suitable for instantiation given the class's Parameter object"""
 
-    # Shallow-copy Parameter object, with special handling for watchers
-    # (from try/except/finally in Parameters.__getitem__ in https://github.com/holoviz/param/pull/306)
-    p = paramobj
-    try:
-        # Do not copy watchers on class parameter
-        watchers = p.watchers
-        p.watchers = {}
-        p = copy.copy(p)
-    except:
-        raise
-    finally:
-        p.watchers = {k: list(v) for k, v in watchers.items()}
-
+    # Shallow-copy Parameter object
+    p = copy.copy(paramobj)
     p.owner = owner
+
+    # Reset watchers since class parameter watcher should not execute
+    # on instance parameters
+    p.watchers = {}
 
     # shallow-copy any mutable slot values other than the actual default
     for s in p.__class__.__slots__:

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -540,6 +540,67 @@ class TestWatch(unittest.TestCase):
         assert inst_events[0].what == 'bounds'
         assert inst_events[0].new == (3, 4)
 
+    def test_param_watch_no_side_effect(self):
+        # Example 1 of https://github.com/holoviz/param/issues/829
+
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+        store = []
+        P.param.watch(store.append, 'x')
+
+        P.x = 10
+
+        assert len(store) == 1
+        assert 'value' in P.param.x.watchers
+
+        p = P()
+
+        assert 'value' in P.param.x.watchers
+
+        # Checking this does not have bad side-effects
+        p.param.x
+
+        # Watcher still on the class Parameter
+        assert 'value' in P.param.x.watchers
+        # Watcher not on the instance
+        assert p.param.x.watchers == {}
+
+        P.x = 20
+        # Watcher still triggered
+        assert len(store) == 2
+
+        p.x = 30
+        # Watcher not triggerd on instance update
+        assert len(store) == 2
+
+    def test_param_watch_multiple_instances(self):
+        # Example 4 of https://github.com/holoviz/param/issues/829
+
+        class P(param.Parameterized):
+            x = param.Parameter()
+            l = param.List([])
+
+            @param.depends('x:constant', watch=True)
+            def cb(self):
+                self.l.append(self.param.x.constant)
+
+        assert P.param.x.watchers == {}
+
+        p = P()
+
+        # Creating the instance ???
+        assert P.param.x.watchers == {}
+
+        p2 = P()
+
+        # Modify constant on p2.param.x
+        p2.param.x.constant = True
+
+        # The event should only trigger on p2, not p
+        assert p2.l == [True]
+        assert p.l == []
+
     def test_watch_deepcopy(self):
         obj = SimpleWatchExample()
 

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -98,6 +98,9 @@ class TestWatch(unittest.TestCase):
         self.accumulator = 0
         self.list_accumulator = []
 
+    def tearDown(self):
+        SimpleWatchExample.param.d.bounds = None
+
     def test_triggered_when_changed(self):
         def accumulator(change):
             self.accumulator += change.new
@@ -512,6 +515,30 @@ class TestWatch(unittest.TestCase):
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 0)
         self.assertEqual(args[1].type, 'set')
+
+    def test_watch_param_slot(self):
+        obj = SimpleWatchExample()
+
+        cls_events = []
+        SimpleWatchExample.param.watch(cls_events.append, 'd', what='bounds')
+
+        obj.param.objects('existing')['d'].bounds = (1, 2)
+
+        assert len(cls_events) == 1
+        assert cls_events[0].name == 'd'
+        assert cls_events[0].what == 'bounds'
+        assert cls_events[0].new == (1, 2)
+
+        inst_events = []
+        obj.param.watch(inst_events.append, 'd', what='bounds')
+
+        obj.param.objects('existing')['d'].bounds = (3, 4)
+
+        assert len(cls_events) == 1
+        assert len(inst_events) == 1
+        assert inst_events[0].name == 'd'
+        assert inst_events[0].what == 'bounds'
+        assert inst_events[0].new == (3, 4)
 
     def test_watch_deepcopy(self):
         obj = SimpleWatchExample()


### PR DESCRIPTION
In https://github.com/holoviz/param/pull/826 we discovered some weird logic that was copying over watchers from class to instance parameters. After discussing this we all agreed this does not make sense, this is because slots are not shared between class and instance parameters and therefore it does not make sense that an instance parameter would inherit the watchers from a completely different `Parameter` instance. Worse yet, once an instance was created the watcher would be removed from the class which means that modifying the class `Parameter` slot value would no longer trigger the watcher.

The correct behavior is actually quite simple, watchers should not be copied over, instead the `Parameter` slot watchers should be reset when the instance parameter is created. This ensure that while the instance still shares the `Parameter` object with the class it correctly fires if a slot on the class Parameter is changed and when an instance parameter is created only newly created watchers on the instance will be watched. Since calling `inst.param.watch` will automatically create instance parameters for any parameters that are watched this means that the behavior will be correct in all cases both instances and classes will always correctly trigger the appropriate watchers.

Fixes https://github.com/holoviz/param/issues/829