### PR TITLE
Attempt to fix one reactive test failing intermittently on Windows

### DIFF
--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -608,7 +608,7 @@ async def test_reactive_gen_pipe():
 async def test_reactive_gen_with_dep():
     def gen(i):
         yield i+1
-        time.sleep(0.05)
+        time.sleep(0.1)
         yield i+2
 
     irx = rx(0)


### PR DESCRIPTION
The weekly scheduled job has been failing intermittently over the last months due to one reactive test failing on Windows.

```
================================== FAILURES ===================================
_________________________ test_reactive_gen_with_dep __________________________

    async def test_reactive_gen_with_dep():
        def gen(i):
            yield i+1
            time.sleep(0.05)
            yield i+2
    
        irx = rx(0)
        rxgen = rx(bind(gen, irx))
        assert rxgen.rx.value is param.Undefined
        await asyncio.sleep(0.04)
        assert rxgen.rx.value == 1
        irx.rx.value = 3
        await asyncio.sleep(0.04)
>       assert rxgen.rx.value == 4
E       assert 5 == 4
E        +  where 5 = <param.reactive.reactive_ops object at 0x0000020D4E3FE450>.value
E        +    where <param.reactive.reactive_ops object at 0x0000020D4E3FE450> = <param.reactive.rx object at 0x0000020D4E3FE540>.rx

tests\testreactive.py:621: AssertionError
=========================== short test summary info ===========================
FAILED tests/testreactive.py::test_reactive_gen_with_dep - assert 5 == 4
 +  where 5 = <param.reactive.reactive_ops object at 0x0000020D4E3FE450>.value
 +    where <param.reactive.reactive_ops object at 0x0000020D4E3FE450> = <param.reactive.rx object at 0x0000020D4E3FE540>.rx
============ 1 failed, 1403 passed, 5 skipped, 2 xfailed in 20.62s ============
```

On a Windows machine, I tried increasing the sleep time in the generator from 0.04 to 0.1 second and it seems it did the trick. I can't say I fully understand what's going on in this test though 🙃 