### PR TITLE
Annotate depends and accept_arguments decorators

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -1,22 +1,28 @@
+from __future__ import annotations
+
 import asyncio
 import collections
 import contextvars
 import datetime as dt
-import inspect
 import functools
+import inspect
 import numbers
 import os
 import re
 import sys
 import traceback
 import warnings
-
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, abc, defaultdict
 from contextlib import contextmanager
 from numbers import Real
 from textwrap import dedent
 from threading import get_ident
-from collections import abc
+from typing import TYPE_CHECKING, Callable, Concatenate, ParamSpec, TypeVar
+
+if TYPE_CHECKING:
+    _P = ParamSpec("_P")
+    _R = TypeVar("_R")
+    CallableT = TypeVar("CallableT", bound=Callable)
 
 DEFAULT_SIGNATURE = inspect.Signature([
     inspect.Parameter('self', inspect.Parameter.POSITIONAL_OR_KEYWORD),
@@ -282,12 +288,14 @@ def flatten(line):
             yield element
 
 
-def accept_arguments(f):
+def accept_arguments(
+    f: Callable[Concatenate[CallableT, _P], _R]
+) -> Callable[_P, Callable[[CallableT], _R]]:
     """
     Decorator for decorators that accept arguments
     """
     @functools.wraps(f)
-    def _f(*args, **kwargs):
+    def _f(*args: _P.args, **kwargs: _P.kwargs) -> Callable[[CallableT], _R]:
         return lambda actual_f: f(actual_f, *args, **kwargs)
     return _f
 

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -22,8 +22,8 @@ from typing import TYPE_CHECKING, Callable, TypeVar
 if TYPE_CHECKING:
     from typing_extensions import Concatenate, ParamSpec
 
-    _P = ParamSpec("_P")
-    _R = TypeVar("_R")
+    P = ParamSpec("P")
+    R = TypeVar("R")
     CallableT = TypeVar("CallableT", bound=Callable)
 
 DEFAULT_SIGNATURE = inspect.Signature([
@@ -291,13 +291,13 @@ def flatten(line):
 
 
 def accept_arguments(
-    f: Callable[Concatenate[CallableT, _P], _R]
-) -> Callable[_P, Callable[[CallableT], _R]]:
+    f: Callable[Concatenate[CallableT, P], R]
+) -> Callable[P, Callable[[CallableT], R]]:
     """
     Decorator for decorators that accept arguments
     """
     @functools.wraps(f)
-    def _f(*args: _P.args, **kwargs: _P.kwargs) -> Callable[[CallableT], _R]:
+    def _f(*args: P.args, **kwargs: P.kwargs) -> Callable[[CallableT], R]:
         return lambda actual_f: f(actual_f, *args, **kwargs)
     return _f
 

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -17,9 +17,11 @@ from contextlib import contextmanager
 from numbers import Real
 from textwrap import dedent
 from threading import get_ident
-from typing import TYPE_CHECKING, Callable, Concatenate, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 if TYPE_CHECKING:
+    from typing_extensions import Concatenate, ParamSpec
+
     _P = ParamSpec("_P")
     _R = TypeVar("_R")
     CallableT = TypeVar("CallableT", bound=Callable)


### PR DESCRIPTION
It took some tinkering but I finally have this working. Addresses https://github.com/holoviz/param/issues/958

@MarcSkovMadsen @philippjfr 

Results:

```
>> mypy param/_utils.py --follow-imports=silent
Success: no issues found in 1 source file
```

```
>> mypy param/depends.py --follow-imports=silent
param/depends.py:142: error: Item "str" of "Parameter | str" has no attribute "owner"  [union-attr]
param/depends.py:144: error: Item "str" of "Parameter | str" has no attribute "owner"  [union-attr]
param/depends.py:144: error: Item "str" of "Parameter | str" has no attribute "name"  [union-attr]
```