### PR TITLE
Fix regression in ListSelector with `check_on_set=False`

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -488,7 +488,7 @@ def _instantiate_param_obj(paramobj, owner=None):
     p.watchers = {}
 
     # shallow-copy any mutable slot values other than the actual default
-    for s in p.__class__.__slots__:
+    for s in p.__class__._all_slots_:
         v = getattr(p, s)
         if _is_mutable_container(v) and s != "default":
             setattr(p, s, copy.copy(v))

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2071,18 +2071,17 @@ class ListSelector(Selector):
                     self.objects.append(o)
 
     def _validate(self, val):
+        if (val is None and self.allow_None):
+            return
         self._validate_type(val)
 
         if self.check_on_set:
             self._validate_value(val)
         else:
-            self._ensure_value_is_in_objects(val)
-
+            for v in val:
+                self._ensure_value_is_in_objects(v)
 
     def _validate_type(self, val):
-        if (val is None and self.allow_None):
-            return
-
         if not isinstance(val, list):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes list types, "

--- a/tests/testlistselector.py
+++ b/tests/testlistselector.py
@@ -22,6 +22,7 @@ class TestListSelectorParameters(unittest.TestCase):
             h = param.ListSelector(default=None)
             g = param.ListSelector(default=None,objects=[7,8])
             i = param.ListSelector(default=[7],objects=[9],check_on_set=False)
+            j = param.ListSelector(objects=[11], check_on_set=False, allow_None=True)
 
         self.P = P
 
@@ -84,12 +85,17 @@ class TestListSelectorParameters(unittest.TestCase):
     def test_set_object_setattr(self):
         p = self.P(e=[6])
         p.f = [9]
-        self.assertEqual(p.f, [9])
+        assert p.f == [9]
+        assert p.param.f.objects == [10, 9]
+        assert self.P.param.f.objects == [10]
         p.g = [7]
-        self.assertEqual(p.g, [7])
+        assert p.g == [7]
+        assert p.param.g.objects == self.P.param.g.objects
+        assert p.param.g.objects == [7, 8]
         p.i = [12]
-        self.assertEqual(p.i, [12])
-
+        assert p.i == [12]
+        assert p.param.i.objects == [9, 7, 12]
+        assert self.P.param.i.objects == [9, 7]
 
     def test_set_object_not_None(self):
         p = self.P(e=[6])
@@ -111,6 +117,14 @@ class TestListSelectorParameters(unittest.TestCase):
         else:
             raise AssertionError("Object set outside range.")
 
+    def test_set_one_object_allow_None_check_on_set(self):
+        p = self.P(e=[6])
+        p.j = None
+        assert p.j is None
+        assert p.param.j.objects == [11]
+        p.j = [12]
+        assert p.j == [12]
+        assert p.param.j.objects == [11, 12]
 
     def test_set_object_setattr_post_error(self):
         p = self.P(e=[6])
@@ -147,11 +161,6 @@ class TestListSelectorParameters(unittest.TestCase):
         else:
             raise AssertionError("ListSelector created without range.")
 
-
-    ##################################################################
-    ##################################################################
-    ### new tests (not copied from testobjectselector)
-
     def test_bad_default(self):
         with pytest.raises(
             ValueError,
@@ -172,7 +181,6 @@ class TestListSelectorParameters(unittest.TestCase):
         class Q(param.Parameterized):
             r = param.ListSelector(default=[6])
 
-    ##########################
     def test_default_not_checked_to_be_iterable(self):
         with pytest.raises(
             ValueError,
@@ -187,8 +195,6 @@ class TestListSelectorParameters(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Q.r = 6
-    ##########################
-
 
     def test_compute_default(self):
         class Q(param.Parameterized):


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/872

I also found a pretty bad bug in `_instantiate_param_obj` where we were looping only through the `__slots__` defined on the Parameter class, ignoring the ones it inherits. Easy mistake, `kls.__slots__` should really return all the slots! This bug led `ListSelector._objects` being shared between a Parameterized class and instance, since the `_objects` slot is declared in a parent class.

```diff
-    for s in p.__class__.__slots__:
+    for s in p.__class__._all_slots_:
        v = getattr(p, s)
        if _is_mutable_container(v) and s != "default":
            setattr(p, s, copy.copy(v))
```

I also made sure that setting `None` with `check_on_set=False` and `allow_None=True` doesn't add `None` to the objects.