### PR TITLE
Ensure edit_constant resets class and instance level parameters

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -338,15 +338,23 @@ def edit_constant(parameterized):
     Temporarily set parameters on Parameterized object to constant=False
     to allow editing them.
     """
-    params = parameterized.param.objects('existing').values()
-    constants = [p.constant for p in params]
-    for p in params:
-        p.constant = False
+    kls_params = parameterized.param.objects(instance=False)
+    inst_params = parameterized._param__private.params
+    updated = []
+    for pname, pobj in (kls_params | inst_params).items():
+        if pobj.constant:
+            pobj.constant = False
+            updated.append(pname)
     try:
         yield
     finally:
-        for (p, const) in zip(params, constants):
-            p.constant = const
+        for pname in updated:
+            # Some operations trigger a parameter instantiation (copy),
+            # we ensure both the class and instance parameters are reset.
+            if pname in kls_params:
+                type(parameterized).param[pname].constant=True
+            if pname in inst_params:
+                parameterized.param[pname].constant = True
 
 
 @contextmanager

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -19,6 +19,7 @@ from param.parameterized import (
     ParamOverrides,
     Undefined,
     default_label_formatter,
+    edit_constant,
     no_instance_params,
     shared_parameters,
 )
@@ -312,6 +313,17 @@ class TestParameterized(unittest.TestCase):
         TestPO.const=9
         testpo = TestPO()
         self.assertEqual(testpo.const,9)
+
+    def test_edit_constant(self):
+        testpo = TestPO(const=17)
+        # Checking no parameter was already instantiated
+        assert not testpo._param__private.params
+        with edit_constant(testpo):
+            testpo.const = 18
+        assert testpo.const == 18
+        assert testpo.param['const'].constant
+        assert TestPO.param['const'].constant
+        assert TestPO.param['const'].default == 1
 
     def test_readonly_parameter(self):
         """Test that you can't set a read-only parameter on construction or as an attribute."""


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/1014
Fixes https://github.com/holoviz/param/issues/931

Regression introduced in Param 2.0.0 in https://github.com/holoviz/param/pull/826 that introduced installing an instance parameter (copied from the class) on `__set__` (https://github.com/holoviz/param/commit/6ce1ef3f3ecc01d0c3eca88b0ec50d690dfb40e1). The context manager `edit_constant` was first getting a handle on all the existing parameters (mix of class and instance level parameters), yielding, and then resetting `constant` on the parameters already handled, missing that the parameterized object could have been equipped with instance-level parameters that were created with `constant=False`.

This is fixed in this MR, which also only touches the constant parameters.