### PR TITLE
Recursively resolve references on args and kwargs passed to an reactive operation

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -196,11 +196,11 @@ def resolve_ref(reference, recursive=False):
     """
     if recursive:
         if isinstance(reference, (list, tuple, set)):
-            return [r for v in reference for r in resolve_ref(v)]
+            return [r for v in reference for r in resolve_ref(v, recursive)]
         elif isinstance(reference, dict):
-            return [r for kv in reference.items() for o in kv for r in resolve_ref(o)]
+            return [r for kv in reference.items() for o in kv for r in resolve_ref(o, recursive)]
         elif isinstance(reference, slice):
-            return [r for v in (reference.start, reference.stop, reference.step) for r in resolve_ref(v)]
+            return [r for v in (reference.start, reference.stop, reference.step) for r in resolve_ref(v, recursive)]
     reference = transform_reference(reference)
     if hasattr(reference, '_dinfo'):
         dinfo = getattr(reference, '_dinfo', {})

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -833,7 +833,7 @@ class rx:
             if ref not in ps:
                 ps.append(ref)
         for arg in list(self._operation['args'])+list(self._operation['kwargs'].values()):
-            for ref in resolve_ref(arg):
+            for ref in resolve_ref(arg, recursive=True):
                 if ref not in ps:
                     ps.append(ref)
 

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -125,6 +125,26 @@ def test_reactive_getitem_list():
     assert rx([1, 2, 3])[1].rx.value == 2
     assert rx([1, 2, 3])[2].rx.value == 3
 
+def test_reactive_getitem_list_with_slice():
+    i = rx(1)
+    j = rx(5)
+    lst = list(range(10))
+    lstx = rx(lst)
+    sx = lstx[i: j]
+    assert sx.rx.value == lst[i.rx.value: j.rx.value]
+    i.rx.value = 2
+    assert sx.rx.value == lst[i.rx.value: j.rx.value]
+
+def test_reactive_getitem_numpy_with_tuple():
+    i = rx(0)
+    j = rx(1)
+    arr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    arrx = rx(arr)
+    selx = arrx[i, j]
+    assert selx.rx.value == arr[i.rx.value, j.rx.value]
+    i.rx.value = 1
+    assert selx.rx.value == arr[i.rx.value, j.rx.value]
+
 @pytest.mark.parametrize('ufunc', NUMPY_UFUNCS)
 def test_numpy_ufunc(ufunc):
     l = [1, 2, 3]


### PR DESCRIPTION
Attempts to fix https://github.com/holoviz/param/issues/940

Which can be reproduced with:

```python
import param

start = param.rx(1)
end = param.rx(10)
l = list(range(20))
lrx = param.rx(l)
sx = lrx[start:end]
print(sx.rx.value)  # required to reproduce
start.rx.value = 4
print(sx.rx.value)  # [1, 2, ...], not [4, 5, ...] ! 
```

I think that the reactive expressions of the `start:end` *slice* passed to `__getitem__` were not resolved, which means that no watcher was set to invalidate the expression when `start` is updated. Resolving references recursively fixed the issue and broke no other test, but well, it might be a big hammer 🤔 Anyhow, I've also added another similar test that would have failed without this change, this time with a *tuple* containing reactive expressions passed to Numpy's `__getitem__`.