### PR TITLE
fix: Update generics for ClassSelector

### DIFF
--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2939,7 +2939,7 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self: ClassSelector[CT | None],
+            self: ClassSelector[CT],
             *,
             default: None = None,
             class_: type[CT],
@@ -2969,6 +2969,17 @@ class ClassSelector(SelectorBase[_T]):
             class_: tuple[type, ...],
             is_instance: t.Literal[True] = True,
             allow_None: t.Literal[False] = False,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None: ...
+
+        @t.overload
+        def __init__(
+            self: ClassSelector[t.Any],
+            *,
+            default: t.Any = None,
+            class_: tuple[type, ...],
+            is_instance: t.Literal[True] = True,
+            allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
         ) -> None: ...
 

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2939,7 +2939,7 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
-            self: ClassSelector[CT],
+            self: ClassSelector[CT | None],
             *,
             default: None = None,
             class_: type[CT],


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Started to see some type failures in HoloViews after #1131 was merged.

There is two changes. I'm not sure about the first one though.

1. Changed `self: ClassSelector[CT | None]` to `self: ClassSelector[CT]`. The `| None` caused ty to fail invariance checking. Using self: ClassSelector[CT] lets ty infer CT directly from class_: type[CT].
2. New overload added: `class_: tuple[type, ...]` with `allow_None=True`, which was missing.


``` python
import param


class MyElement:
    def clone(self, data):
        return self

    def iloc(self, index):
        return self


class Container(param.Parameterized):
    # Error: no-matching-overload
    # All overloads require either `default` or specific combinations.
    # This is valid at runtime but ty can't resolve it.
    element = param.ClassSelector(
        class_=MyElement,
        doc="The element.",
    )

    # Error: no-matching-overload when class_ is a tuple
    multi = param.ClassSelector(
        class_=(list, tuple),
        allow_None=True,
        doc="A list or tuple.",
    )


class User(param.Parameterized):
    container = param.ClassSelector(
        class_=Container,
    )

    def use(self):
        # Error: unresolved-attribute — ty infers `element` as
        # `Unknown | _T@ClassSelector` and doesn't know it has `.clone`
        return self.container.element.clone([])
```


## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Claude + Sonnet 4.6. To create the MRE based on HoloViews examples and then for fixing them in Param.


