### PR TITLE
Better error when calling len() on a reactive expression

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1939,6 +1939,19 @@ class rx:
         for i in range(len(self._current)):
             yield items[i]
 
+    def __bool__(self):
+        # Implemented otherwise truth value testing (e.g. if rx: ...)
+        # defers to __len__ which raises an error.
+        return True
+
+    def __len__(self):
+        raise TypeError(
+            'len(<rx_obj>) is not supported. Use `<rx_obj>.rx.len()` to '
+            'obtain the length as a reactive expression, or '
+            '`len(<rx_obj>.rx.value)` to obtain the length of the underlying '
+            'expression value.'
+        )
+
     def _eval_operation(self, obj, operation):
         fn, args, kwargs = operation['fn'], operation['args'], operation['kwargs']
         resolved_args = []

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -2,6 +2,7 @@ import asyncio
 import math
 import operator
 import os
+import re
 import unittest
 import time
 
@@ -767,3 +768,20 @@ def test_reactive_callback_resolve_accessor():
     dfx = rx(df)
     out = dfx["name"].str._callback()
     assert out is df["name"].str
+
+
+def test_reactive_dunder_len_error():
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            'len(<rx_obj>) is not supported. Use `<rx_obj>.rx.len()` to '
+            'obtain the length as a reactive expression, or '
+            '`len(<rx_obj>.rx.value)` to obtain the length of the underlying '
+            'value.'
+        )
+    ):
+        len(rx([1, 2]))
+
+
+def test_reactive_dunder_bool():
+    assert bool(rx([1, 2]))

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -292,7 +292,7 @@ def test_reactive_len():
     l = i.rx.len()
     assert l.rx.value == 3
     i.rx.value = [1, 2]
-    assert l == 2
+    assert l.rx.value == 2
 
 def test_reactive_bool():
     i = rx(1)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -777,7 +777,7 @@ def test_reactive_dunder_len_error():
             'len(<rx_obj>) is not supported. Use `<rx_obj>.rx.len()` to '
             'obtain the length as a reactive expression, or '
             '`len(<rx_obj>.rx.value)` to obtain the length of the underlying '
-            'value.'
+            'expression value.'
         )
     ):
         len(rx([1, 2]))


### PR DESCRIPTION
Closes https://github.com/holoviz/param/issues/954

The suggestion in the issue was:

> I believe we can't implement `__len__` reactively, but can't we provide a better error message in this case? E.g. it seems like we could print a warning saying that the value returned won't be reactive (and what to do instead (`.rx.len()`), and then return the non-reactive length.

I am not in favor of emitting a warning and returning the non-reactive length as this sets a bit of a weird precedent (we could do the same for other parts of the Python data model we can't proxy). Instead with this PR a `TypeError` is raised with a more explicit message. Note that if in the future we decide to warn and return the non-reactive length, that PR makes it still possible.

```
TypeError: len(<rx_obj>) is not supported. Use `<rx_obj>.rx.len()` to obtain
the length as a reactive expression, or `len(<rx_obj>.rx.value)` to obtain the
length of the underlying expression value.
```

After implementing that, this test started to fail:

```python
def test_reactive_len():
    i = rx([1, 2, 3])
    l = i.rx.len()
    assert l.rx.value == 3
    i.rx.value = [1, 2]
    assert l == 2
```

It turns out that:

1. it was buggy, the last assert should have been `assert l.rx.value == 2`. `l == 2` returns a reactive expression that is truthy
2. [truth value testing](https://docs.python.org/3/library/stdtypes.html#truth-value-testing) checks for `__bool__` first and `__len__` second. Since `rx` did not implement `__bool__` and this PR added `__len__` with a TypeError, calling `bool(<rx_obj>)` (or `if <rx_obj>: ...`) started to emit an error.

This PR resolves that by:
1. Fixing the test
2. Implementing `rx.__bool__` that always returns `True` like it used to before the PR.