### PR TITLE
Ensure that .param.update context manager restore refs

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2303,14 +2303,15 @@ class Parameters:
         """
         refs = {}
         if self_.self is not None:
-            params = ([] if arg is Undefined else list(arg)) + list(kwargs)
+            private = self_.self._param__private
+            params = list(kwargs if arg is Undefined else dict(arg, **kwargs))
             for pname in params:
                 if pname in refs:
                     continue
-                elif pname in self_.self._param__private.refs:
-                    refs[pname] = self_.self._param__private.refs[pname]
-                elif pname in self_.self._param__private.async_refs:
-                    refs[pname] = self_.self._param__private.async_refs[pname]
+                elif pname in private.refs:
+                    refs[pname] = private.refs[pname]
+                elif pname in private.async_refs:
+                    refs[pname] = private.async_refs[pname]
         restore = dict(self_._update(arg, **kwargs))
         return _ParametersRestorer(parameters=self_, restore=restore, refs=refs)
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1757,16 +1757,17 @@ class _ParametersRestorer:
     Context-manager to handle the reset of parameter values after an update.
     """
 
-    def __init__(self, *, parameters, restore):
+    def __init__(self, *, parameters, restore, refs=None):
         self._parameters = parameters
         self._restore = restore
+        self._refs = {} if refs is None else refs
 
     def __enter__(self):
         return self._restore
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         try:
-            self._parameters._update(self._restore)
+            self._parameters._update(dict(self._restore, **self._refs))
         finally:
             self._restore = {}
 
@@ -2291,7 +2292,7 @@ class Parameters:
 
     # Bothmethods
 
-    def update(self_, *args, **kwargs):
+    def update(self_, arg=Undefined, /, **kwargs):
         """
         For the given dictionary or iterable or set of param=value
         keyword arguments, sets the corresponding parameter of this
@@ -2300,22 +2301,25 @@ class Parameters:
         May also be used as a context manager to temporarily set and
         then reset parameter values.
         """
-        restore = self_._update(*args, **kwargs)
-        return _ParametersRestorer(parameters=self_, restore=restore)
+        refs = {}
+        if self_.self is not None:
+            params = ([] if arg is Undefined else list(arg)) + list(kwargs)
+            for pname in params:
+                if pname in refs:
+                    continue
+                elif pname in self_.self._param__private.refs:
+                    refs[pname] = self_.self._param__private.refs[pname]
+                elif pname in self_.self._param__private.async_refs:
+                    refs[pname] = self_.self._param__private.async_refs[pname]
+        restore = dict(self_._update(arg, **kwargs))
+        return _ParametersRestorer(parameters=self_, restore=restore, refs=refs)
 
-    def _update(self_, *args, **kwargs):
+    def _update(self_, arg=Undefined, /, **kwargs):
         BATCH_WATCH = self_._BATCH_WATCH
         self_._BATCH_WATCH = True
         self_or_cls = self_.self_or_cls
-        if args:
-            if len(args) == 1 and not kwargs:
-                kwargs = args[0]
-            else:
-                self_._BATCH_WATCH = False
-                raise ValueError(
-                    f"{self_.cls.__name__}.param.update accepts *either* an iterable "
-                    "or key=value pairs, not both."
-                )
+        if arg is not Undefined:
+            kwargs = dict(arg, **kwargs)
 
         trigger_params = [
             k for k in kwargs

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -796,26 +796,6 @@ class TestParameterized(unittest.TestCase):
 
         assert p.x == 0
 
-    def test_update_error_dict_and_kwargs_instance(self):
-        t = TestPO(inst='foo')
-        with pytest.raises(ValueError, match=re.escape("TestPO.param.update accepts *either* an iterable or key=value pairs, not both")):
-            t.param.update(dict(a=1), a=1)
-
-    def test_update_context_error_dict_and_kwargs_instance(self):
-        t = TestPO(inst='foo')
-        with pytest.raises(ValueError, match=re.escape("TestPO.param.update accepts *either* an iterable or key=value pairs, not both")):
-            with t.param.update(dict(a=1), a=1):
-                pass
-
-    def test_update_error_dict_and_kwargs_class(self):
-        with pytest.raises(ValueError, match=re.escape("TestPO.param.update accepts *either* an iterable or key=value pairs, not both")):
-            TestPO.param.update(dict(a=1), a=1)
-
-    def test_update_context_error_dict_and_kwargs_class(self):
-        with pytest.raises(ValueError, match=re.escape("TestPO.param.update accepts *either* an iterable or key=value pairs, not both")):
-            with TestPO.param.update(dict(a=1), a=1):
-                pass
-
     def test_update_context_single_parameter(self):
         t = TestPO(inst='foo')
         with t.param.update(inst='bar'):

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -796,6 +796,20 @@ class TestParameterized(unittest.TestCase):
 
         assert p.x == 0
 
+    def test_update_dict_and_kwargs_instance(self):
+        t = TestPO(inst='foo', notinst=0)
+        t.param.update(dict(notinst=1, inst='bar'), notinst=2)
+        assert t.notinst == 2
+        assert t.inst == 'bar'
+
+    def test_update_context_dict_and_kwargs_instance(self):
+        t = TestPO(inst='foo', notinst=0)
+        with t.param.update(dict(notinst=1, inst='bar'), notinst=2):
+            assert t.notinst == 2
+            assert t.inst == 'bar'
+        assert t.notinst == 0
+        assert t.inst == 'foo'
+
     def test_update_context_single_parameter(self):
         t = TestPO(inst='foo')
         with t.param.update(inst='bar'):

--- a/tests/testrefs.py
+++ b/tests/testrefs.py
@@ -85,6 +85,19 @@ def test_parameter_ref_update():
     p3.string = 'newly linked'
     assert p2.string == 'newly linked'
 
+def test_parameter_ref_update_context():
+    p = Parameters(string='linked')
+    p2 = Parameters(string=p.param.string)
+
+    assert p2.string == 'linked'
+    with p2.param.update(string='override'):
+        assert p2.string == 'override'
+        p.string = 'not yet linked'
+        assert p2.string == 'override'
+    assert p2.string == 'not yet linked'
+    p.string = 'relinked'
+    assert p2.string == 'relinked'
+
 def test_bind_ref():
     p = Parameters()
     p2 = Parameters(string=bind(lambda x: x + '!', p.param.string))


### PR DESCRIPTION
This PR does two things:

1. Ensures that `.param.update` restores the references when exiting the context
2. Allows `.param.update` to accept an argument AND kwargs, just like `dict.update`.

Fixes https://github.com/holoviz/param/issues/914