### PR TITLE
Update script_repr docstring to mention existence of script_repr_suppress_defaults

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -5172,6 +5172,15 @@ def script_repr(
     configuration. It captures only the state of the object's parameters, not
     its internal (non-parameter) attributes.
 
+    Note: By default, script_repr prints only parameter values that have changed from
+    their defaults; for the complete set of parameter values, including 
+    all defaults, first run:
+
+    param.parameterized.script_repr_suppress_defaults=False
+
+    For more details on this, see:
+    https://param.holoviz.org/en/docs/latest/user_guide/Serialization_and_Persistence.html#script-repr-limitations-and-workarounds
+
     Parameters
     ----------
     val : Parameterized

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -5173,7 +5173,7 @@ def script_repr(
     its internal (non-parameter) attributes.
 
     Note: By default, script_repr prints only parameter values that have changed from
-    their defaults; for the complete set of parameter values, including 
+    their defaults; for the complete set of parameter values, including
     all defaults, first run:
 
     param.parameterized.script_repr_suppress_defaults=False


### PR DESCRIPTION

Added mention of suppress flag (or is it a global config variable?) to the script_repr docstring, for awareness, clarification and completeness.

See also #1159 .


By default, script_repr prints only parameter values that have changed from their defaults; for the complete set of parameter values, including all defaults, first run:

    param.parameterized.script_repr_suppress_defaults=False
    
For more details on this, see:
    https://param.holoviz.org/en/docs/latest/user_guide/Serialization_and_Persistence.html#script-repr-limitations-and-workarounds
