### PR TITLE
Add instructions about basedpyright to Typing docs

### DIFF
--- a/doc/user_guide/Typing.ipynb
+++ b/doc/user_guide/Typing.ipynb
@@ -109,19 +109,18 @@
    "cell_type": "markdown",
    "id": "56c5e6bc-0d3e-4a43-834a-feecb0060ecd",
    "metadata": {},
-   "source": "## Choice of Type Checker\n\nThe Python ecosystem now has a number of different type checking tools. Param itself is type checked against four of the most common popular type checkers, including:\n\n- `mypy`: The default type checker for Python, without a language server.\n- `pyright`: The default type checker for VSCode, including a language server.\n- `pyrefly`: A type checker written in Rust by Meta (still in beta), including a language server.\n- `ty`: A type checker written in Rust by the Astral team (still in beta), including a language server.\n\nIf you are developing a library built on Param, we recommend using pyright as your type checker. Param's type annotations are primarily optimized for pyright, and it is the checker most likely to benefit your users. VSCode (via Pylance) runs pyright automatically, so correct inference will surface in your users' editors without any extra setup on their part."
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ad1a8098",
-   "source": "## Mypy Plugin\n\nIf you use mypy, we recommend enabling the param mypy plugin. Add the following to your `pyproject.toml`:\n\n```toml\n[tool.mypy]\nplugins = [\"param.mypy_plugin\"]\n```\n\nOr in `mypy.ini` / `setup.cfg`:\n\n```ini\n[mypy]\nplugins = param.mypy_plugin\n```\n\nThe plugin is needed because param uses a metaclass `__setattr__` to route class-level parameter assignment through the descriptor protocol. Without the plugin, mypy does not recognize this pattern ([mypy #9758](https://github.com/python/mypy/issues/9758)) and rejects valid code like:\n\n```python\nclass MyModel(param.Parameterized):\n    flag = param.Boolean(default=False)\n\nMyModel.flag = True  # mypy error without the plugin\n```\n\nWith the plugin enabled, mypy correctly understands that the assignment sets the parameter's default value and type-checks it against the parameter's value type. Pyright handles this correctly without any plugin.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c46b524d",
-   "source": "## basedpyright\n\n[basedpyright](https://docs.basedpyright.com/) is a community fork of pyright with stricter default rules. Param does not officially support basedpyright-specific lint rules, but it works fine if you suppress one false positive.\n\nbasedpyright enables `reportUnannotatedClassAttribute` by default, which warns on any class attribute without an explicit type annotation in non-`@final` classes:\n\n```\nwarning: Type annotation for attribute `title` is required because this class\nis not decorated with `@final` (reportUnannotatedClassAttribute)\n```\n\nThis rule is not present in standard pyright, mypy, or any other supported checker. It does not apply well to Param because the Parameter descriptors already encode the full type contract via `__get__`/`__set__` overloads, making the warnings false positives.\n\n**Recommended fix**: suppress the rule project-wide. In `pyproject.toml`:\n\n```toml\n[tool.basedpyright]\nreportUnannotatedClassAttribute = \"none\"\n```\n\nOr in `pyrightconfig.json`:\n\n```json\n{\n  \"reportUnannotatedClassAttribute\": \"none\"\n}\n```\n\nNote that this also suppresses the warning for non-Parameterized classes in your project. If you want the rule active elsewhere, you can disable it per-file by adding a comment at the top of files that use Param:\n\n```python\n# pyright: reportUnannotatedClassAttribute=none\n```\n\n**Why not use `@final` or add annotations?** Marking Parameterized classes as `@final` would break Param's fundamental design pattern since these classes are routinely subclassed. Adding redundant type annotations (e.g. `title: str = param.String()`) creates a maintenance burden and a potential source-of-truth mismatch between the annotation and the Parameter's actual type (consider `allow_None=True` being added later without updating the annotation).\n\nTo isolate basedpyright-specific rules when debugging type errors, you can temporarily set all `reportUnannotated*` rules to `\"none\"` so that only standard pyright diagnostics remain.",
-   "metadata": {}
+   "source": [
+    "## Choice of Type Checker\n",
+    "\n",
+    "The Python ecosystem now has a number of different type checking tools. Param itself is type checked against four of the most common popular type checkers, including:\n",
+    "\n",
+    "- `mypy`: The default type checker for Python, without a language server.\n",
+    "- `pyright`: The default type checker for VSCode, including a language server.\n",
+    "- `pyrefly`: A type checker written in Rust by Meta, including a language server.\n",
+    "- `ty`: A type checker written in Rust by the Astral team (still in beta), including a language server.\n",
+    "\n",
+    "If you are developing a library built on Param, we recommend using pyright as your type checker. Param's type annotations are primarily optimized for pyright, and it is the checker most likely to benefit your users. VSCode (via Pylance) runs pyright automatically, so correct inference will surface in your users' editors without any extra setup on their part."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -208,6 +207,96 @@
     "- Use Parameter keyword arguments (`allow_None`, `item_type`, `class_`, `bounds`) to improve both runtime checks and type precision.\n",
     "- For finite choices today, prefer `Literal[...]` annotations with `Selector`.\n",
     "- Run your type checker alongside your tests to get both static and runtime safety."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "851a0c4a-822b-4bf0-832d-1d58e673971b",
+   "metadata": {},
+   "source": [
+    "## Tool specific information\n",
+    "\n",
+    "Below is giving tool specific information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad1a8098",
+   "metadata": {},
+   "source": [
+    "### Mypy\n",
+    "\n",
+    "If you use mypy, we recommend enabling the param mypy plugin. Add the following to your `pyproject.toml`:\n",
+    "\n",
+    "```toml\n",
+    "[tool.mypy]\n",
+    "plugins = [\"param.mypy_plugin\"]\n",
+    "```\n",
+    "\n",
+    "Or in `mypy.ini` / `setup.cfg`:\n",
+    "\n",
+    "```ini\n",
+    "[mypy]\n",
+    "plugins = param.mypy_plugin\n",
+    "```\n",
+    "\n",
+    "The plugin is needed because param uses a metaclass `__setattr__` to route class-level parameter assignment through the descriptor protocol. Without the plugin, mypy does not recognize this pattern ([mypy #9758](https://github.com/python/mypy/issues/9758)) and rejects valid code like:\n",
+    "\n",
+    "```python\n",
+    "class MyModel(param.Parameterized):\n",
+    "    flag = param.Boolean(default=False)\n",
+    "\n",
+    "MyModel.flag = True  # mypy error without the plugin\n",
+    "```\n",
+    "\n",
+    "With the plugin enabled, mypy correctly understands that the assignment sets the parameter's default value and type-checks it against the parameter's value type. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c46b524d",
+   "metadata": {},
+   "source": [
+    "### basedpyright\n",
+    "\n",
+    "[basedpyright](https://docs.basedpyright.com/) is a community fork of pyright with stricter default rules. Param does not officially support basedpyright-specific type rules, but it works fine if you suppress one false positive.\n",
+    "\n",
+    "basedpyright enables `reportUnannotatedClassAttribute` by default, which warns on any class attribute without an explicit type annotation in non-`@final` classes. \n",
+    "\n",
+    "This rule does not apply well to Param because the Parameter descriptors already encode the full type contract via `__get__`/`__set__` overloads, making the warnings false positives. Marking Parameterized classes as `@final` would break Param's fundamental design pattern since these classes are routinely subclassed. Adding redundant type annotations (e.g. `title: str = param.String()`) creates a maintenance burden and a potential source-of-truth mismatch between the annotation and the Parameter's actual type (consider `allow_None=True` being added later without updating the annotation).\n",
+    "\n",
+    "The Recommended fix is to suppress the rule project-wide. In `pyproject.toml`:\n",
+    "\n",
+    "```toml\n",
+    "[tool.basedpyright]\n",
+    "reportUnannotatedClassAttribute = \"none\"\n",
+    "```\n",
+    "\n",
+    "Or in `pyrightconfig.json`:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"reportUnannotatedClassAttribute\": \"none\"\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Note that this also suppresses the warning for non-Parameterized classes in your project. If you want the rule active elsewhere, you can disable it per-file by adding a comment at the top of files that use Param:\n",
+    "\n",
+    "```python\n",
+    "# pyright: reportUnannotatedClassAttribute=none\n",
+    "```\n",
+    "\n",
+    "To isolate basedpyright-specific rules when debugging type errors, you can temporarily set the following setting:\n",
+    "\n",
+    "```toml\n",
+    "[tool.basedpyright]\n",
+    "typeCheckingMode = \"standard\"\n",
+    "reportAny = \"none\"\n",
+    "reportExplicitAny = \"none\"\n",
+    "reportUnreachable = \"none\"\n",
+    "reportUnusedParameter = \"none\"\n",
+    "reportIgnoreCommentWithoutRule = \"none\"\n",
+    "```"
    ]
   }
  ],

--- a/doc/user_guide/Typing.ipynb
+++ b/doc/user_guide/Typing.ipynb
@@ -119,6 +119,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c46b524d",
+   "source": "## basedpyright\n\n[basedpyright](https://docs.basedpyright.com/) is a community fork of pyright with stricter default rules. Param does not officially support basedpyright-specific lint rules, but it works fine if you suppress one false positive.\n\nbasedpyright enables `reportUnannotatedClassAttribute` by default, which warns on any class attribute without an explicit type annotation in non-`@final` classes:\n\n```\nwarning: Type annotation for attribute `title` is required because this class\nis not decorated with `@final` (reportUnannotatedClassAttribute)\n```\n\nThis rule is not present in standard pyright, mypy, or any other supported checker. It does not apply well to Param because the Parameter descriptors already encode the full type contract via `__get__`/`__set__` overloads, making the warnings false positives.\n\n**Recommended fix**: suppress the rule project-wide. In `pyproject.toml`:\n\n```toml\n[tool.basedpyright]\nreportUnannotatedClassAttribute = \"none\"\n```\n\nOr in `pyrightconfig.json`:\n\n```json\n{\n  \"reportUnannotatedClassAttribute\": \"none\"\n}\n```\n\nNote that this also suppresses the warning for non-Parameterized classes in your project. If you want the rule active elsewhere, you can disable it per-file by adding a comment at the top of files that use Param:\n\n```python\n# pyright: reportUnannotatedClassAttribute=none\n```\n\n**Why not use `@final` or add annotations?** Marking Parameterized classes as `@final` would break Param's fundamental design pattern since these classes are routinely subclassed. Adding redundant type annotations (e.g. `title: str = param.String()`) creates a maintenance burden and a potential source-of-truth mismatch between the annotation and the Parameter's actual type (consider `allow_None=True` being added later without updating the annotation).\n\nTo isolate basedpyright-specific rules when debugging type errors, you can temporarily set all `reportUnannotated*` rules to `\"none\"` so that only standard pyright diagnostics remain.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "8cc4ed0d",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Adds documentation about how to handle false-positive type errors using `basedpyright`, closing https://github.com/holoviz/param/issues/1147.