### PR TITLE
Add a page listing the active deprecations

### DIFF
--- a/doc/reference/deprecations.md
+++ b/doc/reference/deprecations.md
@@ -1,0 +1,36 @@
+# Deprecations
+
+- `ParamFutureWarning` since `2.0.0` - Parameterized namespace / `instance._param_watchers` (getter and setter): use instead the property `inst.param.watchers`
+- `ParamFutureWarning` since `2.0.0` - Warn on failed validation of the *default* value of a Parameter after the inheritance mechanism has completed
+- `ParamFutureWarning` since `2.0.0` - Running unsafe operations **during Parameterized instance initialization**, instead run these operations after having called `super().__init__(**params)`:
+    - `instance.param.objects(instance=True)`
+    - `instance.param.trigger("<param_name>")`
+    - `instance.param.watch(callback, "<param_name>")`
+- `ParamDeprecationWarning` since `2.0.0` - Parameter slots / `List._class`: use instead `item_type`
+- `ParamDeprecationWarning` since `2.0.0` - Parameter slots / `Number.set_hook`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.produce_value`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.as_unicode`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.is_ordered_dict`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.hashable`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.named_objs`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.normalize_path`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.abbreviate_paths`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.all_equal`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.add_metaclass`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.batch_watch`: use instead `batch_call_watchers`
+- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.recursive_repr`: no replacement
+- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.overridable_property`: no replacement
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.set_default`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param._add_parameter`: use instead `.param.add_parameter`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.params`: use instead `.param.values()` or `.param['param']`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.set_param`: use instead `.param.update`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.get_param_values`: use instead `.param.values().items()` (or `.param.values()` for the common case of `dict(....param.get_param_values())`)
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.params_depended_on`: use instead `.param.method_dependencies`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.defaults`: use instead `{k:v.default for k,v in p.param.objects().items()}`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.print_param_defaults`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.print_param_values`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.message`: use instead `.param.log(param.MESSAGE, ...)`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.verbose`: use instead `.param.log(param.VERBOSE, ...)`
+- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.debug`: use instead `.param.log(param.DEBUG, ...)`
+- `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` - Instantiating most parameters with positional arguments beyond `default` is deprecated
+- `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` - For `Selector` parameters that accept `objects` as first positional argument, and `ClassSelector` parameters that accept `class_` as first positional argument, passing any argument by position is deprecated.

--- a/doc/reference/deprecations.md
+++ b/doc/reference/deprecations.md
@@ -1,36 +1,38 @@
 # Deprecations
 
-- `ParamFutureWarning` since `2.0.0` - Parameterized namespace / `instance._param_watchers` (getter and setter): use instead the property `inst.param.watchers`
-- `ParamFutureWarning` since `2.0.0` - Warn on failed validation of the *default* value of a Parameter after the inheritance mechanism has completed
-- `ParamFutureWarning` since `2.0.0` - Running unsafe operations **during Parameterized instance initialization**, instead run these operations after having called `super().__init__(**params)`:
-    - `instance.param.objects(instance=True)`
-    - `instance.param.trigger("<param_name>")`
-    - `instance.param.watch(callback, "<param_name>")`
-- `ParamDeprecationWarning` since `2.0.0` - Parameter slots / `List._class`: use instead `item_type`
-- `ParamDeprecationWarning` since `2.0.0` - Parameter slots / `Number.set_hook`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.produce_value`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.as_unicode`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.is_ordered_dict`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.hashable`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.named_objs`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.normalize_path`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.__init__` module / `param.abbreviate_paths`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.all_equal`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.add_metaclass`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.batch_watch`: use instead `batch_call_watchers`
-- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.recursive_repr`: no replacement
-- `ParamDeprecationWarning` since `2.0.0` - `param.parameterized` module / `param.parameterized.overridable_property`: no replacement
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.set_default`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param._add_parameter`: use instead `.param.add_parameter`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.params`: use instead `.param.values()` or `.param['param']`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.set_param`: use instead `.param.update`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.get_param_values`: use instead `.param.values().items()` (or `.param.values()` for the common case of `dict(....param.get_param_values())`)
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.params_depended_on`: use instead `.param.method_dependencies`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.defaults`: use instead `{k:v.default for k,v in p.param.objects().items()}`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.print_param_defaults`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.print_param_values`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.message`: use instead `.param.log(param.MESSAGE, ...)`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.verbose`: use instead `.param.log(param.VERBOSE, ...)`
-- `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` - Parameterized `.param` namespace / `.param.debug`: use instead `.param.log(param.DEBUG, ...)`
-- `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` - Instantiating most parameters with positional arguments beyond `default` is deprecated
-- `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` - For `Selector` parameters that accept `objects` as first positional argument, and `ClassSelector` parameters that accept `class_` as first positional argument, passing any argument by position is deprecated.
+
+| Warning | Description |
+|-|-|
+| `ParamFutureWarning` since `2.0.0` | Parameterized namespace / `instance._param_watchers` (getter and setter): use instead the property `inst.param.watchers` |
+| `ParamFutureWarning` since `2.0.0` | Warn on failed validation of the *default* value of a Parameter after the inheritance mechanism has completed |
+| `ParamFutureWarning` since `2.0.0` | Running unsafe `instance.param.objects(instance=True)` during Parameterized instance initialization, instead run it after having called `super().__init__(**params)` |
+| `ParamFutureWarning` since `2.0.0` | Running unsafe `instance.param.objects(instance=True)` during Parameterized instance initialization, instead run it after having called `super().__init__(**params)` |
+| `ParamFutureWarning` since `2.0.0` | Running unsafe `instance.param.watch(callback, "<param_name>")` during Parameterized instance initialization, instead run it after having called `super().__init__(**params)` |
+| `ParamDeprecationWarning` since `2.0.0` | Parameter slots / `List._class`: use instead `item_type` |
+| `ParamDeprecationWarning` since `2.0.0` | Parameter slots / `Number.set_hook`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.produce_value`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.as_unicode`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.is_ordered_dict`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.hashable`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.named_objs`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.normalize_path`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.abbreviate_paths`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.all_equal`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.add_metaclass`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.batch_watch`: use instead `batch_call_watchers` |
+| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.recursive_repr`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.overridable_property`: no replacement |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.set_default`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param._add_parameter`: use instead `.param.add_parameter` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.params`: use instead `.param.values()` or `.param['param']` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.set_param`: use instead `.param.update` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.get_param_values`: use instead `.param.values().items()` (or `.param.values()` for the common case of `dict(....param.get_param_values())`) |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.params_depended_on`: use instead `.param.method_dependencies` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.defaults`: use instead `{k:v.default for k,v in p.param.objects().items()}` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.print_param_defaults`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.print_param_values`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.message`: use instead `.param.log(param.MESSAGE, ...)` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.verbose`: use instead `.param.log(param.VERBOSE, ...)` |
+| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.debug`: use instead `.param.log(param.DEBUG, ...)` |
+| `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` | Instantiating most parameters with positional arguments beyond `default` is deprecated |
+| `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` | For `Selector` parameters that accept `objects` as first positional argument, and `ClassSelector` parameters that accept `class_` as first positional argument, passing any argument by position is deprecated. |

--- a/doc/reference/index.md
+++ b/doc/reference/index.md
@@ -10,4 +10,5 @@ maxdepth: 2
 ---
 Param <param/index>
 Numbergen <numbergen>
+Deprecations <deprecations>
 ```


### PR DESCRIPTION
Experimenting with adding this page, as I've been working on [HEP 2](https://github.com/holoviz/holoviz/pull/388) and think that it'd help maintainers (users too in fact!) if such a page existed and was maintained over time.

![image](https://github.com/holoviz/param/assets/35924738/3059ae79-fdbc-45e5-9030-935aec1448cf)

For example, I bumped a couple of warnings in https://github.com/holoviz/param/pull/921 and updated the page accordingly.

![image](https://github.com/holoviz/param/assets/35924738/80486e4a-0b4e-4785-8385-56a4a48bf8fe)
