### PR TITLE
Add support for async and generator functions in rx.pipe

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -258,8 +258,12 @@ class reactive_ops:
         kwargs: mapping, optional
           A dictionary of keywords to pass to `func`.
         """
-        def apply(vs, *args, **kwargs):
-            return [func(v, *args, **kwargs) for v in vs]
+        if inspect.iscoroutinefunction(func):
+            async def apply(vs, *args, **kwargs):
+                return list(await asyncio.gather(*(func(v, *args, **kwargs) for v in vs)))
+        else:
+            def apply(vs, *args, **kwargs):
+                return [func(v, *args, **kwargs) for v in vs]
         return self._as_rx()._apply_operator(apply, *args, **kwargs)
 
     def not_(self):

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -258,6 +258,11 @@ class reactive_ops:
         kwargs: mapping, optional
           A dictionary of keywords to pass to `func`.
         """
+        if inspect.isasyncgenfunction(func) or inspect.isgeneratorfunction(func):
+            raise TypeError(
+                "Cannot map a generator function. Only regular function "
+                "or coroutine functions are permitted."
+            )
         if inspect.iscoroutinefunction(func):
             async def apply(vs, *args, **kwargs):
                 return list(await asyncio.gather(*(func(v, *args, **kwargs) for v in vs)))

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -551,7 +551,6 @@ async def test_reactive_async_func():
 
 async def test_reactive_pipe_async_func():
     async def async_func(value):
-        print(value)
         await asyncio.sleep(0.02)
         return value+2
 

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -588,7 +588,7 @@ async def test_reactive_gen_pipe():
     assert rxgen.rx.value is param.Undefined
     await asyncio.sleep(0.04)
     assert rxgen.rx.value == 1
-    await asyncio.sleep(0.07)
+    await asyncio.sleep(0.1)
     assert rxgen.rx.value == 2
     rxv.rx.value = 2
     await asyncio.sleep(0.03)
@@ -630,10 +630,10 @@ async def test_reactive_gen_pipe_with_dep():
     irx.rx.value = 3
     await asyncio.sleep(0.04)
     assert rxgen.rx.value == 4
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.1)
     assert rxgen.rx.value == 5
     rxv.rx.value = 5
-    await asyncio.sleep(0.03)
+    await asyncio.sleep(0.04)
     assert rxgen.rx.value == 9
 
 async def test_reactive_async_gen():

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -584,19 +584,14 @@ async def test_reactive_gen_pipe():
 
     rxv = rx(0)
     rxgen = rxv.rx.pipe(gen)
+    rxgen.rx.watch()
     assert rxgen.rx.value is param.Undefined
     await asyncio.sleep(0.04)
     assert rxgen.rx.value == 1
-    for _ in range(3):
-        await asyncio.sleep(0.05)
-        if rxgen.rx.value == 2:
-            break
+    await asyncio.sleep(0.07)
     assert rxgen.rx.value == 2
     rxv.rx.value = 2
-    for _ in range(3):
-        await asyncio.sleep(0.05)
-        if rxgen.rx.value == 3:
-            break
+    await asyncio.sleep(0.03)
     assert rxgen.rx.value == 3
 
 async def test_reactive_gen_with_dep():
@@ -635,10 +630,7 @@ async def test_reactive_gen_pipe_with_dep():
     irx.rx.value = 3
     await asyncio.sleep(0.04)
     assert rxgen.rx.value == 4
-    for _ in range(3):
-        await asyncio.sleep(0.05)
-        if rxgen.rx.value == 5:
-            break
+    await asyncio.sleep(0.05)
     assert rxgen.rx.value == 5
     rxv.rx.value = 5
     await asyncio.sleep(0.03)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -307,6 +307,20 @@ def test_reactive_map():
     i.rx.value = range(1, 4)
     assert b.rx.value == [2, 4, 6]
 
+async def test_reactive_async_map():
+    i = rx(range(3))
+    async def mul(x):
+        await asyncio.sleep(0.05)
+        return x*2
+    b = i.rx.map(mul)
+    assert b.rx.value is param.Undefined
+    await asyncio.sleep(0.1)
+    assert b.rx.value == [0, 2, 4]
+    i.rx.value = range(1, 4)
+    assert b.rx.value == [0, 2, 4]
+    await asyncio.sleep(0.1)
+    assert b.rx.value == [2, 4, 6]
+
 def test_reactive_map_args():
     i = rx(range(3))
     j = rx(2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import time
 
 from contextlib import contextmanager
 
@@ -111,3 +113,64 @@ def warnings_as_excepts(match=None):
             raise ValueError(f'Exception emitted {str(e)!r} does not contain {match!r}')
     finally:
         param.parameterized.warnings_as_exceptions = orig
+
+
+async def async_wait_until(fn, timeout=5000, interval=100):
+    """
+    Exercise a test function in a loop until it evaluates to True
+    or times out.
+
+    The function can either be a simple lambda that returns True or False:
+    >>> await async_wait_until(lambda: x.values() == ['x'])
+
+    Or a defined function with an assert:
+    >>> async def _()
+    >>>    assert x.values() == ['x']
+    >>> await async_wait_until(_)
+
+    Parameters
+    ----------
+    fn : callable
+        Callback
+    timeout : int, optional
+        Total timeout in milliseconds, by default 5000
+    interval : int, optional
+        Waiting interval, by default 100
+
+    Adapted from pytest-qt.
+    """
+    # Hide this function traceback from the pytest output if the test fails
+    __tracebackhide__ = True
+
+    start = time.monotonic()
+
+    def timed_out():
+        elapsed = time.monotonic() - start
+        elapsed_ms = elapsed * 1000
+        return elapsed_ms > timeout
+
+    timeout_msg = f"async_wait_until timed out in {timeout} milliseconds"
+
+    while True:
+        try:
+            result = fn()
+            if asyncio.iscoroutine(result):
+                result = await result
+        except AssertionError as e:
+            if timed_out():
+                raise TimeoutError(timeout_msg) from e
+        else:
+            if result not in (None, True, False):
+                raise ValueError(
+                    "`async_wait_until` callback must return None, True, or "
+                    f"False, returned {result!r}"
+                )
+            # None is returned when the function has an assert
+            if result is None:
+                return
+            # When the function returns True or False
+            if result:
+                return
+            if timed_out():
+                raise TimeoutError(timeout_msg)
+        await asyncio.sleep(interval / 1000)


### PR DESCRIPTION
We already support using asynchronous and generator functions as inputs to a reactive expression but until now we did not handle them when you use them as an input to an operation that is performed on the data. This meant that `.rx.pipe` and `.rx.map` would simply return the coroutine or generator as the value instead of evaluating it lazily.

Here we add support for these by scheduling the task on the event loop and then triggering an event when the function evaluates. Internally this is achieved by creating a `Trigger` which is added as one of the dependencies of the reactive expression such as that any consumer of the expression (whether Panel, the display hook or anything else) is notified when the async function or generator yields a new value.

In testing this I also found an oversight which meant that if you used a bound function as the input to `.rx.pipe` it would not extract its dependencies.