### PR TITLE
Update Parameters.ipynb to add missing word.

### DIFF
--- a/doc/user_guide/Parameters.ipynb
+++ b/doc/user_guide/Parameters.ipynb
@@ -909,7 +909,7 @@
     "Param allows you to create Parameterized objects by inheriting from the `Parameterized` base class. Param has evolved over time to reduce its footprint and reserve as few as possible attributes on this namespace, to reduce the risk of name clashes and allow you to freely define your attribute names. Param reserves a few names that are described below, make sure not to override, unless it is stated it is allowed:\n",
     "\n",
     "- Public attributes:\n",
-    "    - `name`: Parameterized classes and instances have a name `String` Parameter, that by default is set to the class name when accessed from the class and to the class name appended with a 5 digit when accessed from the instance. You can override this Parameter by your own `String` Parameter if you need to.\n",
+    "    - `name`: Parameterized classes and instances have a name `String` Parameter, that by default is set to the class name when accessed from the class and to the class name appended with a 5 digit number, starting at 00000, when accessed from the instance. You can override this Parameter by your own `String` Parameter if you need to.\n",
     "    - `param`: Property that helps keep the Parameterized namespace clean and disambiguate between Parameter objects and parameter values, it gives access to a namespace that offers various methods (see the section below) to update and inspect the Parameterized object at hand.\n",
     "- Private attributes:\n",
     "    - `_param__parameters`: Store the object returned by `.param` on the class\n",


### PR DESCRIPTION
Added a missing word, and added that the numbering in name starts at 00000 for instances. If there is a reference known to the source code / lines where this is defined, I will add it to the doc.