### PR TITLE
Tests: compatibility with Pandas 3.0

### DIFF
--- a/tests/testfiledeserialization.py
+++ b/tests/testfiledeserialization.py
@@ -206,8 +206,8 @@ class TestFileDeserialization(unittest.TestCase):
     @hdf5_skip
     def test_data_frame_hdf5(self):
         path = '{}/val.h5'.format(self.temp_dir)
-        P.data_frame.to_hdf(path, 'df')
+        P.data_frame.to_hdf(path, key='df')
         self._test_deserialize_array(P, path, 'data_frame')
         path = '{}/val.hdf5'.format(self.temp_dir)
-        P.data_frame.to_hdf(path, 'df')
+        P.data_frame.to_hdf(path, key='df')
         self._test_deserialize_array(P, path, 'data_frame')


### PR DESCRIPTION
Pandas 3.0 will not allow calling `to_hdf` with positional arguments (except the first one). This only affects the test suite.