### PR TITLE
Update Parameter_Types.ipynb to fix a 404 (2nd iteration)

### DIFF
--- a/doc/user_guide/Parameter_Types.ipynb
+++ b/doc/user_guide/Parameter_Types.ipynb
@@ -52,7 +52,7 @@
    "id": "e9787a67",
    "metadata": {},
    "source": [
-    "The full behavior of these types is covered in the [Param API Reference Manual](https://param.holoviz.org/reference.html#param-module). Here we will discuss the major categories of Parameter type and how to use them, including examples of what each type does _not_ allow (labeled `with param.exceptions_summarized():`).  Each of these classes is also suitable for subclassing to create more specialized types enforcing your own specific constraints.  After reading about Parameters in general, feel free to skip around in this page and only look at the Parameter types of interest to you!"
+    "The full behavior of these types is covered in the [Param API Reference Manual](https://param.holoviz.org/reference/param/index.html#parameters). Here we will discuss the major categories of Parameter type and how to use them, including examples of what each type does _not_ allow (labeled `with param.exceptions_summarized():`).  Each of these classes is also suitable for subclassing to create more specialized types enforcing your own specific constraints.  After reading about Parameters in general, feel free to skip around in this page and only look at the Parameter types of interest to you!"
    ]
   },
   {


### PR DESCRIPTION
The 404 URL was not updated in the previous PR: https://github.com/holoviz/param/pull/1052



This PR changes the 404 URL:

https://param.holoviz.org/reference.html#param-module

To:

https://param.holoviz.org/reference/param/index.html#parameters

https://github.com/holoviz/param/issues/1051