### PR TITLE
type: Infer parameters types for `__init__(default...)`, `__get__` and `__set__`

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -231,7 +231,7 @@ def _identity_hook(obj, val):
     return val
 
 
-class _Undefined:
+class _TUndefined:
     """
     Dummy value to signal completely undefined values rather than
     simple None values.
@@ -247,7 +247,7 @@ class _Undefined:
         return '<Undefined>'
 
 
-Undefined = _Undefined()
+Undefined = _TUndefined()
 
 
 @contextmanager


### PR DESCRIPTION
Adding type hints to `__set__`, `__get__`, and `__init__`.

Haven't tested on old versions, so for now this should be seen as a POC. 



<details>
<summary>Code</summary>


``` python
from __future__ import annotations

from typing import reveal_type
from datetime import date

import param


class MyParams(param.Parameterized):
    a = param.Integer()
    b = param.Integer(default=10)
    c = param.Boolean(default=True)
    d = param.Number()
    e = param.Number(default=10.0)

    f = param.Date()
    g = param.Date(default=date(2020, 1, 1))

    h = param.ClassSelector(default=1, class_=int)


params = MyParams()
reveal_type(params.a)
reveal_type(params.b)
reveal_type(params.c)
reveal_type(params.d)
reveal_type(params.e)
reveal_type(params.f)
reveal_type(params.g)
reveal_type(params.h)

for s in "abcdefgh":
    print(f"params.{s} = {getattr(params, s)}")
```


</details>


With this PR:
![image](https://github.com/user-attachments/assets/9f8cd846-ca22-44be-aa02-fbad64a5e7f4)

Before:

![ Screenshot 2024-12-13 12 29 33](https://github.com/user-attachments/assets/0e26b208-f73a-48c7-b0ff-99b3edff13b8)