### PR TITLE
Make Comparator check for identity

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1710,6 +1710,8 @@ class Comparator:
 
     @classmethod
     def is_equal(cls, obj1, obj2):
+        if obj1 is obj2:
+            return True
         for eq_type, eq in cls.equalities.items():
             try:
                 are_instances = isinstance(obj1, eq_type) and isinstance(obj2, eq_type)


### PR DESCRIPTION
Seems like a crazy oversight, not all objects can be compared for equality so we should always check for identity first.