### PR TITLE
Correctly define generics for ClassSelector

### DIFF
--- a/param/parameters.py
+++ b/param/parameters.py
@@ -67,6 +67,7 @@ if t.TYPE_CHECKING:
     from .parameterized import _ParameterKwargs
 
     LT = t.TypeVar("LT")
+    CT = t.TypeVar("CT")
 
     AT = t.TypeVar("AT", np.ndarray, np.ndarray | None)
     DF = t.TypeVar("DF", pd.DataFrame, pd.DataFrame | None)
@@ -2915,10 +2916,10 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self,
+            self: ClassSelector[CT],
             *,
-            default: _T,
-            class_: type[_T] | tuple[type[_T], ...],
+            default: CT,
+            class_: type[CT] | tuple[type[CT], ...],
             is_instance: t.Literal[True] = True,
             allow_None: t.Literal[False] = False,
             doc: str | None = None,
@@ -2938,10 +2939,10 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self,
+            self: ClassSelector[CT | None],
             *,
             default: None = None,
-            class_: type[_T] | tuple[type[_T], ...],
+            class_: type[CT] | tuple[type[CT], ...],
             is_instance: t.Literal[True] = True,
             allow_None: t.Literal[False] = False,
             **kwargs: Unpack[_ParameterKwargs]
@@ -2950,10 +2951,10 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self,
+            self: ClassSelector[CT | None],
             *,
-            default: _T | None = None,
-            class_: type[_T] | tuple[type[_T], ...],
+            default: CT | None = None,
+            class_: type[CT] | tuple[type[CT], ...],
             is_instance: t.Literal[True] = True,
             allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
@@ -2962,10 +2963,10 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self,
+            self: ClassSelector[type[CT]],
             *,
-            default: type[_T],
-            class_: type[_T] | tuple[type[_T], ...],
+            default: type[CT],
+            class_: type[CT] | tuple[type[CT], ...],
             is_instance: t.Literal[False],
             allow_None: t.Literal[False] = False,
             **kwargs: Unpack[_ParameterKwargs]
@@ -2974,10 +2975,10 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self,
+            self: ClassSelector[type[CT] | None],
             *,
             default: None = None,
-            class_: type[_T] | tuple[type[_T], ...],
+            class_: type[CT] | tuple[type[CT], ...],
             is_instance: t.Literal[False],
             allow_None: t.Literal[False] = False,
             **kwargs: Unpack[_ParameterKwargs]
@@ -2986,10 +2987,10 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self,
+            self: ClassSelector[type[CT] | None],
             *,
-            default: type[_T] | None = None,
-            class_: type[_T] | tuple[type[_T], ...],
+            default: type[CT] | None = None,
+            class_: type[CT] | tuple[type[CT], ...],
             is_instance: t.Literal[False],
             allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
@@ -3158,7 +3159,7 @@ class Array(ClassSelector["AT"]):
         import numpy
         super().__init__(  # type: ignore[misc, call-overload]
             default=default,  # type: ignore[arg-type]
-            class_=numpy.ndarray,
+            class_=numpy.ndarray,  # type: ignore[arg-type]
             is_instance=True,
             allow_None=allow_None,  # type: ignore[arg-type]
             **params,  # type: ignore[arg-type]

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2919,7 +2919,7 @@ class ClassSelector(SelectorBase[_T]):
             self: ClassSelector[CT],
             *,
             default: CT,
-            class_: type[CT] | tuple[type[CT], ...],
+            class_: type[CT],
             is_instance: t.Literal[True] = True,
             allow_None: t.Literal[False] = False,
             doc: str | None = None,
@@ -2942,7 +2942,7 @@ class ClassSelector(SelectorBase[_T]):
             self: ClassSelector[CT | None],
             *,
             default: None = None,
-            class_: type[CT] | tuple[type[CT], ...],
+            class_: type[CT],
             is_instance: t.Literal[True] = True,
             allow_None: t.Literal[False] = False,
             **kwargs: Unpack[_ParameterKwargs]
@@ -2954,7 +2954,7 @@ class ClassSelector(SelectorBase[_T]):
             self: ClassSelector[CT | None],
             *,
             default: CT | None = None,
-            class_: type[CT] | tuple[type[CT], ...],
+            class_: type[CT],
             is_instance: t.Literal[True] = True,
             allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
@@ -2963,10 +2963,21 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
+            self: ClassSelector[t.Any],
+            *,
+            default: t.Any = None,
+            class_: tuple[type, ...],
+            is_instance: t.Literal[True] = True,
+            allow_None: t.Literal[False] = False,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None: ...
+
+        @t.overload
+        def __init__(
             self: ClassSelector[type[CT]],
             *,
             default: type[CT],
-            class_: type[CT] | tuple[type[CT], ...],
+            class_: type[CT],
             is_instance: t.Literal[False],
             allow_None: t.Literal[False] = False,
             **kwargs: Unpack[_ParameterKwargs]
@@ -2996,6 +3007,17 @@ class ClassSelector(SelectorBase[_T]):
             **kwargs: Unpack[_ParameterKwargs]
         ) -> None:
             ...
+
+        @t.overload
+        def __init__(
+            self: ClassSelector[t.Any],
+            *,
+            default: t.Any = None,
+            class_: tuple[type, ...],
+            is_instance: t.Literal[False] = False,
+            allow_None: t.Literal[False] = False,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None: ...
 
     def __init__(
         self, *,


### PR DESCRIPTION
This PR correctly defines the generics needed for `ClassSelector` to infer the `allow_None` cases correctly.