### PR TITLE
type: Fix NumericTuple

### DIFF
--- a/param/parameters.py
+++ b/param/parameters.py
@@ -1639,11 +1639,11 @@ class NumericTuple(Tuple[_T]):
 
         @t.overload
         def __init__(
-            self: NumericTuple[tuple[float, ...] | None],
+            self: NumericTuple[tuple[float, ...]],
             default: tuple[float, ...] = (0.0, 0.0),
             *,
             length: int | None = None,
-            allow_None: t.Literal[True] = True,
+            allow_None: t.Literal[False] = False,
             doc: str | None = None,
             label: str | None = None,
             precedence: float | None = None,
@@ -1662,10 +1662,21 @@ class NumericTuple(Tuple[_T]):
         @t.overload
         def __init__(
             self: NumericTuple[tuple[float, ...] | None],
-            default: None = None,
+            default: tuple[float, ...] | None = (0.0, 0.0),
             *,
             length: int | None = None,
-            allow_None: t.Literal[False] = False,
+            allow_None: t.Literal[True] = True,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None:
+            ...
+
+        @t.overload
+        def __init__(
+            self: NumericTuple[tuple[float, ...] | None],
+            default: None,
+            *,
+            length: int | None = None,
+            allow_None: bool = False,
             **kwargs: Unpack[_ParameterKwargs]
         ) -> None:
             ...


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Fixes:

``` python
from __future__ import annotations

import param


class Palette(param.Parameterized):
    range = param.NumericTuple(default=(0, 1))


reveal_type(Palette().range)
```

And if we set range to None:
``` python-traceback
Traceback (most recent call last):
  File "/home/shh/projects/holoviz/repos/param/mre.py", line 12, in <module>
    Palette().range = None
    ^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/param/param/parameterized.py", line 677, in _f
    instance_param.__set__(obj, val)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/param/param/parameterized.py", line 679, in _f
    return f(self, obj, val)
  File "/home/shh/projects/holoviz/repos/param/param/parameterized.py", line 1975, in __set__
    self._validate(val)
    ~~~~~~~~~~~~~~^^^^^
  File "/home/shh/projects/holoviz/repos/param/param/parameters.py", line 1619, in _validate
    self._validate_value(val, self.allow_None)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/param/param/parameters.py", line 1708, in _validate_value
    super()._validate_value(value, allow_None)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/param/param/parameters.py", line 1603, in _validate_value
    raise ValueError(
    ...<2 lines>...
    )
ValueError: NumericTuple parameter 'Palette.range' only takes a tuple value, not <class 'NoneType'>.
```

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Claude Code + Sonnet 4.6, asked to fix the typing

## Checklist

<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [ ] Added documentation
