### PR TITLE
Mitigating performance regressions in 2.0

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -27,6 +27,7 @@ except ImportError:
 from collections import defaultdict, namedtuple, OrderedDict
 from functools import partial, wraps, reduce
 from html import escape
+from itertools import chain
 from operator import itemgetter, attrgetter
 from types import FunctionType, MethodType
 
@@ -909,10 +910,8 @@ class ParameterMetaclass(type):
 
         # Compute all slots
         all_slots = set()
-        for base in bases:
-            for bcls in base.__mro__:
-                for slot in getattr(bcls, '__slots__', []):
-                    all_slots.add(slot)
+        for bcls in set(chain(*(base.__mro__ for base in bases))):
+            all_slots |= set(getattr(bcls, '__slots__', set()))
 
         # To get the benefit of slots, subclasses must themselves define
         # __slots__, whether or not they define attributes not present in

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -907,7 +907,8 @@ class ParameterMetaclass(type):
         # when asking for help on Parameter *object*, return the doc slot
         classdict['__doc__'] = property(attrgetter('doc'))
 
-        # Compute all slots in order
+        # Compute all slots in order, using a dict later turned into a list
+        # as it's the fastest way to get an ordered set in Python
         all_slots = {}
         for bcls in set(chain(*(base.__mro__[::-1] for base in bases))):
             all_slots.update(dict.fromkeys(getattr(bcls, '__slots__', [])))

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1322,7 +1322,7 @@ class Parameter(_ParameterBase):
             raise AttributeError("Parameter name cannot be modified after "
                                  "it has been bound to a Parameterized.")
 
-        implemented = (attribute != "default" and hasattr(self, 'watchers') and attribute in self.watchers)
+        implemented = (attribute != "default" and attribute in getattr(self, 'watchers', []))
         slot_attribute = attribute in self.__class__._all_slots_
         try:
             old = getattr(self, attribute) if implemented else NotImplemented

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -405,13 +405,12 @@ def _instantiate_param_obj(paramobj, owner=None):
     """Return a Parameter object suitable for instantiation given the class's Parameter object"""
 
     # Shallow-copy Parameter object without the watchers
-    try:
-        watchers = paramobj.watchers
-        paramobj.watchers = {}
-        p = copy.copy(paramobj)
-    finally:
-        paramobj.watchers = watchers
+    p = copy.copy(paramobj)
     p.owner = owner
+
+    # Reset watchers since class parameter watcher should not execute
+    # on instance parameters
+    p.watchers = {}
 
     # shallow-copy any mutable slot values other than the actual default
     for s in p.__class__.__slots__:


### PR DESCRIPTION
An attempt at mitigating some of the performance regressions associated with Param 2.0

# Comparing 2.0.0a3 vs this branch

<img width="953" alt="Screen Shot 2023-09-22 at 15 35 39" src="https://github.com/holoviz/param/assets/1550771/66c50629-3000-4f01-ac87-107b96716411">


# Comparing 1.13.0 vs this branch

<img width="953" alt="Screen Shot 2023-09-22 at 15 36 19" src="https://github.com/holoviz/param/assets/1550771/88ad33c5-02b6-48ae-b16d-b883ffe53695">


