### PR TITLE
Unpack partial in iscoroutinefunction

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -210,7 +210,8 @@ def iscoroutinefunction(function):
     """
     Whether the function is an asynchronous generator or a coroutine.
     """
-    # TODO: document why this is needed
+    # Partial unwrapping not required starting from Python 3.11.0
+    # See https://github.com/holoviz/param/pull/894#issuecomment-1867084447
     while isinstance(function, functools.partial):
         function = function.func
     return (

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -208,18 +208,15 @@ def full_groupby(l, key=lambda x: x):
 
 def iscoroutinefunction(function):
     """
-    Whether the function is an asynchronous coroutine function.
+    Whether the function is an asynchronous generator or a coroutine.
     """
-    if not hasattr(inspect, 'iscoroutinefunction'):
-        return False
-    import asyncio
-    try:
-        return (
-            inspect.isasyncgenfunction(function) or
-            asyncio.iscoroutinefunction(function)
-        )
-    except AttributeError:
-        return False
+    # TODO: document why this is needed
+    while isinstance(function, functools.partial):
+        function = function.func
+    return (
+        inspect.isasyncgenfunction(function) or
+        inspect.iscoroutinefunction(function)
+    )
 
 
 def flatten(line):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,12 +1,14 @@
 import datetime as dt
 import os
 
+from functools import partial
+
 import param
 import pytest
 
 from param import guess_param_types, resolve_path
 from param.parameterized import bothmethod
-from param._utils import _is_mutable_container
+from param._utils import _is_mutable_container, iscoroutinefunction
 
 
 try:
@@ -393,3 +395,29 @@ def test_error_prefix_set_instance():
 )
 def test__is_mutable_container(obj, ismutable):
     assert _is_mutable_container(obj) is ismutable
+
+
+async def coro():
+    return
+
+
+def test_iscoroutinefunction_coroutine():
+    assert iscoroutinefunction(coro)
+
+
+def test_iscoroutinefunction_partial_coroutine():
+    pcoro = partial(partial(coro))
+    assert iscoroutinefunction(pcoro)
+
+
+async def agen():
+    yield
+
+
+def test_iscoroutinefunction_asyncgen():
+    assert iscoroutinefunction(agen)
+
+
+def test_iscoroutinefunction_partial_asyncgen():
+    pagen = partial(partial(agen))
+    assert iscoroutinefunction(pagen)


### PR DESCRIPTION
We've observed that `inspect.iscoroutinefunction` doesn't return the same output of different versions of Python 3.10 when the function is a `functools.partial`. We make sure that param's `iscoroutinefunction` (that covers async generators too) unpacks partials before checking if they wrap a coroutine/async generator or not.

- [x] Before merging I would like to track down more precisely when things changed on CPython's side and if we see the same issue in Python 3.11 (if not, the unpacking could be removed when Python 3.10 support is dropped in some years), from memory we observed different results between CPython 3.10.5 and 3.10.13.