### PR TITLE
Ensure type checkers skip ParameterizedFunction.__init__

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -5464,7 +5464,7 @@ class ParameterizedFunction(Parameterized):
         else:                 inst.__name__ = self_or_cls.name
         return inst
 
-    def __new__(class_,*args,**params):
+    def __new__(class_,*args,**params) -> Any:
         # Create and __call__() an instance of this class.
         inst = class_.instance()
         inst.param._set_name(class_.__name__)


### PR DESCRIPTION
`ParameterizedFunction.__new__` returns an instance that is not a subclass of `ParameterizedFunction` but whatever `__call__` returns. This means that the run time will not call `ParameterizedFunction.__init__` (that's how Python works). Annotating `__new__` with `Any` is the way to let type checkers know about this, so this PR implements that.

Pyright had a bug around this that got fixed with the latest release 1.1.395, more info https://github.com/microsoft/pyright/issues/9909. I've tested the example shared in https://github.com/holoviz/param/pull/1021 with the latest Pyright and this PR and it worked fine.