### PR TITLE
Set `creationflags` on Windows only

### DIFF
--- a/param/version.py
+++ b/param/version.py
@@ -21,10 +21,13 @@ __author__ = 'Jean-Luc Stevens'
 import os, subprocess, json
 
 def run_cmd(args, cwd=None):
+    kwargs = {}
+    if os.name == 'nt':
+        kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
     proc = subprocess.Popen(args, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             cwd=cwd,
-                            creationflags=subprocess.CREATE_NO_WINDOW)
+                            **kwargs)
     output, error = (str(s.decode()).strip() for s in proc.communicate())
 
     # Detects errors as _either_ a non-zero return code _or_ messages

--- a/tests/testversion.py
+++ b/tests/testversion.py
@@ -1,0 +1,6 @@
+from param.version import run_cmd
+
+
+def test_run_cmd():
+    output = run_cmd(['echo', 'test'])
+    assert output == 'test'


### PR DESCRIPTION
`subprocess.CREATE_NO_WINDOW` is a Windows constant so it fails on other platforms: https://docs.python.org/3/library/subprocess.html#windows-constants.

Also adding a simple test that would have caught that.