### PR TITLE
Minor optimizations in hot codepaths accessing class parameters

### DIFF
--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -287,11 +287,31 @@ class ParameterizedParamAccessSuite:
         self.P1 = P1
         self.p1 = P1()
 
-    def test_class(self):
+    def time_class(self):
         self.P1.param
 
-    def test_instance(self):
+    def time_instance(self):
         self.p1.param
+
+class ParameterizedParamContainsSuite:
+
+    def setup(self):
+        class P1(param.Parameterized):
+            x0 = param.Parameter()
+            x1 = param.Parameter()
+            x2 = param.Parameter()
+            x3 = param.Parameter()
+            x4 = param.Parameter()
+            x5 = param.Parameter()
+
+        self.P1 = P1
+        self.p1 = P1()
+
+    def time_class(self):
+        'x5' in self.P1.param
+
+    def time_instance(self):
+        'x5' in self.p1.param
 
 
 class ParameterizedSetattrSuite:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1851,7 +1851,7 @@ class Parameters:
         inst = self_.self
         if inst is None:
             return self_._cls_parameters[key]
-        p = self_.params.objects(instance=False)[key]
+        p = self_.objects(instance=False)[key]
         return _instantiated_parameter(inst, p)
 
     def __dir__(self_):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1866,10 +1866,7 @@ class Parameters:
         yield from self_.objects(instance=False)
 
     def __contains__(self_, param):
-        for p in self_.cls._param__private.params:
-            if param == p:
-                return True
-        return False
+        return param in self_._cls_parameters
 
     def __getattr__(self_, attr):
         """
@@ -2238,8 +2235,8 @@ class Parameters:
         # would need to handle the params() cache as well
         # (which is tricky but important for startup speed).
         cls = self_.cls
-        type.__setattr__(cls,param_name,param_obj)
-        ParameterizedMetaclass._initialize_parameter(cls,param_name,param_obj)
+        type.__setattr__(cls, param_name, param_obj)
+        ParameterizedMetaclass._initialize_parameter(cls, param_name, param_obj)
         # delete cached params()
         cls._param__private.params.clear()
 
@@ -2355,6 +2352,31 @@ class Parameters:
                                  (self_or_cls.name))
         return self_.update(kwargs)
 
+    @property
+    def _cls_parameters(self_):
+        """
+        Class parameters are cached because they are accessed often,
+        and parameters are rarely added (and cannot be deleted)
+        """
+        cls = self_.cls
+        pdict = cls._param__private.params
+        if pdict:
+            return pdict
+
+        paramdict = {}
+        for class_ in classlist(cls):
+            for name, val in class_.__dict__.items():
+                if isinstance(val, Parameter):
+                    paramdict[name] = val
+
+        # We only want the cache to be visible to the cls on which
+        # params() is called, so we mangle the name ourselves at
+        # runtime (if we were to mangle it now, it would be
+        # _Parameterized.__params for all classes).
+        # cls._param__private.params[f'_{cls.__name__}__params'] = paramdict
+        cls._param__private.params = paramdict
+        return paramdict
+
     def objects(self_, instance=True):
         """
         Returns the Parameters of this instance or class
@@ -2379,25 +2401,7 @@ class Parameters:
                 stacklevel=2,
             )
 
-        cls = self_.cls
-        # We cache the parameters because this method is called often,
-        # and parameters are rarely added (and cannot be deleted)
-        pdict = cls._param__private.params
-        if not pdict:
-            paramdict = {}
-            for class_ in classlist(cls):
-                for name, val in class_.__dict__.items():
-                    if isinstance(val, Parameter):
-                        paramdict[name] = val
-
-            # We only want the cache to be visible to the cls on which
-            # params() is called, so we mangle the name ourselves at
-            # runtime (if we were to mangle it now, it would be
-            # _Parameterized.__params for all classes).
-            # cls._param__private.params[f'_{cls.__name__}__params'] = paramdict
-            cls._param__private.params = paramdict
-            pdict = paramdict
-
+        pdict = self_._cls_parameters
         if instance and self_.self is not None:
             if instance == 'existing':
                 if getattr(self_.self._param__private, 'initialized', False) and self_.self._param__private.params:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1866,7 +1866,10 @@ class Parameters:
         yield from self_.objects(instance=False)
 
     def __contains__(self_, param):
-        return param in list(self_)
+        for p in self_.cls._param__private.params:
+            if param == p:
+                return True
+        return False
 
     def __getattr__(self_, attr):
         """


### PR DESCRIPTION
No reason why the have to call `.objects` to get the list of parameters and also no reason we have check all parameters.