### PR TITLE
Remove warning emitted by concrete_descendents

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -9,7 +9,7 @@ import os
 import re
 import traceback
 import warnings
-from collections import Counter, OrderedDict, abc, defaultdict
+from collections import OrderedDict, abc, defaultdict
 from contextlib import contextmanager
 from numbers import Real
 from textwrap import dedent
@@ -498,25 +498,29 @@ def concrete_descendents(parentclass: type) -> dict[str, type]:
 
     Only non-abstract classes will be included.
 
-    Warns
-    -----
-    ParamWarning
-        ``concrete_descendents`` overrides descendents that share the same
-        class name. To avoid this, use :func:`descendents` with ``concrete=True``.
+    .. warning::
+       ``concrete_descendents`` overrides descendents that share the same
+       class name. To avoid this, use :func:`descendents` with ``concrete=True``.
     """
+    # Warns
+    # -----
+    # ParamWarning
+    #     ``concrete_descendents`` overrides descendents that share the same
+    #     class name. To avoid this, use :func:`descendents` with ``concrete=True``.
+
     desc = descendents(parentclass, concrete=True)
     concrete_desc = {c.__name__: c for c in desc}
     # Descendents with the same name are clobbered.
-    if len(desc) != len(concrete_desc):
-        class_count = Counter([kls.__name__ for kls in desc])
-        clobbered = [kls for kls, count in class_count.items() if count > 1]
-        warnings.warn(
-            '`concrete_descendents` overrides descendents that share the same '
-            'class name. Other descendents with the same name as the following '
-            f'classes exist but were not returned: {clobbered!r}\n'
-            'Use `descendents(parentclass, concrete=True)` instead.',
-            ParamWarning,
-        )
+    # if len(desc) != len(concrete_desc):
+    #     class_count = Counter([kls.__name__ for kls in desc])
+    #     clobbered = [kls for kls, count in class_count.items() if count > 1]
+    #     warnings.warn(
+    #         '`concrete_descendents` overrides descendents that share the same '
+    #         'class name. Other descendents with the same name as the following '
+    #         f'classes exist but were not returned: {clobbered!r}\n'
+    #         'Use `descendents(parentclass, concrete=True)` instead.',
+    #         ParamWarning,
+    #     )
     return concrete_desc
 
 

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -683,8 +683,8 @@ class Number(Dynamic):
     def __get__(self, obj, objtype):
         """Retrieve the value of the attribute, checking bounds if dynamically generated.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         obj: Parameterized | None
             The instance the attribute is accessed on, or `None` for class access.
         objtype: type[Parameterized]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -10,7 +10,7 @@ import pytest
 from param import guess_param_types, resolve_path
 from param.parameterized import bothmethod, Parameterized, ParameterizedABC
 from param._utils import (
-    ParamWarning,
+    # ParamWarning,
     _is_abstract,
     _is_mutable_container,
     concrete_descendents,
@@ -547,15 +547,15 @@ def test_concrete_descendents():
     }
 
 
-def test_concrete_descendents_same_name_warns():
-    class X: pass
-    class Y(X): pass
-    y = Y  # noqa
-    class Y(X): pass
-    with pytest.warns(
-        ParamWarning,
-        match=r".*\['Y'\]"
-    ):
-        cd = concrete_descendents(X)
-    # y not returned
-    assert cd == {'X': X, 'Y': Y}
+# def test_concrete_descendents_same_name_warns():
+#     class X: pass
+#     class Y(X): pass
+#     y = Y  # noqa
+#     class Y(X): pass
+#     with pytest.warns(
+#         ParamWarning,
+#         match=r".*\['Y'\]"
+#     ):
+#         cd = concrete_descendents(X)
+#     # y not returned
+#     assert cd == {'X': X, 'Y': Y}


### PR DESCRIPTION
Found out that `concrete_descendents` is used in more places than I expected, and that in these places it would sometimes emit the warning due to the name clobbering (which I didn't expect at all). We'll have to fix this differently in these places, maybe simply copy/pasting the good code from `descendents`.