### PR TITLE
Reorder param.List overloads to allow default type inference

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -15,6 +15,8 @@ from textwrap import dedent
 from threading import get_ident
 
 if t.TYPE_CHECKING:
+    import asyncio
+
     from param.parameterized import Parameter
 
     _P = t.ParamSpec("_P")
@@ -604,7 +606,7 @@ def _in_ipython():
     except NameError:
         return False
 
-_running_tasks = set()
+_running_tasks: set[asyncio.Task] = set()
 
 def async_executor(func):
     import asyncio

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -190,7 +190,7 @@ object_count = 0
 warning_count = 0
 
 # Hook to apply to depends and bind arguments to turn them into valid parameters
-_reference_transforms = []
+_reference_transforms: list[t.Callable[[t.Any], t.Any]] = []
 
 def register_reference_transform(transform):
     """

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -3608,7 +3608,7 @@ class List(Parameter[_T]):
             self: List[list[LT]],
             default: list[LT] = [],
             *,
-            item_type: type[LT] | tuple[type[LT], ...] = (),
+            item_type: type[LT] | tuple[type[LT], ...],
             bounds: tuple[int, int | None] | None = (0, None),
             is_instance: bool = True,
             allow_None: t.Literal[False] = False,
@@ -3632,17 +3632,7 @@ class List(Parameter[_T]):
             self: List[list[LT] | None],
             default: list[LT] | None = None,
             *,
-            item_type: type[LT] | tuple[type[LT], ...] = (),
-            allow_None: t.Literal[True] = True,
-            **kwargs: Unpack[_ParameterKwargs]
-        ) -> None:
-            ...
-
-        @t.overload
-        def __init__(
-            self: List[list[t.Any] | None],
-            default: list[t.Any] | None = None,
-            *,
+            item_type: type[LT] | tuple[type[LT], ...],
             allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
         ) -> None:
@@ -3655,6 +3645,16 @@ class List(Parameter[_T]):
             *,
             item_type: None = None,
             allow_None: t.Literal[False] = False,
+            **kwargs: Unpack[_ParameterKwargs]
+        ) -> None:
+            ...
+
+        @t.overload
+        def __init__(
+            self: List[list[t.Any] | None],
+            default: list[t.Any] | None = None,
+            *,
+            allow_None: t.Literal[True] = True,
             **kwargs: Unpack[_ParameterKwargs]
         ) -> None:
             ...


### PR DESCRIPTION
The `param.List` typing overloads were defined in an order that meant that by default `mypy` would complain that an explicit type declaration was needed. This PR fixes this so that `param.List` resolves to `list[Any]` or `list[Any] | None` by default.

For testing https://github.com/holoviz/param/pull/1148 will enable mypy type assert checks that ensure this works correctly.