### PR TITLE
Fix typo in user guide: Outputs.ipynb

### DIFF
--- a/doc/user_guide/Outputs.ipynb
+++ b/doc/user_guide/Outputs.ipynb
@@ -151,7 +151,7 @@
    "id": "3a68b349",
    "metadata": {},
    "source": [
-    "Here, you can see that there are _two_ outputs from `prod_str()`, one of type Number and one of type String, and that they are in the order (number, string) in the tuple. The other outputs are all a single result returned directly from that method, with the indicated types (defaulting to `Parameter`) and names. Annotating outputs in this way can help you build large, flexible systems for connecting Parameterized objects together into larger data or computational structures."
+    "Here, you can see that there are _two_ outputs from `products()`, one of type Number and one of type String, and that they are in the order (number, string) in the tuple. The other outputs are all a single result returned directly from that method, with the indicated types (defaulting to `Parameter`) and names. Annotating outputs in this way can help you build large, flexible systems for connecting Parameterized objects together into larger data or computational structures."
    ]
   }
  ],


### PR DESCRIPTION
A small method names mixup.