### PR TITLE
Implement support for allowing Parameter references

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -663,7 +663,8 @@ class Dynamic(Parameter):
     def __init__(
         self, default=None, *,
         doc=None, label=None, precedence=None, instantiate=False, constant=False,
-        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True
+        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -851,7 +852,8 @@ class Bytes(Parameter):
         self,
         default=b"", *, regex=None, allow_None=False,
         doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -957,7 +959,8 @@ class Number(Dynamic):
         self,
         default=0.0, *, bounds=None, softbounds=None, inclusive_bounds=(True,True), step=None, set_hook=None,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1150,7 +1153,8 @@ class Magnitude(Number):
         self,
         default=1.0, *, bounds=(0.0, 1.0), softbounds=None, inclusive_bounds=(True,True), step=None, set_hook=None,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1172,7 +1176,8 @@ class Boolean(Parameter):
         self,
         default=False, *,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1225,7 +1230,8 @@ class Tuple(Parameter):
         self,
         default=(0,0), *, length=None,
         doc=None, label=None, precedence=None, instantiate=False, constant=False,
-        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True
+        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1312,7 +1318,8 @@ class XYCoordinates(NumericTuple):
         self,
         default=(0.0, 0.0), *, length=None,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1335,7 +1342,8 @@ class Callable(Parameter):
         self,
         default=None, *,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1408,7 +1416,8 @@ class Composite(Parameter):
         self,
         *, attribs=None,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1718,8 +1727,8 @@ class Selector(SelectorBase, _SignatureSelector):
         self,
         *, objects=[], default=None, instantiate=False, compute_default_fn=None,
         check_on_set=None, allow_None=None, empty_default=False,
-        doc=None, label=None, precedence=None,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        doc=None, label=None, precedence=None, constant=False, readonly=False,
+        pickle_default_value=True, per_instance=True, allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1835,13 +1844,14 @@ class ObjectSelector(Selector):
     Deprecated. Same as Selector, but with a different constructor for
     historical reasons.
     """
+
     @typing.overload
     def __init__(
         self,
         default=None, *, objects=[], instantiate=False, compute_default_fn=None,
         check_on_set=None, allow_None=None, empty_default=False,
-        doc=None, label=None, precedence=None,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        doc=None, label=None, precedence=None, constant=False, readonly=False,
+        pickle_default_value=True, per_instance=True, allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1868,7 +1878,8 @@ class ClassSelector(SelectorBase):
         self,
         *, class_, default=None, instantiate=True, is_instance=True,
         allow_None=False, doc=None, label=None, precedence=None,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -1944,7 +1955,8 @@ class List(Parameter):
         self,
         default=[], *, class_=None, item_type=None, instantiate=True, bounds=(0, None),
         allow_None=False, doc=None, label=None, precedence=None,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2058,7 +2070,8 @@ class Dict(ClassSelector):
         self,
         default=None, *, is_instance=True,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=True,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2076,7 +2089,8 @@ class Array(ClassSelector):
         self,
         default=None, *, is_instance=True,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=True,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2134,7 +2148,8 @@ class DataFrame(ClassSelector):
         self,
         default=None, *, rows=None, columns=None, ordered=None, is_instance=True,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=True,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2249,7 +2264,8 @@ class Series(ClassSelector):
         self,
         default=None, *, rows=None, allow_None=False, is_instance=True,
         doc=None, label=None, precedence=None, instantiate=True,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2415,7 +2431,8 @@ class Path(Parameter):
         self,
         default=None, *, search_paths=None, check_exists=True,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2558,8 +2575,8 @@ class FileSelector(Selector):
         self,
         default=None, *, path="", objects=[], instantiate=False, compute_default_fn=None,
         check_on_set=None, allow_None=None, empty_default=False,
-        doc=None, label=None, precedence=None,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        doc=None, label=None, precedence=None, constant=False, readonly=False,
+        pickle_default_value=True, per_instance=True, allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2606,8 +2623,8 @@ class ListSelector(Selector):
         self,
         default=None, *, objects=[], instantiate=False, compute_default_fn=None,
         check_on_set=None, allow_None=None, empty_default=False,
-        doc=None, label=None, precedence=None,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        doc=None, label=None, precedence=None, constant=False, readonly=False,
+        pickle_default_value=True, per_instance=True, allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2670,7 +2687,8 @@ class MultiFileSelector(ListSelector):
         default=None, *, path="", objects=[], compute_default_fn=None,
         check_on_set=None, allow_None=None, empty_default=False,
         doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True,
+        per_instance=True, allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2722,7 +2740,8 @@ class Date(Number):
         self,
         default=None, *, bounds=None, softbounds=None, inclusive_bounds=(True,True), step=None, set_hook=None,
         doc=None, label=None, precedence=None, instantiate=False, constant=False,
-        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True
+        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2782,7 +2801,8 @@ class CalendarDate(Number):
         self,
         default=None, *, bounds=None, softbounds=None, inclusive_bounds=(True,True), step=None, set_hook=None,
         doc=None, label=None, precedence=None, instantiate=False, constant=False,
-        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True
+        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2874,7 +2894,8 @@ class Color(Parameter):
         self,
         default=None, *, allow_named=True,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -2931,7 +2952,8 @@ class Range(NumericTuple):
         self,
         default=None, *, bounds=None, softbounds=None, inclusive_bounds=(True,True), step=None, length=None,
         doc=None, label=None, precedence=None, instantiate=False, constant=False,
-        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True
+        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 
@@ -3169,7 +3191,8 @@ class Event(Boolean):
         self,
         default=False, *,
         allow_None=False, doc=None, label=None, precedence=None, instantiate=False,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True
+        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 

--- a/param/depends.py
+++ b/param/depends.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from functools import wraps
 
 from .parameterized import (
-    Parameter, Parameterized, ParameterizedMetaclass, transform_dependency,
+    Parameter, Parameterized, ParameterizedMetaclass, transform_reference,
 )
 from ._utils import accept_arguments, iscoroutinefunction
 
@@ -48,8 +48,8 @@ def depends(func, *dependencies, watch=False, on_init=False, **kw):
         by default False
     """
     dependencies, kw = (
-        tuple(transform_dependency(arg) for arg in dependencies),
-        {key: transform_dependency(arg) for key, arg in kw.items()}
+        tuple(transform_reference(arg) for arg in dependencies),
+        {key: transform_reference(arg) for key, arg in kw.items()}
     )
 
     if iscoroutinefunction(func):

--- a/param/depends.py
+++ b/param/depends.py
@@ -4,15 +4,12 @@ from collections import defaultdict
 from functools import wraps
 
 from .parameterized import (
-    Parameter, Parameterized, ParameterizedMetaclass
+    Parameter, Parameterized, ParameterizedMetaclass, transform_dependency,
 )
 from ._utils import accept_arguments, iscoroutinefunction
 
-# Hooks to apply to depends and bind arguments to turn them into valid parameters
-
-_reactive_display_objs = weakref.WeakSet()
 _display_accessors = {}
-_dependency_transforms = []
+_reactive_display_objs = weakref.WeakSet()
 
 def register_display_accessor(name, accessor, force=False):
     if name in _display_accessors and not force:
@@ -30,90 +27,6 @@ def unregister_display_accessor(name):
     for fn in _reactive_display_objs:
         delattr(fn, name)
 
-def register_depends_transform(transform):
-    """
-    Appends a transform to extract potential parameter dependencies
-    from an object.
-
-    Arguments
-    ---------
-    transform: Callable[Any, Any]
-    """
-    return _dependency_transforms.append(transform)
-
-def transform_dependency(arg):
-    """
-    Transforms arguments for depends and bind functions applying any
-    registered dependency transforms. This is useful for adding
-    handling for depending on objects that are not simple Parameters or
-    functions with dependency definitions.
-    """
-    for transform in _dependency_transforms:
-        if isinstance(arg, Parameter) or hasattr(arg, '_dinfo'):
-            break
-        arg = transform(arg)
-    return arg
-
-def eval_function_with_deps(function):
-    """Evaluates a function after resolving its dependencies.
-
-    Calls and returns a function after resolving any dependencies
-    stored on the _dinfo attribute and passing the resolved values
-    as arguments.
-    """
-    args, kwargs = (), {}
-    if hasattr(function, '_dinfo'):
-        arg_deps = function._dinfo['dependencies']
-        kw_deps = function._dinfo.get('kw', {})
-        if kw_deps or any(isinstance(d, Parameter) for d in arg_deps):
-            args = (getattr(dep.owner, dep.name) for dep in arg_deps)
-            kwargs = {n: getattr(dep.owner, dep.name) for n, dep in kw_deps.items()}
-    return function(*args, **kwargs)
-
-def resolve_value(value):
-    """
-    Resolves the current value of a dynamic reference.
-    """
-    if isinstance(value, (list, tuple)):
-        return type(value)(resolve_value(v) for v in value)
-    elif isinstance(value, dict):
-        return type(value)((resolve_value(k), resolve_value(v)) for k, v in value.items())
-    elif isinstance(value, slice):
-        return slice(
-            resolve_value(value.start),
-            resolve_value(value.stop),
-            resolve_value(value.step)
-        )
-    value = transform_dependency(value)
-    if hasattr(value, '_dinfo'):
-        value = eval_function_with_deps(value)
-    elif isinstance(value, Parameter):
-        value = getattr(value.owner, value.name)
-    return value
-
-def resolve_ref(reference, recursive=False):
-    """
-    Resolves all parameters a dynamic reference depends on.
-    """
-    if recursive:
-        if isinstance(reference, (list, tuple, set)):
-            return [r for v in reference for r in resolve_ref(v)]
-        elif isinstance(reference, dict):
-            return [r for kv in reference.items() for o in kv for r in resolve_ref(o)]
-        elif isinstance(reference, slice):
-            return [r for v in (reference.start, reference.stop, reference.step) for r in resolve_ref(v)]
-    reference = transform_dependency(reference)
-    if hasattr(reference, '_dinfo'):
-        dinfo = getattr(reference, '_dinfo', {})
-        args = list(dinfo.get('dependencies', []))
-        kwargs = list(dinfo.get('kw', {}).values())
-        refs = []
-        for arg in (args + kwargs):
-            refs.extend(resolve_ref(arg))
-        return refs
-    elif isinstance(reference, Parameter):
-        return [reference]
-    return []
 
 @accept_arguments
 def depends(func, *dependencies, watch=False, on_init=False, **kw):

--- a/param/ipython.py
+++ b/param/ipython.py
@@ -24,7 +24,8 @@ import uuid
 
 import param
 
-from param.depends import depends, register_display_accessor, resolve_ref
+from param.depends import depends, register_display_accessor
+from param.parameterized import resolve_ref
 from param.reactive import reactive
 
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1511,7 +1511,8 @@ class String(Parameter):
         self,
         default="", *, regex=None,
         doc=None, label=None, precedence=None, instantiate=False, constant=False,
-        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True
+        readonly=False, pickle_default_value=True, allow_None=False, per_instance=True,
+        allow_refs=False, nested_refs=False
     ):
         ...
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1444,8 +1444,6 @@ class Parameter(_ParameterBase):
         event = Event(what='value', name=name, obj=obj, cls=self.owner,
                       old=_old, new=val, type=None)
 
-        print(watchers)
-
         # Copy watchers here since they may be modified inplace during iteration
         for watcher in sorted(watchers, key=lambda w: w.precedence):
             obj.param._call_watcher(watcher, event)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1958,7 +1958,7 @@ class Parameters:
                             "Parameter definition to declare whether references "
                             "should be resolved or not.",
                             category=_ParamFutureWarning,
-                            stacklevel=2,
+                            stacklevel=4,
                         )
                 setattr(self, name, val)
                 continue

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1374,8 +1374,8 @@ class Parameter(_ParameterBase):
         item in a list).
         """
         name = self.name
-        if obj is not None and self.allow_refs:
-            ref, deps, val = self.owner.param._resolve_ref(self, val)
+        if obj is not None and self.allow_refs and obj._param__private.initialized:
+            ref, deps, val = obj.param._resolve_ref(self, val)
             refs = obj._param__private.refs
             if ref is not None:
                 self.owner.param._update_ref(name, ref)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1924,8 +1924,8 @@ class Parameters:
 
     async def _async_ref(self_, pname, awaitable):
         if pname in self_.self._param__private.async_refs:
-            self_.self._param__private._async_refs[pname].cancel()
-        self_.self._param__private._async_refs[pname] = asyncio.current_task()
+            self_.self._param__private.async_refs[pname].cancel()
+        self_.self._param__private.async_refs[pname] = asyncio.current_task()
         try:
             if isinstance(awaitable, types.AsyncGeneratorType):
                 async for new_obj in awaitable:
@@ -1934,7 +1934,7 @@ class Parameters:
         except Exception as e:
             raise e
         finally:
-            del self_.self._param__private._async_refs[pname]
+            del self_.self._param__private.async_refs[pname]
 
     @classmethod
     def _changed(cls, event):
@@ -3873,6 +3873,7 @@ class _InstancePrivate:
         'parameters_state',
         'dynamic_watchers',
         'params',
+        'async_refs',
         'refs',
         'ref_watchers',
         'watchers',
@@ -3898,6 +3899,7 @@ class _InstancePrivate:
                 "watchers": [] # Queue of batched watchers
             }
         self.ref_watchers = []
+        self.async_refs = {}
         self.parameters_state = parameters_state
         self.dynamic_watchers = defaultdict(list) if dynamic_watchers is None else dynamic_watchers
         self.params = {} if params is None else params

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1858,18 +1858,18 @@ class Parameters:
                 # behavior may change in future.
                 if name not in self_.cls._param__private.explicit_no_refs:
                     try:
-                        ref, _, _, _ = self_._resolve_ref(pobj, val)
+                        ref, _, resolved, _ = self_._resolve_ref(pobj, val)
                     except Exception:
                         ref = None
                     if ref:
                         warnings.warn(
                             f"Parameter {name!r} is being given a valid parameter "
-                            f"reference {val} but is implicitly allow_ref=False. "
-                            "In future references like these will be resolved to "
-                            "their underlying value unless allow_ref=False. "
-                            "Please explicitly set allow_ref on the Parameter "
-                            "definition to declare whethe references should be "
-                            "resolved or not.",
+                            f"reference {val} but is implicitly allow_refs=False. "
+                            "In future allow_refs will be enabled by default and "
+                            f"the reference {val} will be resolved to its underlying "
+                            f"value {resolved}. Please explicitly set allow_ref on the "
+                            "Parameter definition to declare whether references "
+                            "should be resolved or not.",
                             category=_ParamFutureWarning,
                             stacklevel=2,
                         )

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1887,7 +1887,7 @@ class Parameters:
         updates, generators = {}, {}
         for pname, ref in self_.self._param__private.refs.items():
             # Skip updating value if dependency has not changed
-            deps = resolve_ref(ref)
+            deps = resolve_ref(ref, self_[pname].nested_refs)
             if not any((dep.owner is e.obj and dep.name == e.name) for dep in deps for e in events):
                 continue
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1896,11 +1896,10 @@ class Parameters:
     def _sync_refs(self_, *events):
         from .depends import resolve_ref, resolve_value
         updates, generators = {}, {}
-        print(self_.self, self_.self._param__private.refs)
         for pname, ref in self_.self._param__private.refs.items():
             # Skip updating value if dependency has not changed
             deps = resolve_ref(ref, self_[pname].nested_refs)
-            is_async = inspect.isasyncgenfunction(ref)
+            is_async = iscoroutinefunction(ref)
             if not any((dep.owner is e.obj and dep.name == e.name) for dep in deps for e in events) and not is_async:
                 continue
 
@@ -1927,7 +1926,7 @@ class Parameters:
 
     def _resolve_ref(self_, pobj, value):
         from .depends import resolve_ref, resolve_value
-        is_async = inspect.isasyncgenfunction(value)
+        is_async = iscoroutinefunction(value)
         deps = resolve_ref(value, recursive=pobj.nested_refs)
         if not deps and not is_async:
             return None, None, value, False

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1857,7 +1857,6 @@ class Parameters:
     def _setup_refs(self_, refs):
         groups = defaultdict(list)
         for pname, subrefs in refs.items():
-            print(pname, subrefs)
             for p in subrefs:
 
                 if isinstance(p, Parameter):

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -95,7 +95,7 @@ from .depends import (
 )
 from .parameterized import (
     Parameter, Parameterized, eval_function_with_deps, get_method_owner,
-    register_depends_transform, resolve_ref, resolve_value, transform_dependency
+    register_reference_transform, resolve_ref, resolve_value, transform_reference
 )
 from ._utils import iscoroutinefunction, full_groupby
 
@@ -314,13 +314,13 @@ def bind(function, *args, watch=False, **kwargs):
     annotated with all dependencies.
     """
     args, kwargs = (
-        tuple(transform_dependency(arg) for arg in args),
-        {key: transform_dependency(arg) for key, arg in kwargs.items()}
+        tuple(transform_reference(arg) for arg in args),
+        {key: transform_reference(arg) for key, arg in kwargs.items()}
     )
     dependencies = {}
 
     # If the wrapped function has a dependency add it
-    fn_dep = transform_dependency(function)
+    fn_dep = transform_reference(function)
     if isinstance(fn_dep, Parameter) or hasattr(fn_dep, '_dinfo'):
         dependencies['__fn'] = fn_dep
 
@@ -375,7 +375,7 @@ def bind(function, *args, watch=False, **kwargs):
         if callable(function):
             fn = function
         else:
-            p = transform_dependency(function)
+            p = transform_reference(function)
             if isinstance(p, Parameter):
                 fn = getattr(p.owner, p.name)
             else:
@@ -494,7 +494,7 @@ class reactive:
 
     def __new__(cls, obj, **kwargs):
         wrapper = None
-        obj = transform_dependency(obj)
+        obj = transform_reference(obj)
         if kwargs.get('fn'):
             fn = kwargs.pop('fn')
             wrapper = kwargs.pop('_wrapper', None)
@@ -978,4 +978,4 @@ def _reactive_transform(obj):
         return obj
     return bind(lambda *_: obj.rx.resolve(), *obj._params)
 
-register_depends_transform(_reactive_transform)
+register_reference_transform(_reactive_transform)

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -106,7 +106,7 @@ class Wrapper(Parameterized):
     Simple wrapper to allow updating literal values easily.
     """
 
-    object = Parameter()
+    object = Parameter(allow_refs=False)
 
 
 class Trigger(Parameterized):

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -91,12 +91,11 @@ from typing import Any, Callable, Optional
 
 from . import Event
 from .depends import (
-    _display_accessors, _reactive_display_objs, eval_function_with_deps,
-    register_depends_transform, depends, resolve_ref, resolve_value,
-    transform_dependency
+    _display_accessors, _reactive_display_objs, depends,
 )
 from .parameterized import (
-    Parameter, Parameterized, get_method_owner
+    Parameter, Parameterized, eval_function_with_deps, get_method_owner,
+    register_depends_transform, resolve_ref, resolve_value, transform_dependency
 )
 from ._utils import iscoroutinefunction, full_groupby
 

--- a/tests/testrefs.py
+++ b/tests/testrefs.py
@@ -1,0 +1,74 @@
+import param
+
+from param.reactive import bind, reactive
+
+class Parameters(param.Parameterized):
+
+    string = param.String(default="string", allow_refs=True)
+
+    dictionary = param.Dict(default={}, allow_refs=True, nested_refs=True)
+
+    string_list = param.List(default=[], item_type=str, allow_refs=True, nested_refs=True)
+
+
+def test_parameter_ref():
+    p = Parameters()
+    p2 = Parameters(string=p.param.string)
+
+    assert p.string == p2.string
+    p.string = 'new_string'
+    assert p2.string == 'new_string'
+
+def test_parameter_ref_update():
+    p = Parameters()
+    p2 = Parameters(string=p.param.string)
+    p3 = Parameters(string='new string')
+
+    p2.string = p3.param.string
+    assert p2.string == 'new string'
+    p.string = 'still linked'
+    assert p2.string != 'still linked'
+    p3.string = 'newly linked'
+    assert p2.string == 'newly linked'
+
+def test_bind_ref():
+    p = Parameters()
+    p2 = Parameters(string=bind(lambda x: x + '!', p.param.string))
+    assert p2.string == 'string!'
+    p.string = 'new string'
+    assert p2.string == 'new string!'
+
+def test_reactive_ref():
+    string = reactive('string')
+    rx_string = string+'!'
+    p = Parameters(string=rx_string)
+    assert p.string == 'string!'
+    string.rx.set_input('new string')
+    assert p.string == 'new string!'
+
+def test_nested_list_parameter_ref():
+    p = Parameters()
+    p2 = Parameters(string_list=[p.param.string, 'other'])
+    p3 = Parameters(string='foo')
+
+    assert p2.string_list == ['string', 'other']
+    p2.string_list = [p3.param.string, 'another']
+    assert p2.string_list == ['foo', 'another']
+
+def test_nested_dict_key_parameter_ref():
+    p = Parameters()
+    p2 = Parameters(dictionary={p.param.string: 'value'})
+    p3 = Parameters(string='foo')
+
+    assert p2.dictionary == {'string': 'value'}
+    p2.dictionary = {p3.param.string: 'new_value'}
+    assert p2.dictionary == {'foo': 'new_value'}
+
+def test_nested_dict_value_parameter_ref():
+    p = Parameters()
+    p2 = Parameters(dictionary={'key': p.param.string})
+    p3 = Parameters(string='foo')
+
+    assert p2.dictionary == {'key': 'string'}
+    p2.dictionary = {'new key': p3.param.string}
+    assert p2.dictionary == {'new key': 'foo'}

--- a/tests/testrefs.py
+++ b/tests/testrefs.py
@@ -1,4 +1,5 @@
 import param
+import pytest
 
 from param.reactive import bind, reactive
 
@@ -10,6 +11,15 @@ class Parameters(param.Parameterized):
 
     string_list = param.List(default=[], item_type=str, allow_refs=True, nested_refs=True)
 
+
+def test_parameterized_warns_explicit_no_ref():
+    class ImplicitRefsParameters(param.Parameterized):
+        parameter = param.Parameter(default="string")
+
+    p = Parameters()
+    with pytest.raises(Exception) as e:
+        ImplicitRefsParameters(parameter=p.param.string)
+    assert "Parameter 'parameter' is being given a valid parameter reference <param.parameterized.String" in str(e)
 
 def test_parameter_ref():
     p = Parameters()

--- a/tests/testrefs.py
+++ b/tests/testrefs.py
@@ -19,7 +19,7 @@ def test_parameterized_warns_explicit_no_ref():
     p = Parameters()
     with pytest.raises(Exception) as e:
         ImplicitRefsParameters(parameter=p.param.string)
-    assert "Parameter 'parameter' is being given a valid parameter reference <param.parameterized.String" in str(e)
+    assert f"Parameter 'parameter' on class {p} is being given a valid parameter reference <param.parameterized.String" in str(e)
 
 def test_parameter_ref():
     p = Parameters()

--- a/tests/testrefs.py
+++ b/tests/testrefs.py
@@ -19,7 +19,7 @@ def test_parameterized_warns_explicit_no_ref():
     p = Parameters()
     with pytest.raises(Exception) as e:
         ImplicitRefsParameters(parameter=p.param.string)
-    assert f"Parameter 'parameter' on class {p} is being given a valid parameter reference <param.parameterized.String" in str(e)
+    assert f"Parameter 'parameter' on {ImplicitRefsParameters} is being given a valid parameter reference <param.parameterized.String" in str(e.value)
 
 def test_parameter_ref():
     p = Parameters()


### PR DESCRIPTION
This PR brings an exceptionally useful feature that we have had in Panel since 1.2 to Param. Specifically it allows passing Parameter references (i.e. Parameter objects, reactive functions and expressions) as a parameter value and then automatically mirrors the value of the reference, e.g.:

```python
class Parameters(param.Parameterized):

    string = param.String(default="string", allow_refs=True)
 
p = Parameters()
p2 = Parameters(string=p.param.string)

assert p.string == p2.string
p.string = 'new_string'
assert p2.string == 'new_string'
```

This is much, much easier than setting up callbacks and together with the addition of reactive functions and expressions makes it super easy to set up parameters that depend on some other dynamically computed values. The implementation here is fully backward compatible, since you must enable the support for resolving references like this explicitly with the new `Parameter.allow_refs` slot.

Note that references can only be used on instances, classes will not attempt to resolve references, however you may use a class parameter as a reference.

This implementation also implements updating of references, which could not reasonably be implemented in Panel and is a good reason to move this support to Param.

In addition to allowing simple references to be resolved support can also be enabled for nested references using the `Parameter.nested_refs` slot. This allows constructs such as this to work:

```python
class Parameters(param.Parameterized):

    string = param.String(default="string", allow_refs=True)

    dictionary = param.Dict(default={}, allow_refs=True, nested_refs=True)

p = Parameters()
p2 = Parameters(dictionary={'key': p.param.string})
p3 = Parameters(string='foo')

assert p2.dictionary == {'key': 'string'}
p2.dictionary = {'new key': p3.param.string}
assert p2.dictionary == {'new key': 'foo'}
```