### PR TITLE
Fix generating the API doc

### DIFF
--- a/doc/reference/param/generated/param.rx.rst
+++ b/doc/reference/param/generated/param.rx.rst
@@ -5,23 +5,21 @@
 
 .. autoclass:: rx
 
-   
+
    .. automethod:: __init__
 
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~rx.register_accessor
       ~rx.register_display_handler
       ~rx.register_method_handler
-   
-   
+
+
    .. rubric:: Attributes
 
    .. autosummary::
-   
+
       ~rx.rx
-   
-   

--- a/doc/reference/param/generated/param.rx.rst
+++ b/doc/reference/param/generated/param.rx.rst
@@ -1,0 +1,27 @@
+﻿param.rx
+========
+
+.. currentmodule:: param
+
+.. autoclass:: rx
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~rx.register_accessor
+      ~rx.register_display_handler
+      ~rx.register_method_handler
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~rx.rx
+   
+   

--- a/doc/reference/param/reactive.md
+++ b/doc/reference/param/reactive.md
@@ -9,8 +9,9 @@
   :toctree: generated/
 
   bind
-  rx
 ```
+
+[rx](./generated/param.rx): *rx* allows wrapping objects and then operating on them interactively while recording any operations applied to them.
 
 These methods and properties are available under the `.rx` namespace
 of reactive expressions ({py:class}`rx`).


### PR DESCRIPTION
Somehow https://github.com/holoviz/param/pull/977 by adding the `rx` property broke the autosummary API doc build of the `rx` class. I've made this change and pushed the generated file as a workaround to unblock the release.

```
   .. autosummary::

      ~rx.__init__  # I've removed that line!
      ~rx.register_accessor
      ~rx.register_display_handler
      ~rx.register_method_handler

```