### PR TITLE
Warn with DeprecationWarnings when instantiating Parameters with extra positional arguments

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -98,7 +98,7 @@ def _deprecate_positional_args(func):
                 f"Passing '{extra_args}' as positional argument(s) to 'param.{name}' "
                 "has been deprecated since Param 2.0.0 and will raise an error in a future version, "
                 "please pass them as keyword arguments.",
-                ParamPendingDeprecationWarning,
+                ParamDeprecationWarning,
                 stacklevel=2,
             )
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -4199,13 +4199,13 @@ class Parameterized(metaclass=ParameterizedMetaclass):
 
     #PARAM3_DEPRECATION
     @property
-    @_deprecated(extra_msg="Use `inst.param.watchers` instead.", warning_cat=FutureWarning)
+    @_deprecated(extra_msg="Use `inst.param.watchers` instead.", warning_cat=_ParamFutureWarning)
     def _param_watchers(self):
         return self._param__private.watchers
 
     #PARAM3_DEPRECATION
     @_param_watchers.setter
-    @_deprecated(extra_msg="Use `inst.param.watchers = ...` instead.", warning_cat=FutureWarning)
+    @_deprecated(extra_msg="Use `inst.param.watchers = ...` instead.", warning_cat=_ParamFutureWarning)
     def _param_watchers(self, value):
         self._param__private.watchers = value
 

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -103,11 +103,11 @@ class TestDeprecateParameterizedModule:
             param.parameterized.all_equal(1, 1)
 
     def test_deprecate_param_watchers(self):
-        with pytest.raises(FutureWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.parameterized.Parameterized()._param_watchers
 
     def test_deprecate_param_watchers_setter(self):
-        with pytest.raises(FutureWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.parameterized.Parameterized()._param_watchers = {}
 
     def test_param_error_unsafe_ops_before_initialized(self):

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -22,7 +22,7 @@ def specific_filter():
 class TestDeprecateParameter:
 
     def test_deprecate_posargs_Parameter(self):
-        with pytest.raises(param._utils.ParamPendingDeprecationWarning):
+        with pytest.raises(param._utils.ParamDeprecationWarning):
             param.Parameter(1, 'doc')
 
     def test_deprecate_List_class_(self):

--- a/tests/testsignatures.py
+++ b/tests/testsignatures.py
@@ -97,17 +97,17 @@ def test_signature_position_keywords():
 def test_signature_warning_by_position():
     # Simple test as it's tricky to automatically test all the Parameters
     with pytest.warns(
-        param._utils.ParamPendingDeprecationWarning,
+        param._utils.ParamDeprecationWarning,
         match=r"Passing 'objects' as positional argument\(s\) to 'param.Selector' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments"
     ):
         param.Selector([0, 1])  # objects
     with pytest.warns(
-        param._utils.ParamPendingDeprecationWarning,
+        param._utils.ParamDeprecationWarning,
         match=r"Passing 'class_' as positional argument\(s\) to 'param.ClassSelector' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments"
     ):
         param.ClassSelector(int)  # class_
     with pytest.warns(
-        param._utils.ParamPendingDeprecationWarning,
+        param._utils.ParamDeprecationWarning,
         match=r"Passing 'bounds, softbounds' as positional argument\(s\) to 'param.Number' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments"
     ):
         param.Number(1, (0, 2), (0, 2))  # default (OK), bounds (not OK), softbounds (not OK)

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -652,7 +652,7 @@ class TestWatch(unittest.TestCase):
 
         obj.param.watch(lambda: '', ['a', 'b'])
 
-        with pytest.warns(FutureWarning):
+        with pytest.warns(param._utils.ParamFutureWarning):
             pw = obj._param_watchers
         assert isinstance(pw, dict)
         for pname in ('a', 'b'):
@@ -667,7 +667,7 @@ class TestWatch(unittest.TestCase):
 
         obj.param.watch(accumulator, ['a', 'b'])
 
-        with pytest.warns(FutureWarning):
+        with pytest.warns(param._utils.ParamFutureWarning):
             pw = obj._param_watchers
         del pw['a']
 


### PR DESCRIPTION
Bumping the warnings from `PendingDeprecationWarning` to `DeprecationWarning`.

Also, turning a `FutureWarning` to a `ParamFutureWarning` for the sake of consistency.