### PR TITLE
 fix: `param.depends` method call in class

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,7 +134,7 @@ jobs:
         run: |
           pixi run -e ${{ matrix.environment }} test-unit
 
-  typecheck:
+  type_suite:
     name: type:ubuntu-latest
     needs: [pre_commit, pixi_lock]
     runs-on: ubuntu-latest
@@ -142,23 +142,23 @@ jobs:
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
-          environments: typecheck
+          environments: type
       - name: TY
         id: ty
         continue-on-error: true
-        run: pixi run -e typecheck type-ty
+        run: pixi run -e type type-ty
       - name: mypy
         id: mypy
         continue-on-error: true
-        run: pixi run -e typecheck type-mypy
+        run: pixi run -e type type-mypy
       - name: Pyrefly
         id: pyrefly
         continue-on-error: true
-        run: pixi run -e typecheck type-pyrefly
+        run: pixi run -e type type-pyrefly
       - name: Pyright
         id: pyright
         continue-on-error: true
-        run: pixi run -e typecheck type-pyright
+        run: pixi run -e type type-pyright
       - name: Error if any check failed
         if: steps.ty.outcome != 'success' || steps.mypy.outcome != 'success' || steps.pyrefly.outcome != 'success' || steps.pyright.outcome != 'success'
         run: |
@@ -209,7 +209,7 @@ jobs:
 
   result_test_suite:
     name: result:test
-    needs: [unit_test_suite, core_test_suite, pypy_test_suite, typecheck]
+    needs: [unit_test_suite, core_test_suite, pypy_test_suite, type_suite]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/param/depends.py
+++ b/param/depends.py
@@ -15,11 +15,12 @@ if t.TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable, Generator
 
     _Y = t.TypeVar("_Y")
-    _S = t.TypeVar("_S")
     _T = t.TypeVar("_T")
 
 _P = t.ParamSpec("_P")
+_FullP = t.ParamSpec("_FullP")
 _R = t.TypeVar("_R", covariant=True)
+_S = t.TypeVar("_S")
 Dependency = Parameter | str
 
 class DependencyInfo(t.TypedDict):
@@ -28,6 +29,10 @@ class DependencyInfo(t.TypedDict):
     watch: bool
     on_init: bool
 
+class _DepsFn(t.Protocol[_FullP, _R]):
+    _dinfo: DependencyInfo
+    def __call__(self, *args: _FullP.args, **kwargs: _FullP.kwargs) -> _R: ...
+
 class DependsFunc(t.Protocol[_P, _R]):
     _dinfo: DependencyInfo
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
@@ -35,25 +40,25 @@ class DependsFunc(t.Protocol[_P, _R]):
 
 @t.overload
 def depends(
-    func: Callable[_P, _R], /, *dependencies: Dependency, watch: bool = False, on_init: bool = False, **kw: Dependency
+    func: Callable[t.Concatenate[_S, _P], _R], /, *dependencies: Dependency, watch: bool = False, on_init: bool = False, **kw: Dependency
 ) -> DependsFunc[_P, _R]:
     ...
 
 @t.overload
 def depends(
     *dependencies: str, watch: bool = False, on_init: bool = False
-) -> Callable[[Callable[_P, _R]], DependsFunc[_P, _R]]:
+) -> Callable[[Callable[t.Concatenate[_S, _P], _R]], DependsFunc[_P, _R]]:
     ...
 
 @t.overload
 def depends(
     *dependencies: Parameter, watch: bool = False, on_init: bool = False, **kw: Parameter
-) -> Callable[[Callable[_P, _R]], DependsFunc[_P, _R]]:
+) -> Callable[[Callable[t.Concatenate[_S, _P], _R]], DependsFunc[_P, _R]]:
     ...
 
 def depends(
-    *dependencies: Dependency | Callable[_P, _R], watch: bool = False, on_init: bool = False, **kw: Dependency
-) -> DependsFunc[_P, _R] | Callable[[Callable[_P, _R]], DependsFunc[_P, _R]]:
+    *dependencies: Dependency | Callable[t.Concatenate[_S, _P], _R], watch: bool = False, on_init: bool = False, **kw: Dependency
+) -> DependsFunc[_P, _R] | Callable[[Callable[t.Concatenate[_S, _P], _R]], DependsFunc[_P, _R]]:
     """
     Annotates a function or :class:`Parameterized` method to express its dependencies.
 
@@ -74,51 +79,51 @@ def depends(
 
     """
     if dependencies and callable(dependencies[0]) and not isinstance(dependencies[0], (str, Parameter)):
-        func = t.cast("Callable[_P, _R]", dependencies[0])
+        func = t.cast("Callable[t.Concatenate[_S, _P], _R]", dependencies[0])
         deps = t.cast("tuple[Dependency, ...]", dependencies[1:])
-        return _depends_impl(func, *deps, watch=watch, on_init=on_init, **kw)
+        return t.cast("DependsFunc[_P, _R]", _depends_impl(func, *deps, watch=watch, on_init=on_init, **kw))
 
     deps = t.cast("tuple[Dependency, ...]", dependencies)
 
-    def _decorator(func: Callable[_P, _R]) -> DependsFunc[_P, _R]:
-        return _depends_impl(func, *deps, watch=watch, on_init=on_init, **kw)
+    def _decorator(func: Callable[t.Concatenate[_S, _P], _R]) -> DependsFunc[_P, _R]:
+        return t.cast("DependsFunc[_P, _R]", _depends_impl(func, *deps, watch=watch, on_init=on_init, **kw))
 
     return _decorator
 
 
 def _depends_impl(
-    func: Callable[_P, _R], /, *dependencies: Dependency, watch: bool = False, on_init: bool = False, **kw: Dependency
-) -> DependsFunc[_P, _R]:
+    func: Callable[_FullP, _R], /, *dependencies: Dependency, watch: bool = False, on_init: bool = False, **kw: Dependency
+) -> _DepsFn[_FullP, _R]:
     dependencies, kw = (
         tuple(transform_reference(arg) for arg in dependencies),
         {key: transform_reference(arg) for key, arg in kw.items()}
     )
 
     if inspect.isgeneratorfunction(func):
-        func_gen = t.cast("Callable[_P, Generator[t.Any, t.Any, t.Any]]", func)
+        func_gen = t.cast("Callable[_FullP, Generator[t.Any, t.Any, t.Any]]", func)
         @wraps(func)
         def _depends_gen(*args, **kw):
             for val in func_gen(*args, **kw):
                 yield val
-        _depends = t.cast("Callable[_P, _R]", _depends_gen)
+        _depends = t.cast("Callable[_FullP, _R]", _depends_gen)
     elif inspect.isasyncgenfunction(func):
-        func_agen = t.cast("Callable[_P, AsyncGenerator[t.Any, t.Any]]", func)
+        func_agen = t.cast("Callable[_FullP, AsyncGenerator[t.Any, t.Any]]", func)
         @wraps(func)
         async def _depends_async_gen(*args, **kw):
             async for val in func_agen(*args, **kw):
                 yield val
-        _depends = t.cast("Callable[_P, _R]", _depends_async_gen)
+        _depends = t.cast("Callable[_FullP, _R]", _depends_async_gen)
     elif iscoroutinefunction(func):
-        F = t.cast("Callable[_P, t.Awaitable[_R]]", func)
+        F = t.cast("Callable[_FullP, t.Awaitable[_R]]", func)
         @wraps(func)
         async def _depends_coro(*args, **kw):
             return await F(*args, **kw)
-        _depends = t.cast("Callable[_P, _R]", _depends_coro)
+        _depends = t.cast("Callable[_FullP, _R]", _depends_coro)
     else:
         @wraps(func)
         def _depends_sync(*args, **kw):
             return func(*args, **kw)
-        _depends = t.cast("Callable[_P, _R]", _depends_sync)
+        _depends = t.cast("Callable[_FullP, _R]", _depends_sync)
 
     deps = list(dependencies)+list(kw.values())
     string_specs = False
@@ -155,7 +160,7 @@ def _depends_impl(
     _dinfo.update({'dependencies': dependencies,
                    'kw': kw, 'watch': watch, 'on_init': on_init})
 
-    typed_depends = t.cast("DependsFunc[_P, _R]", _depends)
+    typed_depends = t.cast("_DepsFn[_FullP, _R]", _depends)
     typed_depends._dinfo = _dinfo
 
     if string_specs or not watch:
@@ -196,7 +201,7 @@ def _depends_impl(
         def cb_gen(*events: Event):
             args = _resolve_args()
             dep_kwargs = _resolve_kwargs()
-            func_gen = t.cast("Callable[_P, Generator[t.Any, t.Any, t.Any]]", func)
+            func_gen = t.cast("Callable[_FullP, Generator[t.Any, t.Any, t.Any]]", func)
             for val in func_gen(*args, **dep_kwargs):
                 yield val
         cb = cb_gen
@@ -204,7 +209,7 @@ def _depends_impl(
         async def cb_async_gen(*events: Event):
             args = _resolve_args()
             dep_kwargs = _resolve_kwargs()
-            func_agen = t.cast("Callable[_P, AsyncGenerator[t.Any, t.Any]]", func)
+            func_agen = t.cast("Callable[_FullP, AsyncGenerator[t.Any, t.Any]]", func)
             async for val in func_agen(*args, **dep_kwargs):
                 yield val
         cb = cb_async_gen
@@ -212,7 +217,7 @@ def _depends_impl(
         async def cb_coro(*events: Event):
             args = _resolve_args()
             dep_kwargs = _resolve_kwargs()
-            func_coro = t.cast("Callable[_P, t.Awaitable[t.Any]]", func)
+            func_coro = t.cast("Callable[_FullP, t.Awaitable[t.Any]]", func)
             await func_coro(*args, **dep_kwargs)
         cb = cb_coro
     else:

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2586,7 +2586,7 @@ class Selector(SelectorBase, _SignatureSelector[_T]):
         object.__setattr__(self, 'check_on_set', check_on_set)
 
         instantiate = params.pop("instantiate", Undefined)
-        params["instantiate"] = False if instantiate is Undefined else instantiate
+        params["instantiate"] = False if instantiate is Undefined else instantiate  # pyrefly: ignore[bad-typed-dict-key]
         super().__init__(default=default, **params)
         # Required as Parameter sets allow_None=True if default is None
         if allow_None is Undefined:

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,7 +15,7 @@ default = [
     "example",
     "test-example",
     "lint",
-    "typecheck",
+    "type",
     "doc",
     "dev",
 ]
@@ -60,8 +60,8 @@ no-default-feature = true
 features = ["py313", "lint"]
 no-default-feature = true
 
-[environments.typecheck]
-features = ["py313", "required", "typecheck"]
+[environments.type]
+features = ["py313", "required", "type", "type-task"]
 no-default-feature = true
 
 [feature.required.dependencies]
@@ -204,20 +204,29 @@ lint-install = 'pre-commit install'
 # =============================================
 # =============== TYPECHECK ===================
 # =============================================
-[feature.typecheck.dependencies]
+[feature.type.dependencies]
 ty = "*"
 mypy = "*"
 numpy = "*"
 pandas = "*"
-pyrefly = "!=0.60.0"  # https://github.com/facebook/pyrefly/issues/3042
+pyrefly = "*"
 pyright = "*"
 IPython = "*"
 typing_extensions = "*"
 tornado = "*"
 
-[feature.typecheck.tasks]
-type-ty = 'ty check'
-type-mypy = 'mypy'
-type-pyrefly = 'pyrefly check --output-format min-text --count-errors=0'
-type-pyright = 'pyright'
-type-all = { depends-on = ["type-ty", "type-mypy", "type-pyrefly", "type-pyright"] }
+[feature.type-task.tasks]
+type-ty = { cmd = 'ty check {{ file }}', args = [{ arg = "file", default = "" }] }
+type-mypy = { cmd = 'mypy {{ file }}', args = [{ arg = "file", default = "" }] }
+type-pyrefly = { cmd = 'pyrefly check --output-format min-text --count-errors=0 {{ file }}', args = [
+    { arg = "file", default = "" },
+] }
+type-pyright = { cmd = 'pyright {{ file }}', args = [{ arg = "file", default = "" }] }
+type-all = { depends-on = [
+    { task = "type-ty", args = [ { file = "{{ file }}" } ] },
+    { task = "type-mypy", args = [ { file = "{{ file }}" } ] },
+    { task = "type-pyrefly", args = [ { file = "{{ file }}" } ] },
+    { task = "type-pyright", args = [ { file = "{{ file }}" } ] },
+], args = [
+    { arg = "file", default = "" },
+] }


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Fixes the following error seen in HoloViews. Also updating the infrastructure a bit. 

``` python
from __future__ import annotations

import param


class MyClass(param.Parameterized):
    value = param.Parameter(default=None)

    @param.depends("value", watch=True)
    def _on_change(self) -> None:
        pass

    def trigger(self) -> None:
        self._on_change()  # error: missing-argument
```

Pyright gives the following warnings, but I don't see a way to remove them without making other type checkers fail:

```
/home/shh/projects/holoviz/repos/param/param/depends.py
  /home/shh/projects/holoviz/repos/param/param/depends.py:50:39 - warning: TypeVar "_S" appears only once in generic function signature
    Use "object" instead (reportInvalidTypeVarUse)
  /home/shh/projects/holoviz/repos/param/param/depends.py:56:39 - warning: TypeVar "_S" appears only once in generic function signature
    Use "object" instead (reportInvalidTypeVarUse)
```

## How Has This Been Tested?

CI + locally



## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models:  Claude Code + Sonnet 4.6, To apply the type problem.

## Checklist

<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [ ] Added documentation
