### PR TITLE
Fix publishing a conda package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=$(ls dist/*.conda)" >> $GITHUB_ENV
+          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"


### PR DESCRIPTION
I forgot to click on Publish and then when I clicked it failed.

![image](https://github.com/user-attachments/assets/9a4eef0d-2745-4298-a893-9b59610d8754)

This now points to the right .tag.bz2 extension.