### PR TITLE
Promote deprecation warnings to future warnings

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -106,7 +106,7 @@ def _deprecate_positional_args(func):
                 f"Passing '{extra_args}' as positional argument(s) to 'param.{name}' "
                 "has been deprecated since Param 2.0.0 and will raise an error in a future version, "
                 "please pass them as keyword arguments.",
-                ParamDeprecationWarning,
+                ParamFutureWarning,
                 stacklevel=2,
             )
 
@@ -315,7 +315,7 @@ def _produce_value(value_obj):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=ParamFutureWarning)
 def produce_value(value_obj):
     """
     A helper function that produces an actual parameter from a stored
@@ -328,7 +328,7 @@ def produce_value(value_obj):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=ParamFutureWarning)
 def as_unicode(obj):
     """
     Safely casts any object to unicode including regular string
@@ -340,7 +340,7 @@ def as_unicode(obj):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=ParamFutureWarning)
 def is_ordered_dict(d):
     """
     Predicate checking for ordered dictionaries. OrderedDict is always
@@ -371,7 +371,7 @@ def _hashable(x):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=ParamFutureWarning)
 def hashable(x):
     """
     Return a hashable version of the given object x, with lists and
@@ -420,7 +420,7 @@ def _named_objs(objlist, namesdict=None):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=ParamFutureWarning)
 def named_objs(objlist, namesdict=None):
     """
     Given a list of objects, returns a dictionary mapping from
@@ -558,7 +558,7 @@ def _abbreviate_paths(pathspec,named_paths):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=ParamFutureWarning)
 def abbreviate_paths(pathspec,named_paths):
     """
     Given a dict of (pathname,path) pairs, removes any prefix shared by all pathnames.

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -40,7 +40,6 @@ from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 from ._utils import (
     DEFAULT_SIGNATURE,
-    ParamDeprecationWarning as _ParamDeprecationWarning,
     ParamFutureWarning as _ParamFutureWarning,
     Skip,
     _deprecated,
@@ -289,7 +288,7 @@ def _batch_call_watchers(parameterized, enable=True, run=True):
 
 
 # PARAM3_DEPRECATION
-@_deprecated(extra_msg="Use instead `batch_call_watchers`.")
+@_deprecated(extra_msg="Use instead `batch_call_watchers`.", warning_cat=_ParamFutureWarning)
 @contextmanager
 def batch_watch(parameterized, enable=True, run=True):
     with _batch_call_watchers(parameterized, enable, run):
@@ -402,7 +401,7 @@ def get_occupied_slots(instance):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=_ParamFutureWarning)
 def all_equal(arg1,arg2):
     """
     Return a single boolean for arg1==arg2, even for numpy arrays
@@ -429,7 +428,7 @@ def all_equal(arg1,arg2):
 # (https://docs.python.org/3/reference/datamodel.html#customizing-class-creation)
 #
 # Code from six (https://bitbucket.org/gutworth/six; version 1.4.1).
-@_deprecated()
+@_deprecated(warning_cat=_ParamFutureWarning)
 def add_metaclass(metaclass):
     """Class decorator for creating a class with a metaclass.
 
@@ -551,7 +550,7 @@ def recursive_repr(fillvalue='...'):
     """
     warnings.warn(
         'recursive_repr has been deprecated and will be removed in a future version.',
-        category=_ParamDeprecationWarning,
+        category=_ParamFutureWarning,
         stacklevel=2,
     )
     return _recursive_repr(fillvalue=fillvalue)
@@ -1492,7 +1491,7 @@ class Parameter(_ParameterBase):
                 # PARAM3_DEPRECATION
                 warnings.warn(
                     'Number.set_hook has been deprecated.',
-                    category=_ParamDeprecationWarning,
+                    category=_ParamFutureWarning,
                     stacklevel=6,
                 )
 
@@ -2224,7 +2223,7 @@ class Parameters:
     # Classmethods
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="""Use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`""")
+    @_deprecated(extra_msg="""Use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`""", warning_cat=_ParamFutureWarning)
     def print_param_defaults(self_):
         """Print the default values of all cls's Parameters.
 
@@ -2237,7 +2236,7 @@ class Parameters:
                 print(cls.__name__+'.'+key+ '='+ repr(val.default))
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `p.param.default =`")
+    @_deprecated(extra_msg="Use instead `p.param.default =`", warning_cat=_ParamFutureWarning)
     def set_default(self_,param_name,value):
         """
         Set the default value of param_name.
@@ -2268,7 +2267,7 @@ class Parameters:
         cls._param__private.params.clear()
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `.param.add_parameter`")
+    @_deprecated(extra_msg="Use instead `.param.add_parameter`", warning_cat=_ParamFutureWarning)
     def _add_parameter(self_,param_name, param_obj):
         """Add a new Parameter object into this object's class.
 
@@ -2277,7 +2276,7 @@ class Parameters:
         return self_.add_parameter(param_name, param_obj)
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `.param.values()` or `.param['param']`")
+    @_deprecated(extra_msg="Use instead `.param.values()` or `.param['param']`", warning_cat=_ParamFutureWarning)
     def params(self_, parameter_name=None):
         """
         Return the Parameters of this class as the
@@ -2360,7 +2359,7 @@ class Parameters:
         return restore
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `.param.update`")
+    @_deprecated(extra_msg="Use instead `.param.update`", warning_cat=_ParamFutureWarning)
     def set_param(self_, *args,**kwargs):
         """
         For each param=value keyword argument, sets the corresponding
@@ -2628,7 +2627,7 @@ class Parameters:
     @_deprecated(extra_msg="""
         Use `.param.values().items()` instead (or `.param.values()` for the
         common case of `dict(....param.get_param_values())`)
-    """)
+    """, warning_cat=_ParamFutureWarning)
     def get_param_values(self_, onlychanged=False):
         """
         Return a list of name,value pairs for all Parameters of this
@@ -2770,7 +2769,7 @@ class Parameters:
             self_.self, deps, dynamic, intermediate=intermediate)
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg='Use instead `.param.method_dependencies`')
+    @_deprecated(extra_msg='Use instead `.param.method_dependencies`', warning_cat=_ParamFutureWarning)
     def params_depended_on(self_, *args, **kwargs):
         """
         Given the name of a method, returns a PInfo object for each dependency
@@ -3020,7 +3019,7 @@ class Parameters:
     # Instance methods
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `{k:v.default for k,v in p.param.objects().items()}`")
+    @_deprecated(extra_msg="Use instead `{k:v.default for k,v in p.param.objects().items()}`", warning_cat=_ParamFutureWarning)
     def defaults(self_):
         """
         Return {parameter_name:parameter.default} for all non-constant
@@ -3061,7 +3060,7 @@ class Parameters:
             get_logger(name=self_or_cls.name).log(level, msg, *args, **kw)
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="""Use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`""")
+    @_deprecated(extra_msg="""Use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")`""", warning_cat=_ParamFutureWarning)
     def print_param_values(self_):
         """Print the values of all this object's Parameters.
 
@@ -3083,7 +3082,7 @@ class Parameters:
         self_.log(WARNING, msg, *args, **kw)
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `.param.log(param.MESSAGE, ...)`")
+    @_deprecated(extra_msg="Use instead `.param.log(param.MESSAGE, ...)`", warning_cat=_ParamFutureWarning)
     def message(self_,msg,*args,**kw):
         """
         Print msg merged with args as a message.
@@ -3096,7 +3095,7 @@ class Parameters:
         self_.__db_print(INFO,msg,*args,**kw)
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `.param.log(param.VERBOSE, ...)`")
+    @_deprecated(extra_msg="Use instead `.param.log(param.VERBOSE, ...)`", warning_cat=_ParamFutureWarning)
     def verbose(self_,msg,*args,**kw):
         """
         Print msg merged with args as a verbose message.
@@ -3109,7 +3108,7 @@ class Parameters:
         self_.__db_print(VERBOSE,msg,*args,**kw)
 
     # PARAM3_DEPRECATION
-    @_deprecated(extra_msg="Use instead `.param.log(param.DEBUG, ...)`")
+    @_deprecated(extra_msg="Use instead `.param.log(param.DEBUG, ...)`", warning_cat=_ParamFutureWarning)
     def debug(self_,msg,*args,**kw):
         """
         Print msg merged with args as a debugging statement.
@@ -4541,7 +4540,7 @@ class overridable_property:
     def __init__(self, fget=None, fset=None, fdel=None, doc=None):
         warnings.warn(
             message="overridable_property has been deprecated.",
-            category=_ParamDeprecationWarning,
+            category=_ParamFutureWarning,
             stacklevel=2,
         )
         self.fget = fget

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -38,7 +38,7 @@ from .parameterized import (
     _int_types, _identity_hook
 )
 from ._utils import (
-    ParamDeprecationWarning as _ParamDeprecationWarning,
+    ParamFutureWarning as _ParamFutureWarning,
     _deprecate_positional_args,
     _deprecated,
     _dict_update,
@@ -2497,7 +2497,7 @@ class List(Parameter):
             # PARAM3_DEPRECATION
             warnings.warn(
                 message="The 'class_' attribute on 'List' is deprecated. Use instead 'item_type'",
-                category=_ParamDeprecationWarning,
+                category=_ParamFutureWarning,
                 stacklevel=3,
             )
         if item_type is not Undefined and class_ is not Undefined:
@@ -2658,7 +2658,7 @@ class resolve_path(ParameterizedFunction):
 
 
 # PARAM3_DEPRECATION
-@_deprecated()
+@_deprecated(warning_cat=_ParamFutureWarning)
 class normalize_path(ParameterizedFunction):
     """
     Convert a UNIX-style path to the current OS's format,

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -22,11 +22,11 @@ def specific_filter():
 class TestDeprecateParameter:
 
     def test_deprecate_posargs_Parameter(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.Parameter(1, 'doc')
 
     def test_deprecate_List_class_(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.List(class_=int)
 
     def test_deprecate_Number_set_hook(self):
@@ -34,45 +34,45 @@ class TestDeprecateParameter:
             n = param.Number(set_hook=lambda obj, val: val)
 
         p = P()
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.n = 1
 
 
 class TestDeprecateInitModule:
 
     def test_deprecate_as_unicode(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.as_unicode(1)
 
     def test_deprecate_is_ordered_dict(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.is_ordered_dict(dict())
 
     def test_deprecate_produce_value(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.produce_value(1)
 
     def test_deprecate_hasbable(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.hashable('s')
 
     def test_deprecate_named_objs(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.named_objs(dict())
 
     def test_deprecate_normalize_path(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.normalize_path()
 
     def test_deprecate_abbreviate_path(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.abbreviate_paths()
 
 
 class TestDeprecateParameterizedModule:
 
     def test_deprecate_overridable_property(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             class Foo:
                 def _x(self): pass
                 x = param.parameterized.overridable_property(_x)
@@ -83,23 +83,23 @@ class TestDeprecateParameterizedModule:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             with param.parameterized.batch_watch(p):
                 pass
 
     def test_deprecate_add_metaclass(self):
         class MC(type): pass
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             @param.parameterized.add_metaclass(MC)
             class Base: pass
 
     def test_deprecate_recursive_repr(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.parameterized.recursive_repr(lambda: '')
 
     def test_deprecate_all_equal(self):
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             param.parameterized.all_equal(1, 1)
 
     def test_deprecate_param_watchers(self):
@@ -266,21 +266,21 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.print_param_defaults()
 
     def test_deprecate_set_default(self):
         class P(param.Parameterized):
             x = param.Parameter()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             P.param.set_default('x', 1)
 
     def test_deprecate__add_parameter(self):
         class P(param.Parameterized):
             x = param.Parameter()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             P.param._add_parameter('y', param.Parameter())
 
     def test_deprecate_params(self):
@@ -289,7 +289,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.params()
 
     def test_deprecate_set_param(self):
@@ -298,7 +298,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.set_param('x', 1)
 
     def test_deprecate_get_param_values(self):
@@ -307,7 +307,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.get_param_values()
 
     def test_deprecate_params_depended_on(self):
@@ -316,7 +316,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.params_depended_on()
 
     def test_deprecate_defaults(self):
@@ -325,7 +325,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.defaults()
 
     def test_deprecate_print_param_values(self):
@@ -334,7 +334,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.print_param_values()
 
     def test_deprecate_message(self):
@@ -343,7 +343,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.message('test')
 
     def test_deprecate_verbose(self):
@@ -352,7 +352,7 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.verbose('test')
 
     def test_deprecate_debug(self):
@@ -361,5 +361,5 @@ class TestDeprecateParameters:
 
         p = P()
 
-        with pytest.raises(param._utils.ParamDeprecationWarning):
+        with pytest.raises(param._utils.ParamFutureWarning):
             p.param.debug('test')

--- a/tests/testsignatures.py
+++ b/tests/testsignatures.py
@@ -97,17 +97,17 @@ def test_signature_position_keywords():
 def test_signature_warning_by_position():
     # Simple test as it's tricky to automatically test all the Parameters
     with pytest.warns(
-        param._utils.ParamDeprecationWarning,
+        param._utils.ParamFutureWarning,
         match=r"Passing 'objects' as positional argument\(s\) to 'param.Selector' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments"
     ):
         param.Selector([0, 1])  # objects
     with pytest.warns(
-        param._utils.ParamDeprecationWarning,
+        param._utils.ParamFutureWarning,
         match=r"Passing 'class_' as positional argument\(s\) to 'param.ClassSelector' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments"
     ):
         param.ClassSelector(int)  # class_
     with pytest.warns(
-        param._utils.ParamDeprecationWarning,
+        param._utils.ParamFutureWarning,
         match=r"Passing 'bounds, softbounds' as positional argument\(s\) to 'param.Number' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments"
     ):
         param.Number(1, (0, 2), (0, 2))  # default (OK), bounds (not OK), softbounds (not OK)


### PR DESCRIPTION
This concerns all the deprecated features listed in the table below. Then we release (2.1.2 or 2.2.0), remove in the next minor release (2.2.0 or 2.3.0), with a couple months between the two releases. The last two deprecations at the end of the table may need more time before removal as they were more recently promoted to `ParamDeprecationWarning` (in 2.1.0 in March of this year). 

| Warning | Description |
|-|-|
| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.recursive_repr`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | Parameter slots / `Number.set_hook`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.overridable_property`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | Parameter slots / `List.class_`: use instead `item_type` |
| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.produce_value`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.as_unicode`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.is_ordered_dict`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.hashable`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.named_objs`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.abbreviate_paths`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.batch_watch`: use instead `batch_call_watchers` |
| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.all_equal`: no replacement |
| `ParamDeprecationWarning` since `2.0.0` | `param.parameterized` module / `param.parameterized.add_metaclass`: no replacement |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.print_param_defaults`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.set_default`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param._add_parameter`: use instead `.param.add_parameter` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.params`: use instead `.param.values()` or `.param['param']` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.set_param`: use instead `.param.update` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.get_param_values`: use instead `.param.values().items()` (or `.param.values()` for the common case of `dict(....param.get_param_values())`) |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.params_depended_on`: use instead `.param.method_dependencies` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.defaults`: use instead `{k:v.default for k,v in p.param.objects().items()}` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.print_param_values`: use instead `for k,v in p.param.objects().items(): print(f"{p.__class__.name}.{k}={repr(v.default)}")` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.message`: use instead `.param.log(param.MESSAGE, ...)` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.verbose`: use instead `.param.log(param.VERBOSE, ...)` |
| `ParamDeprecationWarning` since `2.0.0`, soft-deprecated since `1.12.0` | Parameterized `.param` namespace / `.param.debug`: use instead `.param.log(param.DEBUG, ...)` |
| `ParamDeprecationWarning` since `2.0.0` | `param.__init__` module / `param.normalize_path`: no replacement |
| `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` | Instantiating most parameters with positional arguments beyond `default` is deprecated |
| `ParamDeprecationWarning` since `2.1.0`, `ParamPendingDeprecationWarning` since `2.0.0` | For `Selector` parameters that accept `objects` as first positional argument, and `ClassSelector` parameters that accept `class_` as first positional argument, passing any argument by position is deprecated. |
