### PR TITLE
Ensure rx._callback resolves accessors

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -211,7 +211,7 @@ class reactive_ops:
 
     def buffer(self, n):
         """
-        Collects the last n items that were emmitted.
+        Collects the last n items that were emitted.
         """
         items = []
         def collect(new, n):
@@ -954,7 +954,10 @@ class rx:
     def _callback(self):
         params = self._params
         def evaluate(*args, **kwargs):
-            return self._transform_output(self._current)
+            out = self._current
+            if self._method:
+                out = getattr(out, self._method)
+            return self._transform_output(out)
         if params:
             return bind(evaluate, *params)
         return evaluate

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -761,3 +761,9 @@ def test_ensure_ref_can_update_by_watcher_of_same_parameter():
     t.lst = list("ABCDE")
     t.items[1].value = "TEST"
     assert t.lst[1] == "TEST"
+
+def test_reactive_callback_resolve_accessor():
+    df = pd.DataFrame({"name": ["Bill", "Bob"]})
+    dfx = rx(df)
+    out = dfx["name"].str._callback()
+    assert out is df["name"].str


### PR DESCRIPTION
Previously accessors weren't resolved correctly.