### PR TITLE
Deprecate setting a parameter value before full instance initialization

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -37,6 +37,7 @@ from . import serializer
 from ._utils import (
     DEFAULT_SIGNATURE,
     ParamFutureWarning as _ParamFutureWarning,
+    ParamPendingDeprecationWarning as _ParamPendingDeprecationWarning,
     Skip,
     _deprecated,
     _deprecate_positional_args,
@@ -1572,6 +1573,15 @@ class Parameter(_ParameterBase):
             else:
                 # When setting a Parameter before calling super.
                 if not isinstance(obj._param__private, _InstancePrivate):
+                    warnings.warn(
+                        f"Setting the Parameter {self.name!r} to {val!r} before "
+                        f"the Parameterized class {type(obj).__name__!r} is fully "
+                        "instantiated is deprecated and will raise an error in "
+                        "a future version. Ensure the value is set after calling "
+                        "`super().__init__(**params)` in the constructor.",
+                        category=_ParamPendingDeprecationWarning,
+                        stacklevel=5,
+                    )
                     obj._param__private = _InstancePrivate(
                         explicit_no_refs=type(obj)._param__private.explicit_no_refs
                     )
@@ -4438,6 +4448,8 @@ class Parameterized(metaclass=ParameterizedMetaclass):
             self._param__private = _InstancePrivate(
                 explicit_no_refs=type(self)._param__private.explicit_no_refs
             )
+        else:
+            print("BAR")
 
         # Skip generating a custom instance name when a class in the hierarchy
         # has overriden the default of the `name` Parameter.

--- a/tests/testdeprecations.py
+++ b/tests/testdeprecations.py
@@ -97,6 +97,16 @@ class TestDeprecateParameterizedModule:
         with pytest.raises(param._utils.ParamFutureWarning):
             param.parameterized.all_equal(1, 1)
 
+    def test_deprecate_setting_parameter_before_init(self):
+        class P(param.Parameterized):
+            x = param.Parameter()
+
+            def __init__(self, **params):
+                self.x = 10
+                super().__init__(**params)
+        with pytest.raises(param._utils.ParamPendingDeprecationWarning):
+            P()
+
 
 class TestDeprecateParameters:
 


### PR DESCRIPTION
Closes https://github.com/holoviz/param/issues/815