### PR TITLE
`unwatch` no longer logs a warning and idempotent behavior clarified

### DIFF
--- a/doc/user_guide/Dependencies_and_Watchers.ipynb
+++ b/doc/user_guide/Dependencies_and_Watchers.ipynb
@@ -480,7 +480,7 @@
     "\n",
     "- `obj.param.watch_values(fn, parameter_names, what='value', onlychanged=True, queued=False, precedence=0)`: <br>Easier-to-use version of `obj.param.watch` specific to watching for changes in parameter values. Same as `watch`, but hard-codes `what='value'` and invokes the callback `fn` using keyword arguments _param_name_=_new_value_ rather than with a positional-argument list of `Event` objects.\n",
     "\n",
-    "- `obj.param.unwatch(watcher)`: <br>Remove the given `Watcher` (typically obtained as the return value from `watch` or `watch_values`) from those registered on this `obj`.\n",
+    "- `obj.param.unwatch(watcher)`: <br>Remove the given `Watcher` (typically obtained as the return value from `watch` or `watch_values`) from those registered on this `obj`. Calling this method again after the watcher has already been unregistered is a no-op and won't raise any error.\n",
     "\n",
     "To see how to use `watch` and `watch_values`, let's make a class with parameters `a` and `b` and various watchers with corresponding callback methods:"
    ]

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -8,7 +8,7 @@ import pytest
 
 from param.parameterized import Skip, discard_events
 
-from .utils import MockLoggingHandler, warnings_as_excepts
+from .utils import MockLoggingHandler
 
 
 class Accumulator:
@@ -250,15 +250,8 @@ class TestWatch(unittest.TestCase):
         obj = SimpleWatchExample()
         watcher = obj.param.watch(accumulator, 'a')
         obj.param.unwatch(watcher)
-        with warnings_as_excepts(match='No such watcher'):
+        with pytest.raises(ValueError, match="has already been removed or was never added"):
             obj.param.unwatch(watcher)
-        try:
-            param.parameterized.warnings_as_exceptions = False
-            obj.param.unwatch(watcher)
-            self.log_handler.assertEndsWith('WARNING',
-                                ' to remove.')
-        finally:
-            param.parameterized.warnings_as_exceptions = True
 
     def test_simple_batched_watch_setattr(self):
 

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -250,8 +250,8 @@ class TestWatch(unittest.TestCase):
         obj = SimpleWatchExample()
         watcher = obj.param.watch(accumulator, 'a')
         obj.param.unwatch(watcher)
-        with pytest.raises(ValueError, match="has already been removed or was never added"):
-            obj.param.unwatch(watcher)
+        # Idempotent, not error raised.
+        obj.param.unwatch(watcher)
 
     def test_simple_batched_watch_setattr(self):
 

--- a/tests/testwatch.py
+++ b/tests/testwatch.py
@@ -713,6 +713,14 @@ class TestWatch(unittest.TestCase):
         P()
 
 
+    def test_watch_raises_bad_parameter(self):
+        obj = SimpleWatchExample()
+        with pytest.raises(
+            ValueError,
+            match="does_not_exist parameter was not found in list of parameters of class SimpleWatchExample"
+        ):
+            obj.param.watch(lambda e: print(e), 'does_not_exist')
+
 
 class TestWatchMethod(unittest.TestCase):
 


### PR DESCRIPTION
Resolves https://github.com/holoviz/param/issues/1003

By raising `ValueError` when trying to remove an already removed/never registered watcher.