### PR TITLE
Fix implementation of rx.__iter__

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -941,20 +941,9 @@ class rx:
             return
         elif not isinstance(self._current, Iterable):
             raise TypeError(f'cannot unpack non-iterable {type(self._current).__name__} object.')
-        iterator = []
-        def iterate(value):
-            if iterator:
-                iterate = iterator[0]
-            else:
-                iterate = iter(value)
-                iterator.append(iterate)
-            try:
-                yield next(iterate)
-            except StopIteration as e:
-                iterator.clear()
-                raise e
-        for item in self._apply_operator(iterate):
-            yield item
+        items = self._apply_operator(list)
+        for i in range(len(self._current)):
+            yield items[i]
 
     def _eval_operation(self, obj, operation):
         fn, args, kwargs = operation['fn'], operation['args'], operation['kwargs']

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -231,6 +231,20 @@ def test_reactive_iter():
     assert a.rx.resolve() == 'b'
     assert b.rx.resolve() == 'a'
 
+def test_reactive_multi_iter():
+    i = rx(('a', 'b'))
+    a1, b1 = i
+    a2, b2 = i
+    assert a1.rx.resolve() == 'a'
+    assert b1.rx.resolve() == 'b'
+    assert a2.rx.resolve() == 'a'
+    assert b2.rx.resolve() == 'b'
+    i.rx.set_input(('b', 'a'))
+    assert a1.rx.resolve() == 'b'
+    assert b1.rx.resolve() == 'a'
+    assert a2.rx.resolve() == 'b'
+    assert b2.rx.resolve() == 'a'
+
 def test_reactive_is():
     i = rx(None)
     is_ = i.rx.is_(None)


### PR DESCRIPTION
The previous implementation was trying to be too clever. This implementation is simpler but achieves the same thing.