### PR TITLE
Remove Parameterized `__init__` docstring as it shadows class user docstrings

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -5348,6 +5348,15 @@ class Parameterized(metaclass=ParameterizedMetaclass):
     This makes it well-suited for robust, maintainable code bases and
     particularly useful in interactive applications requiring reactive behavior.
 
+    To construct an instance, optional Parameter values must be supplied as
+    keyword arguments (``param_name=value``), overriding their default values
+    for this one instance. Any parameters not explicitly set will retain their
+    defined default values.
+
+    If no ``name`` parameter is provided, the instance's ``name`` attribute will
+    default to an identifier string composed of the class name followed by
+    an incremental 5-digit number.
+
     Attributes
     ----------
     name : str
@@ -5411,6 +5420,9 @@ class Parameterized(metaclass=ParameterizedMetaclass):
         plus a unique integer""")
 
     def __init__(self, **params):
+        # No __init__ docstring to avoid shadowing the user class docstring
+        # displayed in IDEs.
+
         global object_count
 
         # Setting a Parameter value in an __init__ block before calling


### PR DESCRIPTION
A docstring was added to `Parameterized.__init__` in https://github.com/holoviz/param/pull/998/commits/b66a846ca330a52ebb3d6bce7ad1e8c7c275d024. This caused some issues in VSCode, which would now display that docstring instead of user-defined class docstrings (what Panel components typically define). @MarcSkovMadsen initially reported it in this issue against Pylance https://github.com/microsoft/pylance-release/issues/7793.

This PR simply removes the `Parameterized.__init__` docstring, adding some of its content to the class docstring.