### PR TITLE
Ensure untyped List parameter resolves to list[Any]

### DIFF
--- a/param/parameters.py
+++ b/param/parameters.py
@@ -3471,7 +3471,7 @@ class List(Parameter[_T]):
             self: List[list[LT]],
             default: list[LT] = [],
             *,
-            item_type: type[LT] | tuple[type[LT], ...] | None = None,
+            item_type: type[LT] | tuple[type[LT], ...] = None,
             bounds: tuple[int, int | None] | None = (0, None),
             is_instance: bool = True,
             allow_None: t.Literal[False] = False,
@@ -3495,7 +3495,7 @@ class List(Parameter[_T]):
             self: List[list[LT] | None],
             default: list[LT] | None = None,
             *,
-            item_type: type[LT] | tuple[type[LT], ...] | None = None,
+            item_type: type[LT] | tuple[type[LT], ...] = None,
             allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
         ) -> None:

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -3471,7 +3471,7 @@ class List(Parameter[_T]):
             self: List[list[LT]],
             default: list[LT] = [],
             *,
-            item_type: type[LT] | tuple[type[LT], ...] = None,
+            item_type: type[LT] | tuple[type[LT], ...] = (),
             bounds: tuple[int, int | None] | None = (0, None),
             is_instance: bool = True,
             allow_None: t.Literal[False] = False,
@@ -3495,7 +3495,7 @@ class List(Parameter[_T]):
             self: List[list[LT] | None],
             default: list[LT] | None = None,
             *,
-            item_type: type[LT] | tuple[type[LT], ...] = None,
+            item_type: type[LT] | tuple[type[LT], ...] = (),
             allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
         ) -> None:


### PR DESCRIPTION
Some of the overloads were too generic so a `param.List` without an `item_type` did not resolve to `list[Any]` but to the generic `list[LT@__init__]`.