### PR TITLE
perf: Improve import time by lazy import "slow" modules

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import collections
 import contextvars
 import datetime as dt
@@ -254,12 +253,15 @@ def iscoroutinefunction(function):
 
 async def _to_thread(func, /, *args, **kwargs):
     """Polyfill for asyncio.to_thread in Python < 3.9."""
+    import asyncio
     loop = asyncio.get_running_loop()
     ctx = contextvars.copy_context()
     func_call = functools.partial(ctx.run, func, *args, **kwargs)
     return await loop.run_in_executor(None, func_call)
 
 async def _to_async_gen(sync_gen):
+    import asyncio
+
     done = object()
 
     def safe_next():
@@ -671,6 +673,7 @@ def _in_ipython():
 _running_tasks = set()
 
 def async_executor(func):
+    import asyncio
     try:
         event_loop = asyncio.get_running_loop()
     except RuntimeError:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -8,7 +8,6 @@ either alone (providing basic Parameter support) or with param's
 __init__.py (providing specialized Parameter types).
 """
 
-import asyncio
 import copy
 import datetime as dt
 import html
@@ -2198,6 +2197,7 @@ class Parameters:
             async_executor(partial(self_._async_ref, pname, awaitable))
             return
 
+        import asyncio
         current_task = asyncio.current_task()
         running_task = self_.self._param__private.async_refs.get(pname)
         if running_task is None:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -10,9 +10,7 @@ __init__.py (providing specialized Parameter types).
 
 import copy
 import datetime as dt
-import html
 import inspect
-import logging
 import numbers
 import operator
 import re
@@ -25,14 +23,18 @@ from inspect import getfullargspec
 from collections import defaultdict, namedtuple, OrderedDict
 from collections.abc import Callable, Iterable
 from functools import partial, wraps, reduce
-from html import escape
 from itertools import chain
 from operator import itemgetter, attrgetter
 from types import FunctionType, MethodType
 from typing import Any, Union, Literal  # When python 3.9 support is dropped replace Union with |
 
 from contextlib import contextmanager
-from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
+CRITICAL = 50
+ERROR = 40
+WARNING = 30
+INFO = 20
+DEBUG = 10
+VERBOSE = INFO - 1
 
 from . import serializer
 from ._utils import (
@@ -81,8 +83,6 @@ def _int_types():
     if np := sys.modules.get("numpy"):
         yield np.integer
 
-VERBOSE = INFO - 1
-logging.addLevelName(VERBOSE, "VERBOSE")
 
 # Get the appropriate logging.Logger instance. If `logger` is None, a
 # logger named `"param"` will be instantiated. If `name` is set, a descendant
@@ -90,7 +90,9 @@ logging.addLevelName(VERBOSE, "VERBOSE")
 # ``logger.name + ".<name>"``)
 logger = None
 def get_logger(name=None):
+    import logging
     if logger is None:
+        logging.addLevelName(VERBOSE, "VERBOSE")
         root_logger = logging.getLogger('param')
         if not root_logger.handlers:
             root_logger.setLevel(logging.INFO)
@@ -4806,12 +4808,14 @@ dbprint_prefix=None
 
 def truncate(str_, maxlen = 30):
     """Return HTML-safe truncated version of given string."""
+    import html
     rep = (str_[:(maxlen-2)] + '..') if (len(str_) > (maxlen-2)) else str_
     return html.escape(rep)
 
 
 def _get_param_repr(key, val, p, vallen=30, doclen=40):
     """HTML representation for a single Parameter object and its value."""
+    import html
     if isinstance(val, Parameterized) or (type(val) is type and issubclass(val, Parameterized)):
         value = val.param._repr_html_(open=False)
     elif hasattr(val, "_repr_html_"):
@@ -4852,7 +4856,7 @@ def _get_param_repr(key, val, p, vallen=30, doclen=40):
     if getattr(p, 'allow_None', False):
         range_ = ' '.join(s for s in ['<i>nullable</i>', range_] if s)
 
-    tooltip = f' class="param-doc-tooltip" data-tooltip="{escape(p.doc.strip())}"' if p.doc else ''
+    tooltip = f' class="param-doc-tooltip" data-tooltip="{html.escape(p.doc.strip())}"' if p.doc else ''
 
     return (
         f'<tr>'

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -88,7 +88,6 @@ powerful and intuitive way to manage dynamic behavior in Python applications.
 """
 from __future__ import annotations
 
-import asyncio
 import inspect
 import math
 import operator
@@ -569,6 +568,7 @@ class reactive_ops:
                 "or coroutine functions are permitted."
             )
         if inspect.iscoroutinefunction(func):
+            import asyncio
             async def apply(vs, *args, **kwargs):
                 return list(await asyncio.gather(*(func(v, *args, **kwargs) for v in vs)))
         else:
@@ -1622,6 +1622,7 @@ class rx:
         self._error_state = None
 
     async def _resolve_async(self, obj):
+        import asyncio
         self._current_task = task = asyncio.current_task()
         if inspect.isasyncgen(obj):
             async for val in obj:

--- a/tests/testimports.py
+++ b/tests/testimports.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 def test_no_blocklist_imports():
     check = """\
     import sys
+    sys.modules.pop("logging", None)  # Added because of coverage will add it
     import param
 
     blocklist = {"numpy", "IPython", "pandas", "asyncio", "html", "logging"}

--- a/tests/testimports.py
+++ b/tests/testimports.py
@@ -8,7 +8,7 @@ def test_no_blocklist_imports():
     import sys
     import param
 
-    blocklist = {"numpy", "IPython", "pandas"}
+    blocklist = {"numpy", "IPython", "pandas", "asyncio"}
     mods = blocklist & set(sys.modules)
 
     if mods:

--- a/tests/testimports.py
+++ b/tests/testimports.py
@@ -8,7 +8,7 @@ def test_no_blocklist_imports():
     import sys
     import param
 
-    blocklist = {"numpy", "IPython", "pandas", "asyncio"}
+    blocklist = {"numpy", "IPython", "pandas", "asyncio", "html", "logging"}
     mods = blocklist & set(sys.modules)
 
     if mods:


### PR DESCRIPTION
This PR improves the import time by postponing the import of `asyncio`, `logging`, and `html`. And also not updating signatures if not inside a IPython environment. 

# Import time + tuna
Generated with `python -X importtime -c 'import param' 2> tuna.log && tuna tuna.log`. Some notes only focus on the param and ignore the `param.version` time; also, the measurement is not exact (see hyperfine) and needs warmup time after a branch change. 

Main (https://github.com/holoviz/param/commit/9ff6a9f9c7c36cf2e760f18807d7c538bb42e255):
![Screenshot 2025-02-24 at 12-23-58 tuna - tuna log](https://github.com/user-attachments/assets/f27da201-a2fa-4b4e-a3fd-9846ea188a35)

After removing asyncio (https://github.com/holoviz/param/pull/1037/commits/5a63a9e5f5027f31a10a6f2e7ef40485ec1720b5):
![Screenshot 2025-02-24 at 12-28-03 tuna - tuna log](https://github.com/user-attachments/assets/461bbdba-75c1-4a68-8b38-7fd1ad3a288b)

`+` After removing logging and HTML (https://github.com/holoviz/param/pull/1037/commits/3d4885b4a30b8dfb3689a56421fbf510087e4752)
![image](https://github.com/user-attachments/assets/c4cb3b62-7602-4983-aaa7-5fb3d390da17)

`+` Without updating signature in `__init_submodules__` (https://github.com/holoviz/param/pull/1037/commits/30180b86a716d6f17ec72d7bf3a8516174f04cc5):
![image](https://github.com/user-attachments/assets/1dcafbcf-a73a-4474-9328-6220b38c49dd)
 
# Pyinstrument
Also used pyinstrument with `pyinstrument -r html example.py` where example.py is `import param` 

Main (9ff6a9f)
![image](https://github.com/user-attachments/assets/f343d25c-e830-47cd-aaf3-211a06c5501a)


This PR (https://github.com/holoviz/param/pull/1037/commits/30180b86a716d6f17ec72d7bf3a8516174f04cc5):
![image](https://github.com/user-attachments/assets/2c9807b3-fa19-427b-a9dd-b8695c1aaaa6)
 
# hyperfine

Main (https://github.com/holoviz/param/commit/9ff6a9f9c7c36cf2e760f18807d7c538bb42e255)
``` bash
❯ hyperfine "python -c ''" "python -c 'import param'" --warmup 5
Benchmark 1: python -c ''
  Time (mean ± σ):      15.9 ms ±   0.6 ms    [User: 11.8 ms, System: 3.9 ms]
  Range (min … max):    14.4 ms …  17.6 ms    180 runs

Benchmark 2: python -c 'import param'
  Time (mean ± σ):      57.9 ms ±   1.2 ms    [User: 47.5 ms, System: 9.9 ms]
  Range (min … max):    56.0 ms …  61.2 ms    50 runs

Summary
  python -c '' ran
    3.65 ± 0.16 times faster than python -c 'import param'

```

This PR (https://github.com/holoviz/param/pull/1037/commits/30180b86a716d6f17ec72d7bf3a8516174f04cc5):
``` bash
❯ hyperfine "python -c ''" "python -c 'import param'" --warmup 5
Benchmark 1: python -c ''
  Time (mean ± σ):      15.8 ms ±   0.6 ms    [User: 11.7 ms, System: 4.0 ms]
  Range (min … max):    14.4 ms …  17.6 ms    187 runs

Benchmark 2: python -c 'import param'
  Time (mean ± σ):      37.1 ms ±   0.9 ms    [User: 29.8 ms, System: 7.0 ms]
  Range (min … max):    35.4 ms …  39.2 ms    79 runs

Summary
  python -c '' ran
    2.35 ± 0.11 times faster than python -c 'import param'
```
