### PR TITLE
Remove bad abstract declaration on SelectorBase

### DIFF
--- a/param/parameters.py
+++ b/param/parameters.py
@@ -1565,8 +1565,6 @@ class SelectorBase(Parameter):
     Subclasses must implement get_range().
     """
 
-    __abstract = True
-
     def get_range(self):
         raise NotImplementedError("get_range() must be implemented in subclasses.")
 


### PR DESCRIPTION
Resolves https://github.com/holoviz/param/issues/519

`SelectorBase` is a base class but setting `__abstract = True` on a non-Parameterized class has no effect at all and will be ignored by `descendents/concrete_descendents`. The right fix, one day (if it doesn't slow down too much class creation), would be to turn `SelectorBase` into an abc.