### PR TITLE
fix: Memory leak on reactive pipelines

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -94,6 +94,7 @@ import math
 import operator
 import typing as t
 import warnings
+import weakref
 
 from collections.abc import (
     AsyncGenerator, Callable, Coroutine, Generator, Iterable, Iterator, Sized
@@ -1359,6 +1360,39 @@ def bind(
         setattr(wrapped, name, t.cast('Callable', accessor)(wrapped))
     return wrapped
 
+class _WeakInvalidator:
+    """
+    A weakly-bound invalidation callback for an ``rx`` pipeline node.
+
+    ``rx`` nodes register invalidation callbacks on their *source* parameters.
+    If those callbacks were strong bound-method references the source (which is
+    typically long-lived) would keep every derived node — and anything it
+    captured, such as large arrays — alive indefinitely. Wrapping the bound
+    method in a :class:`weakref.WeakMethod` lets the derived node be garbage
+    collected as soon as nothing else references it; once collected the call
+    becomes a no-op and the now-dead watcher is removed by a finalizer (see
+    ``rx._watch_invalidation``).
+    """
+
+    __slots__ = ('_ref', '__weakref__')
+
+    def __init__(self, method):
+        self._ref = weakref.WeakMethod(method)
+
+    def __call__(self, *events):
+        method = self._ref()
+        if method is not None:
+            return method(*events)
+
+
+def _remove_watcher(owner, watcher):
+    """Unwatch ``watcher`` from ``owner``, ignoring if it is already gone."""
+    try:
+        owner.param.unwatch(watcher)
+    except Exception:
+        pass
+
+
 # When we only support python >= 3.11 we should exchange 'rx' with Self type annotation below.
 # See https://peps.python.org/pep-0673/
 
@@ -1712,9 +1746,21 @@ class rx:
             for _, params in full_groupby(self._fn_params, lambda x: id(x.owner)):
                 fps = [p.name for p in params if p in self._root._fn_params]
                 if fps:
-                    params[0].owner.param._watch(self._invalidate_obj, fps, precedence=-1)
+                    self._watch_invalidation(params[0].owner, self._invalidate_obj, fps)
         for _, params in full_groupby(self._internal_params, lambda x: id(x.owner)):
-            params[0].owner.param._watch(self._invalidate_current, [p.name for p in params], precedence=-1)
+            self._watch_invalidation(params[0].owner, self._invalidate_current, [p.name for p in params])
+
+    def _watch_invalidation(self, owner, method, names):
+        """
+        Register a *weak* invalidation watcher on a source parameter.
+
+        The callback only holds a weak reference to this node, so a long-lived
+        source does not pin the (potentially short-lived) derived node alive.
+        A finalizer removes the watcher automatically once this node is garbage
+        collected, keeping the source's watcher list from growing without bound.
+        """
+        watcher = owner.param._watch(_WeakInvalidator(method), names, precedence=-1)
+        weakref.finalize(self, _remove_watcher, owner, watcher)
 
     def _invalidate_current(self, *events):
         if all(event.obj is self._trigger for event in events):

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1,8 +1,10 @@
 import asyncio
+import gc
 import math
 import operator
 import re
 import time
+import weakref
 
 import param
 import pytest
@@ -1029,3 +1031,28 @@ async def test_async_shared_rx_only_triggers_once(lazy):
     assert y_rx.rx.value == 4
 
     assert call_count == 2
+
+
+def test_reactive_derived_node_is_garbage_collected():
+    def watcher_count(source):
+        watchers = source._internal_params[0].owner._param__private.watchers
+        return sum(len(lst) for what in watchers.values() for lst in what.values())
+
+    a = param.rx(1)
+    baseline = watcher_count(a)
+    assert baseline == 2
+
+    b = a + 1
+    assert b.rx.value == 2
+    assert watcher_count(a) > baseline
+
+    ref = weakref.ref(b)
+    del b
+    gc.collect()
+    assert ref() is None
+    assert watcher_count(a) == baseline
+
+    c = a + 10
+    a.rx.value = 5
+    assert c.rx.value == 15
+    assert watcher_count(a) > baseline


### PR DESCRIPTION
## Description
Derived rx nodes registered their invalidation callbacks (_invalidate_obj/_invalidate_current) on their source parameter as strong bound-method references. Since the source is typically long-lived, this pinned every derived node — and anything it captured, such as large arrays — alive indefinitely, with no way to reclaim it.

Wrap the invalidation callbacks in a weakref.WeakMethod (_WeakInvalidator) and register a finalizer to prune the watcher once the node is collected. The node now becomes garbage collectable as soon as it is no longer referenced, and the source's watcher list no longer grows without bound.

This changes no observable public API behavior: while an expression is referenced it behaves exactly as before, and watch()/_watch() are untouched. Only a node that was previously unreachable-but-uncollectable (pinned solely by the source's internal watcher) is now reclaimed.


``` python
import gc
import weakref

import numpy as np
import param
import psutil

ARRAY_ELEMENTS = 10_000_000  # ~80 MB per array
N_ITER = 20


def rss_mb():
    return psutil.Process().memory_info().rss / 1024 / 1024


def watcher_count(source):
    watchers = source._internal_params[0].owner._param__private.watchers
    return sum(len(lst) for what in watchers.values() for lst in what.values())


def run():
    a = param.rx(np.zeros(ARRAY_ELEMENTS))

    print(f"{'iter':>5} | {'watchers on a':>13} | {'b GC-able?':>10} | {'RSS (MB)':>9}")
    print("-" * 46)

    baseline = rss_mb()
    for i in range(N_ITER):
        payload = np.full(ARRAY_ELEMENTS, float(i))
        b = a + payload

        ref = weakref.ref(b)
        del b, payload
        gc.collect()
        leaked = ref() is not None  # alive => leaked, pinned by `a`

        print(
            f"{i:>5} | {watcher_count(a):>13} | "
            f"{'NO (leak)' if leaked else 'yes':>10} | "
            f"{rss_mb() - baseline:>+9.1f}"
        )


if __name__ == "__main__":
    run()
```

main branch:
```
 iter | watchers on a | b GC-able? |  RSS (MB)
----------------------------------------------
    0 |             6 |  NO (leak) |     +76.3
    1 |            10 |  NO (leak) |    +152.6
    2 |            14 |  NO (leak) |    +228.9
    3 |            18 |  NO (leak) |    +305.2
    4 |            22 |  NO (leak) |    +381.5
    5 |            26 |  NO (leak) |    +457.8
    6 |            30 |  NO (leak) |    +534.1
    7 |            34 |  NO (leak) |    +610.4
    8 |            38 |  NO (leak) |    +686.7
    9 |            42 |  NO (leak) |    +763.0
   10 |            46 |  NO (leak) |    +839.3
   11 |            50 |  NO (leak) |    +915.6
   12 |            54 |  NO (leak) |    +991.9
   13 |            58 |  NO (leak) |   +1068.2
   14 |            62 |  NO (leak) |   +1144.5
   15 |            66 |  NO (leak) |   +1220.8
   16 |            70 |  NO (leak) |   +1297.1
   17 |            74 |  NO (leak) |   +1373.4
   18 |            78 |  NO (leak) |   +1449.7
   19 |            82 |  NO (leak) |   +1526.0
```

This branch:
``` 
 iter | watchers on a | b GC-able? |  RSS (MB)
----------------------------------------------
    0 |             2 |        yes |      +0.0
    1 |             2 |        yes |      +0.0
    2 |             2 |        yes |      +0.0
    3 |             2 |        yes |      +0.0
    4 |             2 |        yes |      +0.0
    5 |             2 |        yes |      +0.0
    6 |             2 |        yes |      +0.0
    7 |             2 |        yes |      +0.0
    8 |             2 |        yes |      +0.0
    9 |             2 |        yes |      +0.0
   10 |             2 |        yes |      +0.0
   11 |             2 |        yes |      +0.0
   12 |             2 |        yes |      +0.0
   13 |             2 |        yes |      +0.0
   14 |             2 |        yes |      +0.0
   15 |             2 |        yes |      +0.0
   16 |             2 |        yes |      +0.0
   17 |             2 |        yes |      +0.0
   18 |             2 |        yes |      +0.0
   19 |             2 |        yes |      +0.0
```

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Assisted-by: Claude:claude-opus-4-8

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

Used AI to find the problem and the solution. 

## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
