### PR TITLE
refactor: Don’t directly import numpy and add `gen_types` decorator

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -620,7 +620,10 @@ class _GeneratorIsMeta(type):
     def __subclasscheck__(cls, sub):
         return issubclass(sub, tuple(cls.types()))
 
-class _GeneratorIs(metaclass=_GeneratorIsMeta): ...
+class _GeneratorIs(metaclass=_GeneratorIsMeta):
+    @classmethod
+    def __iter__(cls):
+        yield from cls.types()
 
 def gen_types(gen_func):
     """Decorator that creates a type using _GeneratorIsMeta with a specified gen_types function."""

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -616,11 +616,11 @@ def async_executor(func):
 
 def anyinstance(obj, class_tuple_generator):
     if inspect.isgeneratorfunction(class_tuple_generator):
-        return any(isinstance(obj, i) for i in class_tuple_generator())
+        class_tuple_generator = tuple(class_tuple_generator())
     return isinstance(obj, class_tuple_generator)
 
 
 def anysubclass(obj, class_tuple_generator):
     if inspect.isgeneratorfunction(class_tuple_generator):
-        return any(issubclass(obj, i) for i in class_tuple_generator())
+        class_tuple_generator = tuple(class_tuple_generator())
     return issubclass(obj, class_tuple_generator)

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -612,3 +612,15 @@ def async_executor(func):
         task.add_done_callback(_running_tasks.discard)
     else:
         event_loop.run_until_complete(func())
+
+
+def anyinstance(obj, class_tuple_generator):
+    if inspect.isgeneratorfunction(class_tuple_generator):
+        return any(isinstance(obj, i) for i in class_tuple_generator())
+    return isinstance(obj, class_tuple_generator)
+
+
+def anysubclass(obj, class_tuple_generator):
+    if inspect.isgeneratorfunction(class_tuple_generator):
+        return any(issubclass(obj, i) for i in class_tuple_generator())
+    return issubclass(obj, class_tuple_generator)

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -612,3 +612,19 @@ def async_executor(func):
         task.add_done_callback(_running_tasks.discard)
     else:
         event_loop.run_until_complete(func())
+
+class _GeneratorIsMeta(type):
+    def __instancecheck__(cls, inst):
+        return isinstance(inst, tuple(cls.types()))
+
+    def __subclasscheck__(cls, sub):
+        return issubclass(sub, tuple(cls.types()))
+
+class _GeneratorIs(metaclass=_GeneratorIsMeta): ...
+
+def gen_types(gen_func):
+    """Decorator that creates a type using _GeneratorIsMeta with a specified gen_types function."""
+    if not inspect.isgeneratorfunction(gen_func):
+        msg = "gen_types decorator can only be applied to generator"
+        raise TypeError(msg)
+    return type(gen_func.__name__, (_GeneratorIs,), {"types": staticmethod(gen_func)})

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -612,15 +612,3 @@ def async_executor(func):
         task.add_done_callback(_running_tasks.discard)
     else:
         event_loop.run_until_complete(func())
-
-
-def anyinstance(obj, class_tuple_generator):
-    if inspect.isgeneratorfunction(class_tuple_generator):
-        class_tuple_generator = tuple(class_tuple_generator())
-    return isinstance(obj, class_tuple_generator)
-
-
-def anysubclass(obj, class_tuple_generator):
-    if inspect.isgeneratorfunction(class_tuple_generator):
-        class_tuple_generator = tuple(class_tuple_generator())
-    return issubclass(obj, class_tuple_generator)

--- a/param/_utils.py
+++ b/param/_utils.py
@@ -620,13 +620,18 @@ class _GeneratorIsMeta(type):
     def __subclasscheck__(cls, sub):
         return issubclass(sub, tuple(cls.types()))
 
+    def __iter__(cls):
+        yield from cls.types()
+
 class _GeneratorIs(metaclass=_GeneratorIsMeta):
     @classmethod
     def __iter__(cls):
         yield from cls.types()
 
 def gen_types(gen_func):
-    """Decorator that creates a type using _GeneratorIsMeta with a specified gen_types function."""
+    """
+    Decorator which takes a generator function which yields difference types
+    make it so it can be called with isinstance and issubclass."""
     if not inspect.isgeneratorfunction(gen_func):
         msg = "gen_types decorator can only be applied to generator"
         raise TypeError(msg)

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -18,6 +18,7 @@ import numbers
 import operator
 import random
 import re
+import sys
 import types
 import typing
 import warnings
@@ -74,15 +75,18 @@ else:
 
 from inspect import getfullargspec
 
-dt_types = (dt.datetime, dt.date)
-_int_types = (int,)
+def _dt_types():
+    yield dt.datetime
+    yield dt.date
+    if "numpy" in sys.modules:
+        import numpy as np
+        yield np.datetime64
 
-try:
-    import numpy as np
-    dt_types = dt_types + (np.datetime64,)
-    _int_types = _int_types + (np.integer,)
-except:
-    pass
+def _int_types():
+    yield int
+    if "numpy" in sys.modules:
+        import numpy as np
+        yield np.integer
 
 VERBOSE = INFO - 1
 logging.addLevelName(VERBOSE, "VERBOSE")
@@ -1714,7 +1718,7 @@ class Comparator:
         type(None): operator.eq,
         lambda o: hasattr(o, '_infinitely_iterable'): operator.eq,  # Time
     }
-    equalities.update({dtt: operator.eq for dtt in dt_types})
+    # equalities.update({dtt: operator.eq for dtt in _dt_types})
 
     @classmethod
     def is_equal(cls, obj1, obj2):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3852,7 +3852,7 @@ def container_script_repr(container,imports,prefix,settings):
 
 
 def _np_random():
-    if "numpy" in sys.modules:
+    if "numpy.random" in sys.modules:
         import numpy as np
         return np.random.RandomState
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3815,7 +3815,7 @@ def pprint(val,imports=None, prefix="\n    ", settings=[],
     elif type(val) in script_repr_reg:
         rep = script_repr_reg[type(val)](val,imports,prefix,settings)
 
-    elif type(val) in (_np_random(), _py_random()):
+    elif isinstance(val, _no_script_repr):
         rep = None
 
     elif isinstance(val, Parameterized) or (type(val) is type and issubclass(val, Parameterized)):
@@ -3852,16 +3852,13 @@ def container_script_repr(container,imports,prefix,settings):
     return rep
 
 
-def _np_random():
-    if "numpy.random" in sys.modules:
-        import numpy as np
-        return np.random.RandomState
-
-
-def _py_random():
-    if "random" in sys.modules:
-        import random
-        return random.Random
+@gen_types
+def _no_script_repr():
+    # Suppress scriptrepr for objects not yet having a useful string representation
+    if random := sys.modules.get("random"):
+        yield random.Random
+    if npr := sys.modules.get("numpy.random"):
+        yield npr.RandomState
 
 
 def function_script_repr(fn,imports,prefix,settings):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -78,15 +78,13 @@ else:
 def _dt_types():
     yield dt.datetime
     yield dt.date
-    if "numpy" in sys.modules:
-        import numpy as np
+    if np := sys.modules.get("numpy"):
         yield np.datetime64
 
 @gen_types
 def _int_types():
     yield int
-    if "numpy" in sys.modules:
-        import numpy as np
+    if np := sys.modules.get("numpy"):
         yield np.integer
 
 VERBOSE = INFO - 1

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -16,7 +16,6 @@ import inspect
 import logging
 import numbers
 import operator
-import random
 import re
 import sys
 import types
@@ -3815,6 +3814,9 @@ def pprint(val,imports=None, prefix="\n    ", settings=[],
     elif type(val) in script_repr_reg:
         rep = script_repr_reg[type(val)](val,imports,prefix,settings)
 
+    elif type(val) in (_np_random(), _py_random()):
+        rep = None
+
     elif isinstance(val, Parameterized) or (type(val) is type and issubclass(val, Parameterized)):
         rep=val.param.pprint(imports=imports, prefix=prefix+"    ",
                         qualify=qualify, unknown_value=unknown_value,
@@ -3849,17 +3851,16 @@ def container_script_repr(container,imports,prefix,settings):
     return rep
 
 
-def empty_script_repr(*args): # pyflakes:ignore (unused arguments):
-    return None
+def _np_random():
+    if "numpy" in sys.modules:
+        import numpy as np
+        return np.random.RandomState
 
-try:
-    # Suppress scriptrepr for objects not yet having a useful string representation
-    import numpy
-    script_repr_reg[random.Random] = empty_script_repr
-    script_repr_reg[numpy.random.RandomState] = empty_script_repr
 
-except ImportError:
-    pass # Support added only if those libraries are available
+def _py_random():
+    if "random" in sys.modules:
+        import random
+        return random.Random
 
 
 def function_script_repr(fn,imports,prefix,settings):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1718,11 +1718,18 @@ class Comparator:
         type(None): operator.eq,
         lambda o: hasattr(o, '_infinitely_iterable'): operator.eq,  # Time
     }
-    # equalities.update({dtt: operator.eq for dtt in _dt_types})
+    gen_equalities = {
+        _dt_types: operator.eq
+    }
 
     @classmethod
     def is_equal(cls, obj1, obj2):
-        for eq_type, eq in cls.equalities.items():
+        equals = cls.equalities.copy()
+        for gen, op in cls.gen_equalities.items():
+            for t in gen():
+                equals[t] = op
+
+        for eq_type, eq in equals.items():
             try:
                 are_instances = isinstance(obj1, eq_type) and isinstance(obj2, eq_type)
             except TypeError:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -21,6 +21,7 @@ import sys
 import types
 import typing
 import warnings
+from inspect import getfullargspec
 
 # Allow this file to be used standalone if desired, albeit without JSON serialization
 try:
@@ -55,6 +56,7 @@ from ._utils import (
     accept_arguments,
     iscoroutinefunction,
     descendents,
+    gen_types,
 )
 
 # Ideally setting param_pager would be in __init__.py but param_pager is
@@ -72,8 +74,7 @@ else:
     param_pager = None
 
 
-from inspect import getfullargspec
-
+@gen_types
 def _dt_types():
     yield dt.datetime
     yield dt.date
@@ -81,6 +82,7 @@ def _dt_types():
         import numpy as np
         yield np.datetime64
 
+@gen_types
 def _int_types():
     yield int
     if "numpy" in sys.modules:

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -111,7 +111,7 @@ def guess_param_types(**kwargs):
         elif isinstance(v, tuple):
             if all(_is_number(el) for el in v):
                 params[k] = NumericTuple(**kws)
-            elif all(anyinstance(el, _dt_types) for el in v) and len(v)==2:
+            elif len(v) == 2 and all(anyinstance(el, _dt_types) for el in v):
                 params[k] = DateRange(**kws)
             else:
                 params[k] = Tuple(**kws)

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -51,8 +51,6 @@ from ._utils import (
     concrete_descendents,
     _abbreviate_paths,
     _to_datetime,
-    anyinstance,
-    anysubclass,
 )
 
 #-----------------------------------------------------------------------------
@@ -96,7 +94,7 @@ def guess_param_types(**kwargs):
         kws = dict(default=v, constant=True)
         if isinstance(v, Parameter):
             params[k] = v
-        elif anyinstance(v, _dt_types):
+        elif isinstance(v, _dt_types):
             params[k] = Date(**kws)
         elif isinstance(v, bool):
             params[k] = Boolean(**kws)
@@ -111,7 +109,7 @@ def guess_param_types(**kwargs):
         elif isinstance(v, tuple):
             if all(_is_number(el) for el in v):
                 params[k] = NumericTuple(**kws)
-            elif len(v) == 2 and all(anyinstance(el, _dt_types) for el in v):
+            elif len(v) == 2 and all(isinstance(el, _dt_types) for el in v):
                 params[k] = DateRange(**kws)
             else:
                 params[k] = Tuple(**kws)
@@ -854,7 +852,7 @@ class Integer(Number):
         if allow_None and val is None:
             return
 
-        if not anyinstance(val, _int_types):
+        if not isinstance(val, _int_types):
             raise ValueError(
                 f"{_validate_error_prefix(self)} must be an integer, "
                 f"not {type(val)}."
@@ -919,14 +917,14 @@ class Date(Number):
         if self.allow_None and val is None:
             return
 
-        if not anyinstance(val, _dt_types) and not (allow_None and val is None):
+        if not isinstance(val, _dt_types) and not (allow_None and val is None):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes datetime and "
                 f"date types, not {type(val)}."
             )
 
     def _validate_step(self, val, step):
-        if step is not None and not anyinstance(step, _dt_types):
+        if step is not None and not isinstance(step, _dt_types):
             raise ValueError(
                 f"{_validate_error_prefix(self, 'step')} can only be None, "
                 f"a datetime or date type, not {type(step)}."
@@ -1357,7 +1355,7 @@ class DateRange(Range):
     """
 
     def _validate_bound_type(self, value, position, kind):
-        if not anyinstance(value, _dt_types):
+        if not isinstance(value, _dt_types):
             raise ValueError(
                 f"{_validate_error_prefix(self)} {position} {kind} can only be "
                 f"None or a date/datetime value, not {type(value)}."
@@ -1381,7 +1379,7 @@ class DateRange(Range):
                 f"not {type(val)}."
             )
         for n in val:
-            if anyinstance(n, _dt_types):
+            if isinstance(n, _dt_types):
                 continue
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes date/datetime "
@@ -2186,7 +2184,7 @@ class ClassSelector(SelectorBase):
     def _validate_class_(self, val, class_, is_instance):
         if (val is None and self.allow_None):
             return
-        if (is_instance and anyinstance(val, class_)) or (not is_instance and anysubclass(val, class_)):
+        if (is_instance and isinstance(val, class_)) or (not is_instance and issubclass(val, class_)):
             return
 
         if isinstance(class_, tuple):
@@ -2563,7 +2561,7 @@ class List(Parameter):
         if item_type is None or (self.allow_None and val is None):
             return
         for v in val:
-            if anyinstance(v, item_type):
+            if isinstance(v, item_type):
                 continue
             raise TypeError(
                 f"{_validate_error_prefix(self)} items must be instances "

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2186,7 +2186,7 @@ class ClassSelector(SelectorBase):
     def _validate_class_(self, val, class_, is_instance):
         if (val is None and self.allow_None):
             return
-        if (is_instance and anyinstance(val, class_)) or anysubclass(val, class_):
+        if (is_instance and anyinstance(val, class_)) or (not is_instance and anysubclass(val, class_)):
             return
 
         if isinstance(class_, tuple):

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2198,7 +2198,7 @@ class ClassSelector(SelectorBase):
 
         raise ValueError(
             f"{_validate_error_prefix(self)} value must be "
-            f"{'an instance' if is_instance else 'a subclass'} of {class_name}, not {val}."
+            f"{'an instance' if is_instance else 'a subclass'} of {class_name}, not {val!r}."
         )
 
     def get_range(self):

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -143,7 +143,7 @@ def parameterized_class(name, params, bases=Parameterized):
     Dynamically create a parameterized class with the given name and the
     supplied parameters, inheriting from the specified base(s).
     """
-    if not (isinstance(bases, list) or isinstance(bases, tuple)):
+    if not isinstance(bases, (list, tuple)):
         bases=[bases]
     return type(name, tuple(bases), params)
 

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2186,18 +2186,20 @@ class ClassSelector(SelectorBase):
     def _validate_class_(self, val, class_, is_instance):
         if (val is None and self.allow_None):
             return
+        if (is_instance and anyinstance(val, class_)) or anysubclass(val, class_):
+            return
+
         if isinstance(class_, tuple):
-            class_name = ('(%s)' % ', '.join(cl.__name__ for cl in class_))
+            class_name = ('({})'.format(', '.join(cl.__name__ for cl in class_)))
+        elif inspect.isgenerator(class_):
+            class_name = ('({})'.format(', '.join(cl.__name__ for cl in class_())))
         else:
             class_name = class_.__name__
-        if is_instance:
-            if not anyinstance(val, class_):
-                raise ValueError(
-                    f"{_validate_error_prefix(self)} value must be an instance of {class_name}, not {val!r}.")
-        else:
-            if not anysubclass(val, class_):
-                raise ValueError(
-                    f"{_validate_error_prefix(self)} value must be a subclass of {class_name}, not {val}.")
+
+        raise ValueError(
+            f"{_validate_error_prefix(self)} value must be a "
+            f"{'instance' if is_instance else 'subclass'} of {class_name}, not {val}."
+        )
 
     def get_range(self):
         """

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2563,7 +2563,7 @@ class List(Parameter):
         if item_type is None or (self.allow_None and val is None):
             return
         for v in val:
-            if isinstance(v, item_type):
+            if anyinstance(v, item_type):
                 continue
             raise TypeError(
                 f"{_validate_error_prefix(self)} items must be instances "

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -30,6 +30,7 @@ import typing
 import warnings
 
 from collections import OrderedDict
+from collections.abc import Iterable
 from contextlib import contextmanager
 
 from .parameterized import (
@@ -2187,10 +2188,8 @@ class ClassSelector(SelectorBase):
         if (is_instance and isinstance(val, class_)) or (not is_instance and issubclass(val, class_)):
             return
 
-        if isinstance(class_, tuple):
+        if isinstance(class_, Iterable):
             class_name = ('({})'.format(', '.join(cl.__name__ for cl in class_)))
-        elif inspect.isgenerator(class_):
-            class_name = ('({})'.format(', '.join(cl.__name__ for cl in class_())))
         else:
             class_name = class_.__name__
 

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2197,8 +2197,8 @@ class ClassSelector(SelectorBase):
             class_name = class_.__name__
 
         raise ValueError(
-            f"{_validate_error_prefix(self)} value must be a "
-            f"{'instance' if is_instance else 'subclass'} of {class_name}, not {val}."
+            f"{_validate_error_prefix(self)} value must be "
+            f"{'an instance' if is_instance else 'a subclass'} of {class_name}, not {val}."
         )
 
     def get_range(self):

--- a/tests/testimports.py
+++ b/tests/testimports.py
@@ -1,0 +1,20 @@
+import sys
+from subprocess import check_output
+from textwrap import dedent
+
+
+def test_no_blocklist_imports():
+    check = """\
+    import sys
+    import param
+
+    blocklist = {"numpy", "IPython", "pandas"}
+    mods = blocklist & set(sys.modules)
+
+    if mods:
+        print(", ".join(mods), end="")
+    """
+
+    output = check_output([sys.executable, '-c', dedent(check)])
+
+    assert output == b""

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import os
 
+from collections.abc import Iterable
 from functools import partial
 
 import param
@@ -8,7 +9,7 @@ import pytest
 
 from param import guess_param_types, resolve_path
 from param.parameterized import bothmethod
-from param._utils import _is_mutable_container, iscoroutinefunction
+from param._utils import _is_mutable_container, iscoroutinefunction, gen_types
 
 
 try:
@@ -421,3 +422,20 @@ def test_iscoroutinefunction_asyncgen():
 def test_iscoroutinefunction_partial_asyncgen():
     pagen = partial(partial(agen))
     assert iscoroutinefunction(pagen)
+
+def test_gen_types():
+    @gen_types
+    def _int_types():
+        yield int
+
+    assert isinstance(1, (str, _int_types))
+    assert isinstance(5, _int_types)
+    assert isinstance(5.0, _int_types) is False
+
+    assert issubclass(int, (str, _int_types))
+    assert issubclass(int, _int_types)
+    assert issubclass(float, _int_types) is False
+
+    assert next(iter(_int_types())) is int
+    assert next(iter(_int_types)) is int
+    assert isinstance(_int_types, Iterable)


### PR DESCRIPTION
The changes made in this PR are not to directly import non-essential imports (numpy in param) but to only check for the case when the user has already imported them.

This comes down to two things:

1) For param, this is to "hide" numpy imports in functions or generators. This is strictly not necessary, but people check import time with `python -X importtime -c 'import param'`, and because we do an actual import of numpy, we are heavily penalized by it. The random modules (numpy and stdlib) also seem unnecessary to import, only to use the import for not outputting anything with `pprint`. 

2) The second part involves using a new decorator, which overloads `isinstance` and `issubclass` and still makes it function like a generator with and without calling it. This approach can be used in our other libraries, e.g., HoloViews. Here, we currently import pandas to set up different class selectors, which heavily penalizes the import time. We currently require pandas, but that may not always be the case. 