### PR TITLE
In example code in document change value of script_repr_suppress_defaults = to False 

### DIFF
--- a/doc/user_guide/Serialization_and_Persistence.ipynb
+++ b/doc/user_guide/Serialization_and_Persistence.ipynb
@@ -495,7 +495,7 @@
    "outputs": [],
    "source": [
     "import param.parameterized\n",
-    "param.parameterized.script_repr_suppress_defaults=True"
+    "param.parameterized.script_repr_suppress_defaults=False"
    ]
   },
   {


### PR DESCRIPTION

The doc says:

"If you want a record of the complete set of parameter values, including all defaults, you can enable that behavior:"

In the code block that follows, script_repr_suppress_defaults is set to True. But in order to show the complete set of parameter values, suppression should be set to False.

Also, the document should mention the default value for script_repr_suppress_defaults. It seems that by default it is set to True.

In the API reference documentation, I was unable to find mention  of script_repr_suppress_defaults . This seems to be a documentation gap. Should I file a separate issue for this?

<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #{issue}


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model:
Usage:

- [ ] I have tested all AI-generated content in my PR.
- [ ] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [ ] Added documentation
