### PR TITLE
pass references along in `ParameterizedFunction.instance`

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -4450,7 +4450,7 @@ class ParameterizedFunction(Parameterized):
             cls = self_or_cls
         else:
             p = params
-            params = self_or_cls.param.values()
+            params = self_or_cls.param.objects()
             params.update(p)
             params.pop('name')
             cls = self_or_cls.__class__


### PR DESCRIPTION
Previously, only all of the values at the current point in time are copied. Unfortunately, this doesn't copy over references. It would be nice to copy those over too.
