### PR TITLE
Do not install “doc” in site-packages (fix #877)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,18 +97,15 @@ source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 include = [
-    "param",
-    "numbergen",
-]
-exclude = [
-    "doc",
+    "/param",
+    "/numbergen",
 ]
 
 [tool.hatch.build.targets.sdist]
 include = [
-    "param",
-    "numbergen",
-    "tests",
+    "/param",
+    "/numbergen",
+    "/tests",
 ]
 
 [tool.hatch.build.hooks.vcs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ include = [
     "param",
     "numbergen",
 ]
+exclude = [
+    "doc",
+]
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
Tested in a clean git checkout:

```
python3 -m build
python3 -m wheel unpack dist/param-*.whl
find param-*/doc/
```

```
find: ‘param-*/doc/’: No such file or directory
```