### PR TITLE
Allow depends(..., on_init=True) to be applied to async method

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2295,7 +2295,10 @@ class Parameters:
                 watcher = self_._watch_group(obj, method, queued, group, attribute)
                 obj._param__private.dynamic_watchers[method].append(watcher)
         for m in init_methods:
-            m()
+            if iscoroutinefunction(m):
+                async_executor(m)
+            else:
+                m()
 
     def _resolve_dynamic_deps(self, obj, dynamic_dep, param_dep, attribute):
         """

--- a/tests/testparamdepends.py
+++ b/tests/testparamdepends.py
@@ -268,6 +268,25 @@ class TestParamDepends:
         a.a = True
         assert a.value == 2
 
+    async def test_param_depends_async_on_init(self):
+        class A(param.Parameterized):
+
+            a = param.Parameter()
+
+            value = param.Integer()
+
+            @param.depends('a', watch=True, on_init=True)
+            async def callback(self):
+                self.value += 1
+
+        a = A()
+        await asyncio.sleep(0.01)
+        assert a.value == 1
+
+        a.a = True
+        await asyncio.sleep(0.01)
+        assert a.value == 2
+
     def test_param_nested_depends_value_unchanged(self):
         class A(param.Parameterized):
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/param/issues/782

This was an oversight and should have always been supported.