### PR TITLE
Only warn on failed default validation while inheriting Parameter attributes

### DIFF
--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -156,6 +156,107 @@ class TestDeprecateParameterizedModule:
 
         P()
 
+    # Inheritance tests to be move to testparameterizedobject.py when warnings will be turned into errors
+
+    def test_inheritance_with_incompatible_defaults(self):
+        class A(param.Parameterized):
+            p = param.String()
+
+        class B(A): pass
+
+        with pytest.raises(
+            param._utils.ParamFutureWarning,
+            match=re.escape(
+                "Number parameter 'C.p' failed to validate its "
+                "default value on class creation, this is going to raise "
+                "an error in the future. The Parameter type changed between class 'C' "
+                "and one of its parent classes (B, A) which made it invalid. "
+                "Please fix the Parameter type."
+                "\nValidation failed with:\nNumber parameter 'C.p' only takes numeric values, not <class 'str'>."
+            )
+        ):
+            class C(B):
+                p = param.Number()
+
+    def test_inheritance_default_validation_with_more_specific_type(self):
+        class A(param.Parameterized):
+            p = param.Tuple(default=('a', 'b'))
+
+        class B(A): pass
+
+        with pytest.raises(
+            param._utils.ParamFutureWarning,
+            match=re.escape(
+                "NumericTuple parameter 'C.p' failed to validate its "
+                "default value on class creation, this is going to raise "
+                "an error in the future. The Parameter type changed between class 'C' "
+                "and one of its parent classes (B, A) which made it invalid. "
+                "Please fix the Parameter type."
+                "\nValidation failed with:\nNumericTuple parameter 'C.p' only takes numeric values, not <class 'str'>."
+            )
+        ):
+            class C(B):
+                p = param.NumericTuple()
+
+    def test_inheritance_with_changing_bounds(self):
+        class A(param.Parameterized):
+            p = param.Number(default=5)
+
+        class B(A): pass
+
+        with pytest.raises(
+            param._utils.ParamFutureWarning,
+            match=re.escape(
+                "Number parameter 'C.p' failed to validate its "
+                "default value on class creation, this is going to raise "
+                "an error in the future. The Parameter is defined with attributes "
+                "which when combined with attributes inherited from its parent "
+                "classes (B, A) make it invalid. Please fix the Parameter attributes."
+                "\nValidation failed with:\nNumber parameter 'C.p' must be at most 3, not 5."
+            )
+        ):
+            class C(B):
+                p = param.Number(bounds=(-1, 3))
+
+    def test_inheritance_with_changing_default(self):
+        class A(param.Parameterized):
+            p = param.Number(default=5, bounds=(3, 10))
+
+        class B(A): pass
+
+        with pytest.raises(
+            param._utils.ParamFutureWarning,
+            match=re.escape(
+                "Number parameter 'C.p' failed to validate its "
+                "default value on class creation, this is going to raise "
+                "an error in the future. The Parameter is defined with attributes "
+                "which when combined with attributes inherited from its parent "
+                "classes (B, A) make it invalid. Please fix the Parameter attributes."
+                "\nValidation failed with:\nNumber parameter 'C.p' must be at least 3, not 1."
+            )
+        ):
+            class C(B):
+                p = param.Number(default=1)
+
+    def test_inheritance_with_changing_class_(self):
+        class A(param.Parameterized):
+            p = param.ClassSelector(class_=int, default=5)
+
+        class B(A): pass
+
+        with pytest.raises(
+            param._utils.ParamFutureWarning,
+            match=re.escape(
+                "ClassSelector parameter 'C.p' failed to validate its "
+                "default value on class creation, this is going to raise "
+                "an error in the future. The Parameter is defined with attributes "
+                "which when combined with attributes inherited from its parent "
+                "classes (B, A) make it invalid. Please fix the Parameter attributes."
+                "\nValidation failed with:\nClassSelector parameter 'C.p' value must be an instance of str, not 5."
+            )
+        ):
+            class C(B):
+                p = param.ClassSelector(class_=str)
 
 class TestDeprecateParameters:
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1147,56 +1147,6 @@ def test_inheritance_diamond_not_supported():
     assert d.param.p.doc == '11'
 
 
-def test_inheritance_with_incompatible_defaults():
-    class A(param.Parameterized):
-        p = param.String()
-
-    with pytest.raises(ValueError) as excinfo:
-        class B(A):
-            p = param.Number()
-    assert "Number parameter 'B.p' only takes numeric values, not <class 'str'>" in str(excinfo.value)
-
-
-def test_inheritance_default_validation_with_more_specific_type():
-    class A(param.Parameterized):
-        p = param.Tuple(default=('a', 'b'))
-
-    with pytest.raises(ValueError) as excinfo:
-        class B(A):
-            p = param.NumericTuple()
-    assert "NumericTuple parameter 'B.p' only takes numeric values, not <class 'str'>" in str(excinfo.value)
-
-
-def test_inheritance_with_changing_bounds():
-    class A(param.Parameterized):
-        p = param.Number(default=5)
-
-    with pytest.raises(ValueError) as excinfo:
-        class B(A):
-            p = param.Number(bounds=(1, 3))
-    assert "Number parameter 'p' must be at least 1, not 0.0." in str(excinfo.value)
-
-
-def test_inheritance_with_changing_default():
-    class A(param.Parameterized):
-        p = param.Number(default=5, bounds=(3, 10))
-
-    with pytest.raises(ValueError) as excinfo:
-        class B(A):
-            p = param.Number(default=1)
-    assert "Number parameter 'B.p' must be at least 3, not 1." in str(excinfo.value)
-
-
-def test_inheritance_with_changing_class_():
-    class A(param.Parameterized):
-        p = param.ClassSelector(class_=int, default=5)
-
-    with pytest.raises(ValueError) as excinfo:
-        class B(A):
-            p = param.ClassSelector(class_=str)
-    assert "ClassSelector parameter 'B.p' value must be an instance of str, not 5." in str(excinfo.value)
-
-
 def test_inheritance_from_multiple_params_class():
     class A(param.Parameterized):
         p = param.Parameter(doc='foo')


### PR DESCRIPTION
As discussed today, we have decided to just warn for now on failed `default` validation while inheriting Parameter attributes in a hierarchy of classes. The reasoning being that raising an error on failed validation would be too disruptive, as it would break users code on import and would probably be a painful process to update, going one Parameter after another. I have attempted to give as much context as possible (without resorting to `inspect` though) in the error message, which can be seen in the tests. I have chosen to emit a `ParamFutureWarning` that is unconditionally displayed, we really want users to fix their code as soon as they see this warning.

- [ ] Update the release notes with this new deprecation.