### PR TITLE
Fix `.values()/get_value_generator()` when

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -3282,6 +3282,8 @@ class Parameters:
             if isinstance(cls_or_slf, Parameterized) and name in cls_or_slf._param__private.values:
                 # dealing with object and it's been set on this object
                 value = cls_or_slf._param__private.values[name]
+            elif not callable(param_obj.default):
+                value = getattr(cls_or_slf, name)
             else:
                 # dealing with class or isn't set on the object
                 value = param_obj.default

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -553,6 +553,14 @@ class TestParameterized(unittest.TestCase):
         # name not ignored when set
         assert param.Parameterized(name='foo').param.values(onlychanged=True)['name'] == 'foo'
 
+    def test_values_dyn(self):
+        # See https://github.com/holoviz/param/issues/1057
+        t = TestPO()
+        orig_default = t.param.dyn.default
+        t.param.dyn.default = 3290432424
+        values = t.param.values()
+        assert values['dyn'] == orig_default
+
     def test_param_iterator(self):
         self.assertEqual(set(TestPO.param), {'name', 'inst', 'notinst', 'const', 'dyn',
                                              'ro', 'ro2', 'ro_label', 'ro_format'})
@@ -670,6 +678,14 @@ class TestParameterized(unittest.TestCase):
         assert t.param.inspect_value('dyn')!=orig
         t.param._state_pop()
         assert t.param.inspect_value('dyn')==orig
+
+    def test_get_value_generator_dyn(self):
+        # See https://github.com/holoviz/param/issues/1057
+        t = TestPO()
+        orig_default = t.param.dyn.default
+        t.param.dyn.default = 9594323423
+        vg = t.param.get_value_generator('dyn')
+        assert vg == orig_default
 
     def test_label(self):
         t = TestPO()


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/1057

`.param.values()` uses `.param.get_value_generator()` under the hood (this looks all overly complicated by that's another issue) to obtain the value of a Parameter. `get_value_generator()` seems to be designed to deal specifically with Dynamic Parameters (like `Integer`, `Number`, etc.), to return the generator callable. So in cases where there's no generator, we simply return the value.