### PR TITLE
Ensure operations that are unsafe during instance initialization raise errors

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2217,9 +2217,9 @@ class Parameters:
         """
         if self_.self is not None and not self_.self._param__private.initialized and instance is True:
             raise RuntimeError(
-                'Cannot look up instance Parameter objects before the instance '
-                'has been fully initialized. Ensure you have called super().__init__() '
-                'in the instance constructor before trying to access instance '
+                'Cannot look up instantiated Parameter objects until the Parameterized instance '
+                'has been fully initialized. Ensure you have called super().__init__(**params) '
+                'in your Parameterized constructor before trying to access instance '
                 'parameter objects.'
             )
 
@@ -2262,9 +2262,9 @@ class Parameters:
         """
         if self_.self is not None and not self_.self._param__private.initialized:
             raise RuntimeError(
-                'Triggering watchers on a partially initialized instance '
-                'is not supported. Ensure you have called super().__init__() in '
-                'the instance constructor before trying to set up a watcher.'
+                'Triggering watchers on a partially initialized Parameterized instance '
+                'is not supported. Ensure you have called super().__init__(**params) in '
+                'the Parameterized instance constructor before trying to set up a watcher.'
             )
 
         trigger_params = [p for p in self_.self_or_cls.param
@@ -2712,9 +2712,9 @@ class Parameters:
     def _register_watcher(self_, action, watcher, what='value'):
         if self_.self is not None and not self_.self._param__private.initialized:
             raise RuntimeError(
-                '(Un)registering a watcher on a partially initialized instance '
-                'is not supported. Ensure you have called super().__init__() in '
-                'the instance constructor before trying to set up a watcher.'
+                '(Un)registering a watcher on a partially initialized Parameterized instance '
+                'is not supported. Ensure you have called super().__init__(**) in '
+                'the Parameterized instance constructor before trying to set up a watcher.'
             )
 
         parameter_names = watcher.parameter_names

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2214,6 +2214,14 @@ class Parameters:
         instance parameters to be returned by setting
         instance='existing'.
         """
+        if self_.self is not None and not self_.self._param__private.initialized and instance is True:
+            raise RuntimeError(
+                'Cannot look up instance Parameter objects before the instance '
+                'has been fully initialized. Ensure you have called super().__init__() '
+                'in the instance constructor before trying to access instance '
+                'parameter objects.'
+            )
+
         cls = self_.cls
         # We cache the parameters because this method is called often,
         # and parameters are rarely added (and cannot be deleted)
@@ -2251,6 +2259,13 @@ class Parameters:
         changed for a Parameter of type Event, setting it to True so
         that it is clear which Event parameter has been triggered.
         """
+        if self_.self is not None and not self_.self._param__private.initialized:
+            raise RuntimeError(
+                'Triggering watchers on a partially initialized instance '
+                'is not supported. Ensure you have called super().__init__() in '
+                'the instance constructor before trying to set up a watcher.'
+            )
+
         trigger_params = [p for p in self_.self_or_cls.param
                           if hasattr(self_.self_or_cls.param[p], '_autotrigger_value')]
         triggers = {p:self_.self_or_cls.param[p]._autotrigger_value
@@ -2694,6 +2709,13 @@ class Parameters:
         return deps, dynamic_deps
 
     def _register_watcher(self_, action, watcher, what='value'):
+        if self_.self is not None and not self_.self._param__private.initialized:
+            raise RuntimeError(
+                '(Un)registering a watcher on a partially initialized instance '
+                'is not supported. Ensure you have called super().__init__() in '
+                'the instance constructor before trying to set up a watcher.'
+            )
+
         parameter_names = watcher.parameter_names
         for parameter_name in parameter_names:
             if parameter_name not in self_.cls.param:

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -495,6 +495,48 @@ class TestParameterized(unittest.TestCase):
         with pytest.raises(TypeError, match="Read-only parameter 'x' cannot be modified"):
             P()
 
+    def test_param_error_unsafe_ops_before_initialized(self):
+        class P(param.Parameterized):
+
+            x = param.Parameter()
+
+            def __init__(self, **params):
+                with pytest.raises(
+                    RuntimeError,
+                    match=re.escape(
+                        'Cannot look up instantiated Parameter objects until the Parameterized instance '
+                        'has been fully initialized. Ensure you have called super().__init__(**params) '
+                        'in your Parameterized constructor before trying to access instance '
+                        'parameter objects.'
+                    )
+                ):
+                    self.param.objects()
+
+                with pytest.raises(
+                    RuntimeError,
+                    match=re.escape(
+                        'Triggering watchers on a partially initialized Parameterized instance '
+                        'is not supported. Ensure you have called super().__init__(**params) in '
+                        'the Parameterized instance constructor before trying to set up a watcher.'
+                    )
+                ):
+                    self.param.trigger('x')
+
+                with pytest.raises(
+                    RuntimeError,
+                    match=re.escape(
+                        '(Un)registering a watcher on a partially initialized Parameterized instance '
+                        'is not supported. Ensure you have called super().__init__(**) in '
+                        'the Parameterized instance constructor before trying to set up a watcher.'
+                    )
+                ):
+                    self.param.watch(print, 'x')
+
+                self.param.objects(instance=False)
+                super().__init__(**params)
+
+        P()
+
     def test_parameter_constant_iadd_allowed(self):
         # Testing https://github.com/holoviz/param/pull/400
         class P(param.Parameterized):


### PR DESCRIPTION
We are finding that some users do not correctly call `super().__init__()` at all or perform actions that are not safe before they call it. To guide more users to the correct behavior and avoid undefined/weird behavior this PR adds some validations and errors to certain methods on the `.param` namespace.