### PR TITLE
Support declaring a Parameterized class as an ABC

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -519,6 +519,8 @@ def _is_number(obj):
 
 
 def _is_abstract(class_):
+    if inspect.isabstract(class_):
+        return True
     try:
         return class_.abstract
     except AttributeError:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -8,6 +8,7 @@ either alone (providing basic Parameter support) or with param's
 __init__.py (providing specialized Parameter types).
 """
 
+import abc
 import asyncio
 import copy
 import datetime as dt
@@ -4569,6 +4570,22 @@ class Parameterized(metaclass=ParameterizedMetaclass):
     def __str__(self):
         """Return a short representation of the name and class of this object."""
         return f"<{self.__class__.__name__} {self.name}>"
+
+
+class ParameterizedABCMeta(abc.ABCMeta, ParameterizedMetaclass):
+    """Metaclass for abstract base classes using Parameterized.
+
+    Ensures compatibility between ABCMeta and ParameterizedMetaclass.
+    """
+
+
+class ParameterizedABC(Parameterized, metaclass=ParameterizedABCMeta):
+    """Base class for user-defined ABCs that extends Parameterized."""
+
+    def __init_subclass__(cls, **kwargs):
+        if cls.__bases__ and cls.__bases__[0] is ParameterizedABC:
+            setattr(cls, f'_{cls.__name__}__abstract', True)
+        super().__init_subclass__(**kwargs)
 
 
 def print_all_param_defaults():

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -365,11 +365,28 @@ class TestParameterized(unittest.TestCase):
         assert t.param['instPO'].instantiate is True
         assert isinstance(t.instPO,AnotherTestPO)
 
-    def test_abstract_class(self):
+    def test_abstract_class_attribute(self):
         """Check that a class declared abstract actually shows up as abstract."""
         self.assertEqual(TestAbstractPO.abstract, True)
         self.assertEqual(_AnotherAbstractPO.abstract, True)
         self.assertEqual(TestPO.abstract, False)
+        # Test subclasses are not abstract
+        class A(param.Parameterized):
+            __abstract = True
+        class B(A): pass
+        class C(A): pass
+        self.assertEqual(A.abstract, True)
+        self.assertEqual(B.abstract, False)
+        self.assertEqual(C.abstract, False)
+
+    def test_abstract_class_abc(self):
+        """Check that an ABC class actually shows up as abstract."""
+        class A(param.parameterized.ParameterizedABC): pass
+        class B(A): pass
+        class C(A): pass
+        self.assertEqual(A.abstract, True)
+        self.assertEqual(B.abstract, False)
+        self.assertEqual(C.abstract, False)
 
     def test_override_class_param_validation(self):
         test = TestPOValidation()

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -8,8 +8,13 @@ import param
 import pytest
 
 from param import guess_param_types, resolve_path
-from param.parameterized import bothmethod
-from param._utils import _is_mutable_container, iscoroutinefunction, gen_types
+from param.parameterized import bothmethod, Parameterized, ParameterizedABC
+from param._utils import (
+    _is_abstract,
+    _is_mutable_container,
+    iscoroutinefunction,
+    gen_types,
+)
 
 
 try:
@@ -439,3 +444,27 @@ def test_gen_types():
     assert next(iter(_int_types())) is int
     assert next(iter(_int_types)) is int
     assert isinstance(_int_types, Iterable)
+
+
+def test_is_abstract_false():
+    class A: pass
+    class B(Parameterized): pass
+    assert not _is_abstract(A)
+    assert not _is_abstract(B)
+
+
+def test_is_abstract_attribute():
+    class A(Parameterized):
+        __abstract = True
+    class B(A): pass
+
+    assert _is_abstract(A)
+    assert not _is_abstract(B)
+
+
+def test_is_abstract_abc():
+    class A(ParameterizedABC): pass
+    class B(A): pass
+
+    assert _is_abstract(A)
+    assert not _is_abstract(B)


### PR DESCRIPTION
Param has its own way of declaring "abstract" classes by annotating them with `__abstract = True`. Parameterized classes all have an `abstract` property inherited from the metaclass that returns whether this attribute (mangled) was set. The `concrete_descendents` function uses `_is_abstract` to build a collection of the non-abstract descendents only. https://github.com/holoviz/param/issues/84 suggests replacing this approach by [Abstract Bases Classes](https://docs.python.org/3/library/abc.html). This MR doesn't replace the current mechanism (we'd need to deprecate it first) but instead attempts to add support to ABCs, allowing users to declare a Parameterized ABC.

To avoid metaclass conflicts, it introduces the `ParamaterizedABC`class that users must inherit from when they want to declare an ABC.

```python
import abc
import param

class ModelABC(param.parameterized.ParameterizedABC):

    x = param.Number()
    y = param.Number()

    @abc.abstractmethod
    def run(self):
        """This must be implemented by subclasses."""

class BadModel(ModelABC): pass

class GoodModel(ModelABC):
    def run(self):
        return self.x * self.y

try:
    BadModel()
except Exception as e:
    print(repr(e))
    # TypeError("Can't instantiate abstract class BadModel without an implementation for abstract method 'run'")

gm = GoodModel(x=10, y=2)
print(gm.run())
# 20

print(param.concrete_descendents(ModelABC))
# {'GoodModel': <class '__main__.GoodModel'>}
```

---

@sdc50 I know your comment on https://github.com/holoviz/param/issues/84 dates a little (5 years :) ). If you're still interested in this feature, let me know what you think about it. On the HoloViz code bases side, I think we'll need to see whether we can effectively replace `__abstract = True`.

- [ ] Documentation
- [ ] Add more tests