### PR TITLE
Fix issue with precedence of reactive invalidation callback

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -266,7 +266,6 @@ class reactive_ops:
                     'Parameter or another dynamic value it must reflect '
                     'the source and cannot be set.'
                 )
-            prev._invalidate_obj()
             prev._wrapper.object = new
             prev = None
         return self._reactive
@@ -650,9 +649,9 @@ class reactive:
         """
         if self._fn is not None:
             for _, params in full_groupby(self._fn_params, lambda x: id(x.owner)):
-                params[0].owner.param.watch(self._invalidate_obj, [p.name for p in params])
+                params[0].owner.param._watch(self._invalidate_obj, [p.name for p in params], precedence=-1)
         for _, params in full_groupby(self._params, lambda x: id(x.owner)):
-            params[0].owner.param.watch(self._invalidate_current, [p.name for p in params])
+            params[0].owner.param._watch(self._invalidate_current, [p.name for p in params], precedence=-1)
 
     def _invalidate_current(self, *events):
         self._dirty = True
@@ -942,7 +941,7 @@ class reactive:
                 yield new
             return
         elif not isinstance(self._current, Iterable):
-            raise TypeError('cannot unpack non-iterable {type(self._current).__name__} object.')
+            raise TypeError(f'cannot unpack non-iterable {type(self._current).__name__} object.')
         iterator = []
         def iterate(value):
             if iterator:

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -273,3 +273,11 @@ def test_reactive_where_expr_refs():
     assert results == ['string', 'foo']
     p.boolean = False
     assert results == ['string', 'foo', 2.1]
+
+def test_reactive_watch_on_set_input():
+    string = reactive('string')
+    new_string = string + '!'
+    items = []
+    new_string.rx.watch(items.append)
+    string.rx.set_input('new string')
+    assert items == ['new string!']


### PR DESCRIPTION
Previously internal callbacks (with `precedence=-1`) could run before the `reactive` object was fully invalidated causing the cached value to be returned. We now run invalidation callbacks with the `precedence=-1` ensuring that they run first.