### PR TITLE
type: Add missing overload and add `NoNone` type

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -54,7 +54,6 @@ from .parameterized import shared_parameters
 from .parameterized import logging_level
 from .parameterized import DEBUG, VERBOSE, INFO, WARNING, ERROR, CRITICAL
 from .parameters import (
-    NoNone,
     guess_param_types,
     param_union,
     parameterized_class,
@@ -185,7 +184,6 @@ __all__ = (
     'ListSelector',
     'Magnitude',
     'MultiFileSelector',
-    'NoNone',
     'Number',
     'NumericTuple',
     'ObjectSelector',

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -54,6 +54,7 @@ from .parameterized import shared_parameters
 from .parameterized import logging_level
 from .parameterized import DEBUG, VERBOSE, INFO, WARNING, ERROR, CRITICAL
 from .parameters import (
+    NoNone,
     guess_param_types,
     param_union,
     parameterized_class,
@@ -184,6 +185,7 @@ __all__ = (
     'ListSelector',
     'Magnitude',
     'MultiFileSelector',
+    'NoNone',
     'Number',
     'NumericTuple',
     'ObjectSelector',

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import copy
 import datetime as dt
+import enum
 import glob
 import inspect
 import numbers
@@ -2890,6 +2891,14 @@ class MultiFileSelector(ListSelector):
         return _abbreviate_paths(self.path, super().get_range())
 
 
+class NoNoneType(enum.Enum):
+    NO_NONE = enum.auto()
+
+
+NoNone = NoNoneType.NO_NONE
+
+
+
 class ClassSelector(SelectorBase[_T]):
     """
     Parameter allowing selection of either a subclass or an instance of a class
@@ -2951,6 +2960,18 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
+            self: ClassSelector[CT],
+            *,
+            default: CT | None = None,
+            class_: type[CT],
+            is_instance: t.Literal[True] = True,
+            allow_None: NoNoneType,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None:
+            ...
+
+        @t.overload
+        def __init__(
             self: ClassSelector[CT | None],
             *,
             default: CT | None = None,
@@ -2997,6 +3018,18 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
+            self: ClassSelector[type[CT]],
+            *,
+            default: type[CT] | None = None,
+            class_: type[CT],
+            is_instance: t.Literal[False],
+            allow_None: NoNoneType,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None:
+            ...
+
+        @t.overload
+        def __init__(
             self: ClassSelector[type[CT] | None],
             *,
             default: None = None,
@@ -3035,9 +3068,10 @@ class ClassSelector(SelectorBase[_T]):
         class_: type | tuple[type, ...] = t.cast("type | tuple[type, ...]", Undefined),  # pyrefly: ignore[bad-argument-type]
         default: t.Any | None = Undefined,
         is_instance: bool = t.cast("bool", Undefined),  # pyrefly: ignore[bad-argument-type]
-        allow_None: bool = t.cast("bool", Undefined),  # pyrefly: ignore[bad-argument-type]
+        allow_None: bool | NoNoneType = t.cast("bool", Undefined),  # pyrefly: ignore[bad-argument-type]
         **params: Unpack[_ParameterKwargs]
     ) -> None:
+        allow_None = t.cast("bool", Undefined if allow_None is NoNone else allow_None)
         object.__setattr__(self, 'class_', class_)
         object.__setattr__(self, 'is_instance', is_instance)  # type: ignore
         super().__init__(  # type: ignore[misc, call-overload]

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2974,6 +2974,17 @@ class ClassSelector(SelectorBase[_T]):
 
         @t.overload
         def __init__(
+            self: ClassSelector[t.Any],
+            *,
+            default: t.Any = None,
+            class_: tuple[type, ...],
+            is_instance: t.Literal[True] = True,
+            allow_None: t.Literal[True] = True,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None: ...
+
+        @t.overload
+        def __init__(
             self: ClassSelector[type[CT]],
             *,
             default: type[CT],


### PR DESCRIPTION
## Description

Trying to type check HoloViews I found one missing overload. The other thing I noticed was it was very hard to get this pattern to work. This will lead to error in later function because it see it as the `E | None`.

``` python
from typing_extensions import reveal_type

import param


class E: ...


class C(param.Parameterized):
    e0 = param.ClassSelector(class_=E)
    e1 = param.ClassSelector(class_=E, allow_None=param.NoNone)

    def __init__(self, e0=None, e1=None, **params):
        if e0 is None:
            e0 = E()
        if e1 is None:
            e1 = E()
        super().__init__(e0=e0, e1=e1, **params)


reveal_type(C().e0)
reveal_type(C().e1)
```

```
❯ pyright mre_classselector2.py
/home/shh/projects/holoviz/repos/param/mre_classselector2.py
  /home/shh/projects/holoviz/repos/param/mre_classselector2.py:21:13 - information: Type of "C().e0" is "E | None"
  /home/shh/projects/holoviz/repos/param/mre_classselector2.py:22:13 - information: Type of "C().e1" is "E"
0 errors, 0 warnings, 2 informations
```

The alternative way to this would be doing something like this:  `e1 = param.ClassSelector(default=E() if t.TYPE_CHECKING else None, class_=E)`


## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Claude Code + Sonnet 4.6, to make the initial overloads. 


