### PR TITLE
Update the CI to test with PyPy 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -159,14 +159,6 @@ jobs:
         run: |
           .venv\Scripts\Activate.ps1
           pytest tests
-      # - name: pip update
-      #   run: pip install --upgrade pip
-      # - name: install
-      #   run: pip install -e ."[tests,tests-pypy]"
-      # - name: pip list
-      #   run: pip list
-      # - name: Test Unit
-      #   run: pytest tests
 
   result_test_suite:
     name: result:test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,6 +131,11 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: "100"
+      - name: Fetch
+        run: git fetch --prune --tags -f
       - uses: actions/setup-python@v5
         with:
           python-version: 'pypy3.10'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,9 +153,9 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest tests
-
       - name: Run tests (Windows)
         if: matrix.os == 'windows-latest'
+        shell: pwsh
         run: |
           .venv\Scripts\Activate.ps1
           pytest tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,13 +122,14 @@ jobs:
           pixi run -e ${{ matrix.environment }} test-unit
 
   pypy_test_suite:
-    name: core:${{ matrix.environment }}:pypy3.10
+    name: core:${{ matrix.python-version }}:${{ matrix.environment }}
     needs: [pre_commit]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
+        python-version: ["pypy3.10"]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -138,15 +139,25 @@ jobs:
         run: git fetch --prune --tags -f
       - uses: actions/setup-python@v5
         with:
-          python-version: 'pypy3.10'
-      - name: pip update
-        run: pip install --upgrade pip
-      - name: install
-        run: pip install -e ."[tests,tests-pypy]"
-      - name: pip list
-        run: pip list
-      - name: Test Unit
-        run: pytest tests
+          python-version: ${{ matrix.python-version }}
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
+      - name: Create virtual environment
+        run: uv venv --python ${{ matrix.python-version }}
+      - name: Install project dependencies
+        run: uv pip install -e ."[tests,tests-pypy]"
+      - name: List installed packages
+        run: uv pip list
+      - name: Run tests
+        run: uv venv exec pytest tests
+      # - name: pip update
+      #   run: pip install --upgrade pip
+      # - name: install
+      #   run: pip install -e ."[tests,tests-pypy]"
+      # - name: pip list
+      #   run: pip list
+      # - name: Test Unit
+      #   run: pytest tests
 
   result_test_suite:
     name: result:test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,7 +122,7 @@ jobs:
           pixi run -e ${{ matrix.environment }} test-unit
 
   pypy_test_suite:
-    name: core:${{ matrix.python-version }}:${{ matrix.environment }}
+    name: core:${{ matrix.python-version }}:${{ matrix.os }}
     needs: [pre_commit]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -148,8 +148,17 @@ jobs:
         run: uv pip install -e ."[tests,tests-pypy]"
       - name: List installed packages
         run: uv pip list
-      - name: Run tests
-        run: uv venv exec pytest tests
+      - name: Run tests (Linux)
+        if: matrix.os != 'windows-latest'
+        run: |
+          source .venv/bin/activate
+          pytest tests
+
+      - name: Run tests (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          .venv\Scripts\Activate.ps1
+          pytest tests
       # - name: pip update
       #   run: pip install --upgrade pip
       # - name: install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        environment: ["test-core", "test-pypy"]
+        environment: ["test-core"]
     timeout-minutes: 30
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
@@ -121,9 +121,31 @@ jobs:
         run: |
           pixi run -e ${{ matrix.environment }} test-unit
 
+  pypy_test_suite:
+    name: core:${{ matrix.environment }}:pypy3.10
+    needs: [pre_commit]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 'pypy3.10'
+      - name: pip update
+        run: pip install --upgrade pip
+      - name: install
+        run: pip install -e ."[tests,tests-pypy]"
+      - name: pip list
+        run: pip list
+      - name: Test Unit
+        run: pytest tests
+
   result_test_suite:
     name: result:test
-    needs: [unit_test_suite, core_test_suite]
+    needs: [unit_test_suite, core_test_suite, pypy_test_suite]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -135,10 +135,9 @@ pixi run test-unit
 The task is available in the following environments:
 
 1. `test-39`, `test-310`, `test-311`, `test-312`, and `test-313`.
-1. `test-core` and `test-pypy`
+1. `test-core`
 
-Where the first ones have the same environments except for different Python versions. `test-core` only has a core set of dependencies, and `test-pypy` is for testing on PyPy.
-
+Where the first ones have the same environments except for different Python versions. `test-core` only has a core set of dependencies.
 If you haven't set the environment flag in the command, a menu will help you select which one of the environments to use.
 
 ### Example tests
@@ -150,7 +149,7 @@ Example tests can be run with the following command:
 pixi run test-example
 ```
 
-This task has the same environments as the unit tests except for `test-core` and `test-pypy`.
+This task has the same environments as the unit tests except for `test-core`.
 
 ## Documentation
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,7 +16,6 @@ test-311 = ["py311", "test-core", "test", "example", "test-example"]
 test-312 = ["py312", "test-core", "test", "example", "test-example"]
 test-313 = ["py313", "test-core", "test", "example", "test-example"]
 test-core = ["py313", "test-core"]
-test-pypy = ["pypy", "test-core", "test-pypy"]
 docs = ["py311", "example", "doc"]
 build = ["py311", "build"]
 lint = ["py311", "lint"]
@@ -45,12 +44,6 @@ python = "3.13.*"
 
 [feature.py313.activation.env]
 COVERAGE_CORE = "sysmon"
-
-[feature.pypy]
-platforms = ["linux-64", "osx-64", "win-64"] # not supported for osx-arm64
-
-[feature.pypy.dependencies]
-pypy = "7.3.*"
 
 [feature.example.dependencies]
 aiohttp = "*"
@@ -82,17 +75,6 @@ pyarrow = "*"
 pytables = "*"
 xlrd = "*"
 gmpy2 = "*"
-
-[feature.test-pypy.dependencies]
-cloudpickle = "*"
-ipython = "*"
-jsonschema = "*"
-nest-asyncio = "*"
-numpy = "*"
-odfpy = "*"
-openpyxl = "*"
-pandas = "*"
-xlrd = "*"
 
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax doc'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,10 @@ tests-pypy = [
     "jsonschema",
     "nest-asyncio",
     "numpy",
-    "odfpy",
-    "openpyxl",
-    "pandas",
-    "xlrd",
+    # "odfpy",
+    # "openpyxl",
+    # "pandas",
+    # "xlrd",
 ]
 tests-full = [
     "param[tests]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ examples = [
 tests = [
     "pytest",
     "pytest-asyncio",
+    "pytest-cov",
 ]
 tests-deser = [
     "xlrd",
@@ -56,6 +57,17 @@ tests-examples = [
     "pytest-xdist",
     "nbval",
     "param[examples]",
+]
+tests-pypy = [
+    "cloudpickle",
+    "ipython",
+    "jsonschema",
+    "nest-asyncio",
+    "numpy",
+    "odfpy",
+    "openpyxl",
+    "pandas",
+    "xlrd",
 ]
 tests-full = [
     "param[tests]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ tests-examples = [
     "nbval",
     "param[examples]",
 ]
+# Set of dependencies that work with pypy and are quick to install.
 tests-pypy = [
     "cloudpickle",
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,6 @@ tests-pypy = [
     "jsonschema",
     "nest-asyncio",
     "numpy",
-    # "odfpy",
-    # "openpyxl",
-    # "pandas",
-    # "xlrd",
 ]
 tests-full = [
     "param[tests]",


### PR DESCRIPTION
Closes https://github.com/holoviz/param/issues/1028

EDIT:

Ok the CI is green now. I've removed a few dependencies we used to run the PyPy tests with (e.g. pandas) as they were slow to build (7-10 minutes).