### PR TITLE
Added missing `super().__init_subclass__` call in `_ParameterBase.__init_subclass__`

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -971,6 +971,7 @@ class _ParameterBase(metaclass=ParameterMetaclass):
 
     @classmethod
     def __init_subclass__(cls):
+        super().__init_subclass__()
         # _update_signature has been tested against the Parameters available
         # in Param, we don't want to break the Parameters created elsewhere
         # so wrapping this in a loose try/except.


### PR DESCRIPTION
Currently the `_ParameterBase.__init_subclass__` method does not forward to the method on its superclass, so any other base classes in the MRO do not have a chance to perform any necessary subclass initialization steps. This PR adds the missing call.

This is particular relevant when defining a `Parameter` subclass with generic type parameters by inheriting from `typing.Generic` (or equivalently by using the new generics syntax added in Python 3.12). Inheriting from `typing.Generic[T]` where `T` is a `typing.TypeVar` typically allows a class to be parameterized by a concrete type, but this does not work when `_ParameterBase` is in the MRO since the `__init_subclass__` call is not properly propagated up the MRO.

The following example raises an `AttributeError` in the current `param` release, but works correctly after this PR:
```python

from typing import Generic, TypeVar
from param import Selector

T = TypeVar('T')

class GenericSelector(Selector, Generic[T]):
    pass

# raises `AttributeError: type object 'GenericSelector' has no attribute '__parameters__'`:
IntSelector = GenericSelector[int]
```