### PR TITLE
Address deprecations: remove _param_watchers, raise RuntimeError on unsafe ops during init, and failed validation of a parameter default after inheritance

### DIFF
--- a/doc/user_guide/Parameters.ipynb
+++ b/doc/user_guide/Parameters.ipynb
@@ -913,8 +913,7 @@
     "    - `param`: Property that helps keep the Parameterized namespace clean and disambiguate between Parameter objects and parameter values, it gives access to a namespace that offers various methods (see the section below) to update and inspect the Parameterized object at hand.\n",
     "- Private attributes:\n",
     "    - `_param__parameters`: Store the object returned by `.param` on the class\n",
-    "    - `_param__private`: Store various internal data on Parameterized class and instances\n",
-    "    - `_param_watchers` (deprecated in Param 2.0 and to be removed soon): Store a dictionary of instance watchers"
+    "    - `_param__private`: Store various internal data on Parameterized class and instances"
    ]
   },
   {

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2789,8 +2789,6 @@ class Parameters:
         outputs = {}
         for cls in classlist(self_.cls):
             for name in dir(cls):
-                if name == '_param_watchers':
-                    continue
                 method = getattr(self_.self_or_cls, name)
                 dinfo = getattr(method, '_dinfo', {})
                 if 'outputs' not in dinfo:
@@ -4190,18 +4188,6 @@ class Parameterized(metaclass=ParameterizedMetaclass):
     @property
     def param(self):
         return Parameters(self.__class__, self=self)
-
-    #PARAM3_DEPRECATION
-    @property
-    @_deprecated(extra_msg="Use `inst.param.watchers` instead.", warning_cat=_ParamFutureWarning)
-    def _param_watchers(self):
-        return self._param__private.watchers
-
-    #PARAM3_DEPRECATION
-    @_param_watchers.setter
-    @_deprecated(extra_msg="Use `inst.param.watchers = ...` instead.", warning_cat=_ParamFutureWarning)
-    def _param_watchers(self, value):
-        self._param__private.watchers = value
 
     # 'Special' methods
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2449,13 +2449,10 @@ class Parameters:
         that it is clear which Event parameter has been triggered.
         """
         if self_.self is not None and not self_.self._param__private.initialized:
-            warnings.warn(
+            raise RuntimeError(
                 'Triggering watchers on a partially initialized Parameterized instance '
-                'is deprecated and will raise an error in a future version. '
-                'Ensure you have called super().__init__(**params) in '
+                'is not allowed. Ensure you have called super().__init__(**params) in '
                 'the Parameterized instance constructor before trying to set up a watcher.',
-                category=_ParamFutureWarning,
-                stacklevel=2,
             )
 
         trigger_params = [p for p in self_
@@ -2904,13 +2901,10 @@ class Parameters:
 
     def _register_watcher(self_, action, watcher, what='value'):
         if self_.self is not None and not self_.self._param__private.initialized:
-            warnings.warn(
+            raise RuntimeError(
                 '(Un)registering a watcher on a partially initialized Parameterized instance '
-                'is deprecated and will raise an error in a future version. Ensure '
-                'you have called super().__init__(**) in the Parameterized instance '
-                'constructor before trying to set up a watcher.',
-                category=_ParamFutureWarning,
-                stacklevel=4,
+                'is not allowed. Ensure you have called super().__init__(**) in the '
+                'Parameterized instance constructor before trying to set up a watcher.',
             )
 
         parameter_names = watcher.parameter_names

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3644,8 +3644,7 @@ class ParameterizedMetaclass(type):
             # might raise other types of error, so we catch them all.
             except Exception as e:
                 msg = f'{_validate_error_prefix(param)} failed to validate its ' \
-                      'default value on class creation, this is going to raise ' \
-                      'an error in the future. '
+                      'default value on class creation. '
                 parents = ', '.join(klass.__name__ for klass in mcs.__mro__[1:-2])
                 if not type_change and slot_overridden:
                     msg += (
@@ -3666,11 +3665,7 @@ class ParameterizedMetaclass(type):
                     # performance reasons.
                     pass
                 msg += f'\nValidation failed with:\n{e}'
-                warnings.warn(
-                    msg,
-                    category=_ParamFutureWarning,
-                    stacklevel=4,
-                )
+                raise RuntimeError(msg) from e
 
     def get_param_descriptor(mcs,param_name):
         """

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2421,15 +2421,13 @@ class Parameters:
         instance='existing'.
         """
         if self_.self is not None and not self_.self._param__private.initialized and instance is True:
-            warnings.warn(
+            raise RuntimeError(
                 'Looking up instance Parameter objects (`.param.objects()`) until '
-                'the Parameterized instance has been fully initialized is deprecated and will raise an error in a future version. '
+                'the Parameterized instance has been fully initialized is not allowed. '
                 'Ensure you have called `super().__init__(**params)` in your Parameterized '
                 'constructor before trying to access instance Parameter objects, or '
                 'looking up the class Parameter objects with `.param.objects(instance=False)` '
                 'may be enough for your use case.',
-                category=_ParamFutureWarning,
-                stacklevel=2,
             )
 
         pdict = self_._cls_parameters

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -110,38 +110,6 @@ class TestDeprecateParameterizedModule:
         with pytest.raises(param._utils.ParamFutureWarning):
             param.parameterized.Parameterized()._param_watchers = {}
 
-    def test_param_error_unsafe_ops_before_initialized(self):
-        class P(param.Parameterized):
-
-            x = param.Parameter()
-
-            def __init__(self, **params):
-                with pytest.raises(
-                    param._utils.ParamFutureWarning,
-                    match=re.escape(
-                        'Triggering watchers on a partially initialized Parameterized instance '
-                        'is deprecated and will raise an error in a future version. '
-                        'Ensure you have called super().__init__(**params) in '
-                        'the Parameterized instance constructor before trying to set up a watcher.',
-                    )
-                ):
-                    self.param.trigger('x')
-
-                with pytest.raises(
-                    param._utils.ParamFutureWarning,
-                    match=re.escape(
-                        '(Un)registering a watcher on a partially initialized Parameterized instance '
-                        'is deprecated and will raise an error in a future version. Ensure '
-                        'you have called super().__init__(**) in the Parameterized instance '
-                        'constructor before trying to set up a watcher.',
-                    )
-                ):
-                    self.param.watch(print, 'x')
-
-                self.param.objects(instance=False)
-                super().__init__(**params)
-
-        P()
 
     # Inheritance tests to be move to testparameterizedobject.py when warnings will be turned into errors
 

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -102,15 +102,6 @@ class TestDeprecateParameterizedModule:
         with pytest.raises(param._utils.ParamDeprecationWarning):
             param.parameterized.all_equal(1, 1)
 
-    def test_deprecate_param_watchers(self):
-        with pytest.raises(param._utils.ParamFutureWarning):
-            param.parameterized.Parameterized()._param_watchers
-
-    def test_deprecate_param_watchers_setter(self):
-        with pytest.raises(param._utils.ParamFutureWarning):
-            param.parameterized.Parameterized()._param_watchers = {}
-
-
     # Inheritance tests to be move to testparameterizedobject.py when warnings will be turned into errors
 
     def test_inheritance_with_incompatible_defaults(self):

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -119,19 +119,6 @@ class TestDeprecateParameterizedModule:
                 with pytest.raises(
                     param._utils.ParamFutureWarning,
                     match=re.escape(
-                        'Looking up instance Parameter objects (`.param.objects()`) until '
-                        'the Parameterized instance has been fully initialized is deprecated and will raise an error in a future version. '
-                        'Ensure you have called `super().__init__(**params)` in your Parameterized '
-                        'constructor before trying to access instance Parameter objects, or '
-                        'looking up the class Parameter objects with `.param.objects(instance=False)` '
-                        'may be enough for your use case.',
-                    )
-                ):
-                    self.param.objects()
-
-                with pytest.raises(
-                    param._utils.ParamFutureWarning,
-                    match=re.escape(
                         'Triggering watchers on a partially initialized Parameterized instance '
                         'is deprecated and will raise an error in a future version. '
                         'Ensure you have called super().__init__(**params) in '

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -1,7 +1,6 @@
 """
 Test deprecation warnings.
 """
-import re
 import warnings
 
 import param
@@ -102,107 +101,6 @@ class TestDeprecateParameterizedModule:
         with pytest.raises(param._utils.ParamDeprecationWarning):
             param.parameterized.all_equal(1, 1)
 
-    # Inheritance tests to be move to testparameterizedobject.py when warnings will be turned into errors
-
-    def test_inheritance_with_incompatible_defaults(self):
-        class A(param.Parameterized):
-            p = param.String()
-
-        class B(A): pass
-
-        with pytest.raises(
-            param._utils.ParamFutureWarning,
-            match=re.escape(
-                "Number parameter 'C.p' failed to validate its "
-                "default value on class creation, this is going to raise "
-                "an error in the future. The Parameter type changed between class 'C' "
-                "and one of its parent classes (B, A) which made it invalid. "
-                "Please fix the Parameter type."
-                "\nValidation failed with:\nNumber parameter 'C.p' only takes numeric values, not <class 'str'>."
-            )
-        ):
-            class C(B):
-                p = param.Number()
-
-    def test_inheritance_default_validation_with_more_specific_type(self):
-        class A(param.Parameterized):
-            p = param.Tuple(default=('a', 'b'))
-
-        class B(A): pass
-
-        with pytest.raises(
-            param._utils.ParamFutureWarning,
-            match=re.escape(
-                "NumericTuple parameter 'C.p' failed to validate its "
-                "default value on class creation, this is going to raise "
-                "an error in the future. The Parameter type changed between class 'C' "
-                "and one of its parent classes (B, A) which made it invalid. "
-                "Please fix the Parameter type."
-                "\nValidation failed with:\nNumericTuple parameter 'C.p' only takes numeric values, not <class 'str'>."
-            )
-        ):
-            class C(B):
-                p = param.NumericTuple()
-
-    def test_inheritance_with_changing_bounds(self):
-        class A(param.Parameterized):
-            p = param.Number(default=5)
-
-        class B(A): pass
-
-        with pytest.raises(
-            param._utils.ParamFutureWarning,
-            match=re.escape(
-                "Number parameter 'C.p' failed to validate its "
-                "default value on class creation, this is going to raise "
-                "an error in the future. The Parameter is defined with attributes "
-                "which when combined with attributes inherited from its parent "
-                "classes (B, A) make it invalid. Please fix the Parameter attributes."
-                "\nValidation failed with:\nNumber parameter 'C.p' must be at most 3, not 5."
-            )
-        ):
-            class C(B):
-                p = param.Number(bounds=(-1, 3))
-
-    def test_inheritance_with_changing_default(self):
-        class A(param.Parameterized):
-            p = param.Number(default=5, bounds=(3, 10))
-
-        class B(A): pass
-
-        with pytest.raises(
-            param._utils.ParamFutureWarning,
-            match=re.escape(
-                "Number parameter 'C.p' failed to validate its "
-                "default value on class creation, this is going to raise "
-                "an error in the future. The Parameter is defined with attributes "
-                "which when combined with attributes inherited from its parent "
-                "classes (B, A) make it invalid. Please fix the Parameter attributes."
-                "\nValidation failed with:\nNumber parameter 'C.p' must be at least 3, not 1."
-            )
-        ):
-            class C(B):
-                p = param.Number(default=1)
-
-    def test_inheritance_with_changing_class_(self):
-        class A(param.Parameterized):
-            p = param.ClassSelector(class_=int, default=5)
-
-        class B(A): pass
-
-        with pytest.raises(
-            param._utils.ParamFutureWarning,
-            match=re.escape(
-                "ClassSelector parameter 'C.p' failed to validate its "
-                "default value on class creation, this is going to raise "
-                "an error in the future. The Parameter is defined with attributes "
-                "which when combined with attributes inherited from its parent "
-                "classes (B, A) make it invalid. Please fix the Parameter attributes."
-                "\nValidation failed with:\nClassSelector parameter 'C.p' value must be an instance of str, not 5."
-            )
-        ):
-            class C(B):
-                p = param.ClassSelector(class_=str)
 
 class TestDeprecateParameters:
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -588,6 +588,26 @@ class TestParameterized(unittest.TestCase):
             else:
                 assert obj is TestPO.param[p]
 
+    def test_param_error_unsafe_ops_before_initialized(self):
+        class P(param.Parameterized):
+
+            x = param.Parameter()
+
+            def __init__(self, **params):
+                with pytest.raises(
+                    RuntimeError,
+                    match=re.escape(
+                        'Looking up instance Parameter objects (`.param.objects()`) until '
+                        'the Parameterized instance has been fully initialized is not allowed. '
+                        'Ensure you have called `super().__init__(**params)` in your Parameterized '
+                        'constructor before trying to access instance Parameter objects, or '
+                        'looking up the class Parameter objects with `.param.objects(instance=False)` '
+                        'may be enough for your use case.',
+                    )
+                ):
+                    self.param.objects()
+        P()
+
     def test_instance_param_getitem(self):
         test = TestPO()
         assert test.param['inst'] is not TestPO.param['inst']

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -1520,7 +1520,6 @@ def test_namespace_class():
     assert _dir(P) == [
         '_param__parameters',
         '_param__private',
-        '_param_watchers',
         'foo',
         'name',
         'param',
@@ -1542,7 +1541,6 @@ def test_namespace_inst():
     assert _dir(p) == [
         '_param__parameters',
         '_param__private',
-        '_param_watchers',
         'foo',
         'name',
         'param',

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -653,37 +653,6 @@ class TestWatch(unittest.TestCase):
 
         obj.param.watch(lambda: '', ['a', 'b'])
 
-        with pytest.warns(param._utils.ParamFutureWarning):
-            pw = obj._param_watchers
-        assert isinstance(pw, dict)
-        for pname in ('a', 'b'):
-            assert pname in pw
-            assert 'value' in pw[pname]
-            assert isinstance(pw[pname]['value'], list) and len(pw[pname]['value']) == 1
-            assert isinstance(pw[pname]['value'][0], param.parameterized.Watcher)
-
-    def test_watch_watchers_modified(self):
-        accumulator = Accumulator()
-        obj = SimpleWatchExample()
-
-        obj.param.watch(accumulator, ['a', 'b'])
-
-        with pytest.warns(param._utils.ParamFutureWarning):
-            pw = obj._param_watchers
-        del pw['a']
-
-        obj.param.update(a=1, b=1)
-
-        assert accumulator.call_count() == 1
-        args = accumulator.args_for_call(0)
-        assert len(args) == 1
-        assert args[0].name == 'b'
-
-    def test_watch_watchers_exposed_public(self):
-        obj = SimpleWatchExample()
-
-        obj.param.watch(lambda: '', ['a', 'b'])
-
         pw = obj.param.watchers
         assert isinstance(pw, dict)
         for pname in ('a', 'b'):
@@ -692,7 +661,7 @@ class TestWatch(unittest.TestCase):
             assert isinstance(pw[pname]['value'], list) and len(pw[pname]['value']) == 1
             assert isinstance(pw[pname]['value'][0], param.parameterized.Watcher)
 
-    def test_watch_watchers_modified_public(self):
+    def test_watch_watchers_modified(self):
         accumulator = Accumulator()
         obj = SimpleWatchExample()
 


### PR DESCRIPTION
This PR touches these deprecated features that are now emitted at the FutureWarning level:

| Warning | Description | Action |
|-|-|-|
| `ParamFutureWarning` since `2.0.0` | Parameterized namespace / `instance._param_watchers` (getter and setter): use instead the property `inst.param.watchers` | **Removed** |
| `ParamFutureWarning` since `2.0.0` | Warn on failed validation of the *default* value of a Parameter after the inheritance mechanism has completed | **raises** `RuntimeError` |
| `ParamFutureWarning` since `2.0.0` | Running unsafe `instance.param.objects(instance=True)` during Parameterized instance initialization, instead run it after having called `super().__init__(**params)` | **raises** `RuntimeError` |
| `ParamFutureWarning` since `2.0.0` | Running unsafe `instance.param.trigger(<>)` during Parameterized instance initialization, instead run it after having called `super().__init__(**params)` | **raises** `RuntimeError` |
| `ParamFutureWarning` since `2.0.0` | Running unsafe `instance.param.watch(callback, "<param_name>")` during Parameterized instance initialization, instead run it after having called `super().__init__(**params)` | **raises** `RuntimeError` |
