### PR TITLE
reactive: fix typo/bug in reactive_ops.__call__

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -230,7 +230,7 @@ class reactive_ops:
     def __call__(self) -> 'rx':
         """Create a reactive expression."""
         rxi = self._reactive
-        return rxi if isinstance(rx, rx) else rx(rxi)
+        return rxi if isinstance(rxi, rx) else rx(rxi)
 
     def and_(self, other) -> 'rx':
         """


### PR DESCRIPTION
Hi,

I'm new to param/panel, I encountered some strange behaviours while building my first panel application and while trying to read the code to better understand what was going on, I stumbled upon what seems like a typo/bug in `reactive_ops.__call__`.

I have very little context, so I could be missing something important, but `isinstance(x, x)` sort of smells.

Hope this helps.