### PR TITLE
Replace .rx.resolve and .rx.set_input with .rx.value property

### DIFF
--- a/doc/user_guide/Reactive_Expressions.ipynb
+++ b/doc/user_guide/Reactive_Expressions.ipynb
@@ -895,7 +895,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "condition.rx.set_input(False)\n",
+    "condition.rx.value = False\n",
     "\n",
     "ternary_expr.rx.value"
    ]

--- a/doc/user_guide/Reactive_Expressions.ipynb
+++ b/doc/user_guide/Reactive_Expressions.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nrows.rx.set_input(4);"
+    "nrows.rx.value = 4"
    ]
   },
   {
@@ -114,7 +114,7 @@
     "import time\n",
     "\n",
     "for i in range(4,9):\n",
-    "    nrows.rx.set_input(i)\n",
+    "    nrows.rx.value = i\n",
     "    time.sleep(1)"
    ]
   },
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "color.rx.set_input('red');"
+    "color.rx.value = 'red'"
    ]
   },
   {
@@ -175,7 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nrows.rx.set_input(nrows.rx.resolve()+2);"
+    "nrows.rx.value += 2"
    ]
   },
   {
@@ -185,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "color.rx.set_input('darkblue');"
+    "color.rx.value = 'darkblue'"
    ]
   },
   {
@@ -215,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url.rx.set_input('https://datasets.holoviz.org/gapminders/v1/gapminders.csv');"
+    "url.rx.value = 'https://datasets.holoviz.org/gapminders/v1/gapminders.csv'"
    ]
   },
   {
@@ -225,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url.rx.set_input(URL);"
+    "url.rx.valeu = URL"
    ]
   },
   {
@@ -467,7 +467,7 @@
     "\n",
     "Reactive objects generally just provide whatever API the underlying object has, but there are a few extra reactive-specific methods also provided. In order to avoid any clashes between the namespace of the reactive expression and the object it is wrapping, the extra methods are in a special namespace called `.rx`.\n",
     "\n",
-    "For instance, to resolve the current value of the expression into the current value as a static (non-reactive) object, we can call `.rx.resolve()`:"
+    "For instance, to resolve the current value of the expression into the current value as a static (non-reactive) object, we can access the `.rx.value` property:"
    ]
   },
   {
@@ -477,7 +477,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expr.rx.resolve()"
+    "expr.rx.value"
    ]
   },
   {
@@ -549,7 +549,7 @@
    "source": [
     "### Setting the input value\n",
     "\n",
-    "To update the input to a `rx` object we can use the `.rx.set_input(new)` method:"
+    "To update the input to a `rx` object we can use the `.rx.value = new` property setter:"
    ]
   },
   {
@@ -559,9 +559,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name.rx.set_input('there')\n",
+    "name.rx.value = 'there'\n",
     "\n",
-    "str_expr.rx.resolve()"
+    "str_expr.rx.value"
    ]
   },
   {
@@ -596,7 +596,7 @@
     "\n",
     "#### Special methods\n",
     "\n",
-    "Therefore `reactive` implements certain operations as special methods that exist on the `.rx` namespace alongside `rx.set` and `rx.resolve`:\n",
+    "Therefore `reactive` implements certain operations as special methods that exist on the `.rx` namespace alongside the `rx.value` property getter and setter:\n",
     "\n",
     "- `.rx.bool()`: Reactive version of `bool()`, casting the output value to a Boolean.\n",
     "- `.rx.in_()`: Reactive version of `in`, testing if value is in the provided collection.\n",
@@ -807,7 +807,7 @@
     "p.a = 2\n",
     "p.b = 4\n",
     "\n",
-    "gated_expr.rx.resolve()"
+    "gated_expr.rx.value"
    ]
   },
   {
@@ -827,7 +827,7 @@
    "source": [
     "p.param.trigger('run')\n",
     "\n",
-    "gated_expr.rx.resolve()"
+    "gated_expr.rx.value"
    ]
   },
   {
@@ -897,7 +897,7 @@
    "source": [
     "condition.rx.set_input(False)\n",
     "\n",
-    "ternary_expr.rx.resolve()"
+    "ternary_expr.rx.value"
    ]
   },
   {
@@ -917,7 +917,7 @@
    "source": [
     "p.b = 5\n",
     "\n",
-    "ternary_expr.rx.resolve()"
+    "ternary_expr.rx.value"
    ]
   },
   {

--- a/doc/user_guide/Reactive_Expressions.ipynb
+++ b/doc/user_guide/Reactive_Expressions.ipynb
@@ -225,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url.rx.valeu = URL"
+    "url.rx.value = URL"
    ]
   },
   {

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -273,7 +273,7 @@ class reactive_ops:
                 "The value of a derived expression cannot be set. Ensure you "
                 "set the value on the root node wrapping a concrete value, e.g.:"
                 "\n\n    a = rx(1)\n    b = a + 1\n    a.rx.value = 2\n\n "
-                "is valid but you may not set `b.rx.value = 2."
+                "is valid but you may not set `b.rx.value = 2`."
             )
         if self._reactive._wrapper is None:
             raise AttributeError(
@@ -606,7 +606,7 @@ class rx:
         if self._error_state:
             raise self._error_state
         elif self._dirty or self._root._dirty_obj:
-            self.rx.value
+            self._resolve()
         return self._current_
 
     def _compute_root(self):
@@ -791,7 +791,7 @@ class rx:
         current = self_dict['_current_']
         dirty = self_dict['_dirty']
         if dirty:
-            self.rx.value
+            self._resolve()
             current = self_dict['_current_']
 
         method = self_dict['_method']

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -280,7 +280,7 @@ class reactive_ops:
                 "Setting the value of a reactive expression is only "
                 "supported if it wraps a concrete value. A reactive "
                 "expression wrapping a Parameter or another dynamic "
-                "reference cannot be updated set."
+                "reference cannot be updated."
             )
         self._reactive._wrapper.object = resolve_value(new)
 
@@ -671,8 +671,8 @@ class rx:
            if any parameter changes we have to notify the pipeline that
            it has to re-evaluate the pipeline. This is done by marking
            the pipeline as `_dirty`. The next time the `_current` value
-           is requested we then run and `._resolve()` pass that re-executes
-           the pipeline.
+           is requested the value is resolved by re-executing the
+           pipeline.
         """
         if self._fn is not None:
             for _, params in full_groupby(self._fn_params, lambda x: id(x.owner)):

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -202,7 +202,7 @@ class reactive_ops:
         dependencies: param.Parameter | rx
           A dependency that will trigger an update in the output.
         """
-        return bind(lambda *_: self.resolve(), *dependencies).rx()
+        return bind(lambda *_: self.value, *dependencies).rx()
 
     def where(self, x, y):
         """
@@ -225,12 +225,12 @@ class reactive_ops:
         trigger = Trigger(parameters=params)
         if xrefs:
             def trigger_x(*args):
-                if self.resolve():
+                if self.value:
                     trigger.param.trigger('value')
             bind(trigger_x, *xrefs, watch=True)
         if yrefs:
             def trigger_y(*args):
-                if not self.resolve():
+                if not self.value:
                     trigger.param.trigger('value')
             bind(trigger_y, *yrefs, watch=True)
 
@@ -240,7 +240,8 @@ class reactive_ops:
 
     # Operations to get the output and set the input of an expression
 
-    def resolve(self):
+    @property
+    def value(self):
         """
         Returns the current state of the reactive expression by
         evaluating the pipeline.
@@ -252,39 +253,36 @@ class reactive_ops:
         else:
             return self._reactive()
 
-    def set_input(self, new):
+    @value.setter
+    def value(self, new):
         """
         Allows overriding the original input to the pipeline.
         """
         if isinstance(self._reactive, Parameter):
-            raise ValueError(
-                "Parameter.rx.set_input() is not supported. Cannot override "
+            raise AttributeError(
+                "`Parameter.rx.value = value` is not supported. Cannot override "
                 "parameter value."
             )
         elif not isinstance(self._reactive, rx):
-            raise ValueError(
-                "bind(...).rx.set_input() is not supported. Cannot override "
+            raise AttributeError(
+                "`bind(...).rx.value = value` is not supported. Cannot override "
                 "the output of a function."
             )
-        if isinstance(new, rx):
-            new = new.resolve()
-        prev = self._reactive
-        while prev is not None:
-            prev._dirty = True
-            if prev._prev is not None:
-                prev = prev._prev
-                continue
-
-            if prev._wrapper is None:
-                raise ValueError(
-                    'rx.rx.set_input() is only supported if the '
-                    'root object is a constant value. If the root is a '
-                    'Parameter or another dynamic value it must reflect '
-                    'the source and cannot be set.'
-                )
-            prev._wrapper.object = new
-            prev = None
-        return self._reactive
+        elif self._reactive._root is not self._reactive:
+            raise AttributeError(
+                "The value of a derived expression cannot be set. Ensure you "
+                "set the value on the root node wrapping a concrete value, e.g.:"
+                "\n\n    a = rx(1)\n    b = a + 1\n    a.rx.value = 2\n\n "
+                "is valid but you may not set `b.rx.value = 2."
+            )
+        if self._reactive._wrapper is None:
+            raise AttributeError(
+                "Setting the value of a reactive expression is only "
+                "supported if it wraps a concrete value. A reactive "
+                "expression wrapping a Parameter or another dynamic "
+                "reference cannot be updated set."
+            )
+        self._reactive._wrapper.object = resolve_value(new)
 
     def watch(self, fn, onlychanged=True, queued=False, precedence=0):
         """
@@ -298,7 +296,7 @@ class reactive_ops:
 
     def _watch(self, fn, onlychanged=True, queued=False, precedence=0):
         def cb(*args):
-            fn(self.resolve())
+            fn(self.value)
 
         if isinstance(self._reactive, rx):
             params = self._reactive._params
@@ -608,7 +606,7 @@ class rx:
         if self._error_state:
             raise self._error_state
         elif self._dirty or self._root._dirty_obj:
-            self.rx.resolve()
+            self.rx.value
         return self._current_
 
     def _compute_root(self):
@@ -673,7 +671,7 @@ class rx:
            if any parameter changes we have to notify the pipeline that
            it has to re-evaluate the pipeline. This is done by marking
            the pipeline as `_dirty`. The next time the `_current` value
-           is requested we then run and `.resolve()` pass that re-executes
+           is requested we then run and `._resolve()` pass that re-executes
            the pipeline.
         """
         if self._fn is not None:
@@ -793,7 +791,7 @@ class rx:
         current = self_dict['_current_']
         dirty = self_dict['_dirty']
         if dirty:
-            self.rx.resolve()
+            self.rx.value
             current = self_dict['_current_']
 
         method = self_dict['_method']
@@ -861,6 +859,9 @@ class rx:
 
     def __abs__(self):
         return self._apply_operator(abs)
+
+    def __str__(self):
+        return self._apply_operator(str)
 
     def __round__(self, ndigits=None):
         args = () if ndigits is None else (ndigits,)
@@ -964,7 +965,7 @@ class rx:
             while True:
                 try:
                     new = self._apply_operator(next)
-                    new.rx.resolve()
+                    new.rx.value
                 except RuntimeError:
                     break
                 yield new
@@ -995,6 +996,6 @@ class rx:
 def _rx_transform(obj):
     if not isinstance(obj, rx):
         return obj
-    return bind(lambda *_: obj.rx.resolve(), *obj._params)
+    return bind(lambda *_: obj.rx.value, *obj._params)
 
 register_reference_transform(_rx_transform)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -72,213 +72,227 @@ class Parameters(param.Parameterized):
 
 @pytest.mark.parametrize('op', NUMERIC_BINARY_OPERATORS)
 def test_reactive_numeric_binary_ops(op):
-    assert op(rx(1), 2).rx.resolve() == op(1, 2)
-    assert op(rx(2), 2).rx.resolve() == op(2, 2)
+    assert op(rx(1), 2).rx.value == op(1, 2)
+    assert op(rx(2), 2).rx.value == op(2, 2)
 
 @pytest.mark.parametrize('op', COMPARISON_OPERATORS)
 def test_reactive_numeric_comparison_ops(op):
-    assert op(rx(1), 2).rx.resolve() == op(1, 2)
-    assert op(rx(2), 1).rx.resolve() == op(2, 1)
+    assert op(rx(1), 2).rx.value == op(1, 2)
+    assert op(rx(2), 1).rx.value == op(2, 1)
 
 @pytest.mark.parametrize('op', NUMERIC_UNARY_OPERATORS)
 def test_reactive_numeric_unary_ops(op):
-    assert op(rx(1)).rx.resolve() == op(1)
-    assert op(rx(-1)).rx.resolve() == op(-1)
-    assert op(rx(3.142)).rx.resolve() == op(3.142)
+    assert op(rx(1)).rx.value == op(1)
+    assert op(rx(-1)).rx.value == op(-1)
+    assert op(rx(3.142)).rx.value == op(3.142)
 
 @pytest.mark.parametrize('op', NUMERIC_BINARY_OPERATORS)
 def test_reactive_numeric_binary_ops_reverse(op):
-    assert op(2, rx(1)).rx.resolve() == op(2, 1)
-    assert op(2, rx(2)).rx.resolve() == op(2, 2)
+    assert op(2, rx(1)).rx.value == op(2, 1)
+    assert op(2, rx(2)).rx.value == op(2, 2)
 
 @pytest.mark.parametrize('op', LOGIC_BINARY_OPERATORS)
 def test_reactive_logic_binary_ops(op):
-    assert op(rx(True), True).rx.resolve() == op(True, True)
-    assert op(rx(True), False).rx.resolve() == op(True, False)
-    assert op(rx(False), True).rx.resolve() == op(False, True)
-    assert op(rx(False), False).rx.resolve() == op(False, False)
+    assert op(rx(True), True).rx.value == op(True, True)
+    assert op(rx(True), False).rx.value == op(True, False)
+    assert op(rx(False), True).rx.value == op(False, True)
+    assert op(rx(False), False).rx.value == op(False, False)
 
 @pytest.mark.parametrize('op', LOGIC_UNARY_OPERATORS)
 def test_reactive_logic_unary_ops(op):
-    assert op(rx(True)).rx.resolve() == op(True)
-    assert op(rx(False)).rx.resolve() == op(False)
+    assert op(rx(True)).rx.value == op(True)
+    assert op(rx(False)).rx.value == op(False)
 
 @pytest.mark.parametrize('op', LOGIC_BINARY_OPERATORS)
 def test_reactive_logic_binary_ops_reverse(op):
-    assert op(True, rx(True)).rx.resolve() == op(True, True)
-    assert op(True, rx(False)).rx.resolve() == op(True, False)
-    assert op(False, rx(True)).rx.resolve() == op(False, True)
-    assert op(False, rx(False)).rx.resolve() == op(False, False)
+    assert op(True, rx(True)).rx.value == op(True, True)
+    assert op(True, rx(False)).rx.value == op(True, False)
+    assert op(False, rx(True)).rx.value == op(False, True)
+    assert op(False, rx(False)).rx.value == op(False, False)
 
 def test_reactive_getitem_dict():
-    assert rx({'A': 1})['A'].rx.resolve() == 1
-    assert rx({'A': 1, 'B': 2})['B'].rx.resolve() == 2
+    assert rx({'A': 1})['A'].rx.value == 1
+    assert rx({'A': 1, 'B': 2})['B'].rx.value == 2
 
 def test_reactive_getitem_list():
-    assert rx([1, 2, 3])[1].rx.resolve() == 2
-    assert rx([1, 2, 3])[2].rx.resolve() == 3
+    assert rx([1, 2, 3])[1].rx.value == 2
+    assert rx([1, 2, 3])[2].rx.value == 3
 
 @pytest.mark.parametrize('ufunc', NUMPY_UFUNCS)
 def test_numpy_ufunc(ufunc):
     l = [1, 2, 3]
-    assert ufunc(rx(l)).rx.resolve() == ufunc(l)
+    assert ufunc(rx(l)).rx.value == ufunc(l)
     array = np.ndarray([1, 2, 3])
-    assert ufunc(rx(array)).rx.resolve() == ufunc(array)
+    assert ufunc(rx(array)).rx.value == ufunc(array)
 
 def test_reactive_set_new_value():
     i = rx(1)
-    assert i.rx.resolve() == 1
-    i.rx.set_input(2)
-    assert i.rx.resolve() == 2
+    assert i.rx.value == 1
+    i.rx.value = 2
+    assert i.rx.value == 2
+
+def test_reactive_increment_value():
+    i = rx(1)
+    assert i.rx.value == 1
+    i.rx.value += 2
+    assert i.rx.value == 3
+
+def test_reactive_multiply_value_inplace():
+    i = rx(3)
+    assert i.rx.value == 3
+    i.rx.value *= 2
+    assert i.rx.value == 6
 
 def test_reactive_pipeline_set_new_value():
-    i = rx(1) + 2
-    assert i.rx.resolve() == 3
-    i.rx.set_input(2)
-    assert i.rx.resolve() == 4
+    i = rx(1)
+    j = i + 2
+    assert j.rx.value == 3
+    i.rx.value = 2
+    assert j.rx.value == 4
 
 def test_reactive_reflect_param_value():
     P = Parameters(integer=1)
     i = rx(P.param.integer)
-    assert i.rx.resolve() == 1
+    assert i.rx.value == 1
     P.integer = 2
-    assert i.rx.resolve() == 2
+    assert i.rx.value == 2
 
 def test_reactive_pipeline_reflect_param_value():
     P = Parameters(integer=1)
     i = rx(P.param.integer) + 2
-    assert i.rx.resolve() == 3
+    assert i.rx.value == 3
     P.integer = 2
-    assert i.rx.resolve() == 4
+    assert i.rx.value == 4
 
 def test_reactive_reactive_reflect_other_rx():
     i = rx(1)
     j = rx(i)
-    assert j.rx.resolve() == 1
-    i.rx.set_input(2)
-    assert j.rx.resolve() == 2
+    assert j.rx.value == 1
+    i.rx.value = 2
+    assert j.rx.value == 2
 
 def test_reactive_pipeline_reflect_other_reactive_expr():
-    i = rx(1) + 2
-    j = rx(i)
-    assert j.rx.resolve() == 3
-    i.rx.set_input(2)
-    assert i.rx.resolve() == 4
+    i = rx(1)
+    j = i + 2
+    k = rx(j)
+    assert k.rx.value == 3
+    i.rx.value = 2
+    assert k.rx.value == 4
 
 def test_reactive_reflect_bound_method():
     P = Parameters(integer=1)
     i = rx(P.multiply_integer)
-    assert i.rx.resolve() == 2
+    assert i.rx.value == 2
     P.integer = 2
-    assert i.rx.resolve() == 4
+    assert i.rx.value == 4
 
 def test_reactive_pipeline_reflect_bound_method():
     P = Parameters(integer=1)
     i = rx(P.multiply_integer) + 2
-    assert i.rx.resolve() == 4
+    assert i.rx.value == 4
     P.integer = 2
-    assert i.rx.resolve() == 6
+    assert i.rx.value == 6
 
 def test_reactive_reflect_bound_function():
     P = Parameters(integer=1)
     i = rx(bind(lambda v: v * 2, P.param.integer))
-    assert i.rx.resolve() == 2
+    assert i.rx.value == 2
     P.integer = 2
-    assert i.rx.resolve() == 4
+    assert i.rx.value == 4
 
 def test_reactive_pipeline_reflect_bound_function():
     P = Parameters(integer=1)
     i = rx(bind(lambda v: v * 2, P.param.integer)) + 2
-    assert i.rx.resolve() == 4
+    assert i.rx.value == 4
     P.integer = 2
-    assert i.rx.resolve() == 6
+    assert i.rx.value == 6
 
 def test_reactive_dataframe_method_chain(dataframe):
     dfi = rx(dataframe).groupby('str')[['float']].mean().reset_index()
-    pd.testing.assert_frame_equal(dfi.rx.resolve(), dataframe.groupby('str')[['float']].mean().reset_index())
+    pd.testing.assert_frame_equal(dfi.rx.value, dataframe.groupby('str')[['float']].mean().reset_index())
 
 def test_reactive_dataframe_attribute_chain(dataframe):
-    array = rx(dataframe).str.values.rx.resolve()
+    array = rx(dataframe).str.values.rx.value
     np.testing.assert_array_equal(array, dataframe.str.values)
 
 def test_reactive_dataframe_param_value_method_chain(dataframe):
     P = Parameters(string='str')
     dfi = rx(dataframe).groupby(P.param.string)[['float']].mean().reset_index()
-    pd.testing.assert_frame_equal(dfi.rx.resolve(), dataframe.groupby('str')[['float']].mean().reset_index())
+    pd.testing.assert_frame_equal(dfi.rx.value, dataframe.groupby('str')[['float']].mean().reset_index())
     P.string = 'int'
-    pd.testing.assert_frame_equal(dfi.rx.resolve(), dataframe.groupby('int')[['float']].mean().reset_index())
+    pd.testing.assert_frame_equal(dfi.rx.value, dataframe.groupby('int')[['float']].mean().reset_index())
 
 def test_reactive_len():
     i = rx([1, 2, 3])
     l = i.rx.len()
-    assert l.rx.resolve() == 3
-    i.rx.set_input([1, 2])
+    assert l.rx.value == 3
+    i.rx.value = [1, 2]
     assert l == 2
 
 def test_reactive_bool():
     i = rx(1)
     b = i.rx.bool()
-    assert b.rx.resolve() is True
-    i.rx.set_input(0)
-    assert b.rx.resolve() is False
+    assert b.rx.value is True
+    i.rx.value = 0
+    assert b.rx.value is False
 
 def test_reactive_iter():
     i = rx(('a', 'b'))
     a, b = i
-    assert a.rx.resolve() == 'a'
-    assert b.rx.resolve() == 'b'
-    i.rx.set_input(('b', 'a'))
-    assert a.rx.resolve() == 'b'
-    assert b.rx.resolve() == 'a'
+    assert a.rx.value == 'a'
+    assert b.rx.value == 'b'
+    i.rx.value = ('b', 'a')
+    assert a.rx.value == 'b'
+    assert b.rx.value == 'a'
 
 def test_reactive_multi_iter():
     i = rx(('a', 'b'))
     a1, b1 = i
     a2, b2 = i
-    assert a1.rx.resolve() == 'a'
-    assert b1.rx.resolve() == 'b'
-    assert a2.rx.resolve() == 'a'
-    assert b2.rx.resolve() == 'b'
-    i.rx.set_input(('b', 'a'))
-    assert a1.rx.resolve() == 'b'
-    assert b1.rx.resolve() == 'a'
-    assert a2.rx.resolve() == 'b'
-    assert b2.rx.resolve() == 'a'
+    assert a1.rx.value == 'a'
+    assert b1.rx.value == 'b'
+    assert a2.rx.value == 'a'
+    assert b2.rx.value == 'b'
+    i.rx.value = ('b', 'a')
+    assert a1.rx.value == 'b'
+    assert b1.rx.value == 'a'
+    assert a2.rx.value == 'b'
+    assert b2.rx.value == 'a'
 
 def test_reactive_is():
     i = rx(None)
     is_ = i.rx.is_(None)
-    assert is_.rx.resolve()
-    i.rx.set_input(False)
-    assert not is_.rx.resolve()
+    assert is_.rx.value
+    i.rx.value = False
+    assert not is_.rx.value
 
 def test_reactive_in():
     i = rx(2)
     in_ = i.rx.in_([1, 2, 3])
-    assert in_.rx.resolve()
-    i.rx.set_input(4)
-    assert not in_.rx.resolve()
+    assert in_.rx.value
+    i.rx.value = 4
+    assert not in_.rx.value
 
 def test_reactive_is_not():
     i = rx(None)
     is_ = i.rx.is_not(None)
-    assert not is_.rx.resolve()
-    i.rx.set_input(False)
-    assert is_.rx.resolve()
+    assert not is_.rx.value
+    i.rx.value = False
+    assert is_.rx.value
 
 def test_reactive_where_expr():
     p = Parameters()
     r = p.param.boolean.rx.where('A', 'B')
-    assert r.rx.resolve() == 'B'
+    assert r.rx.value == 'B'
     p.boolean = True
-    assert r.rx.resolve() == 'A'
+    assert r.rx.value == 'A'
 
 def test_reactive_where_expr_refs():
     p = Parameters()
     results = []
     r = p.param.boolean.rx.where(p.param.string, p.param.number)
     r.rx.watch(results.append)
-    assert r.rx.resolve() == 3.14
+    assert r.rx.value == 3.14
     p.boolean = True
     assert results == ['string']
     p.string = 'foo'
@@ -293,5 +307,10 @@ def test_reactive_watch_on_set_input():
     new_string = string + '!'
     items = []
     new_string.rx.watch(items.append)
-    string.rx.set_input('new string')
+    string.rx.value = 'new string'
     assert items == ['new string!']
+
+def test_reactive_set_value_non_root_raises():
+    rx_val = rx(1) + 1
+    with pytest.raises(AttributeError):
+        rx_val.rx.value = 3

--- a/tests/testrefs.py
+++ b/tests/testrefs.py
@@ -62,7 +62,7 @@ def test_reactive_ref():
     rx_string = string+'!'
     p = Parameters(string=rx_string)
     assert p.string == 'string!'
-    string.rx.set_input('new string')
+    string.rx.value = 'new string'
     assert p.string == 'new string!'
 
 def test_nested_list_parameter_ref():


### PR DESCRIPTION
Overall this seems much cleaner. Some consequences:

- We no longer allow setting the value of a non-root node of a reactive expression, i.e. `(rx(1) + 1).value = 2` is invalid. This was always what was confusing and made naming this difficult.
- We now automatically gain support for increment (i.e. `.rx.value +=`) and other arithmetic/boolean assignment operators