### PR TITLE
Allow callable (dynamic) values for Date and CalendarDate

### DIFF
--- a/param/parameters.py
+++ b/param/parameters.py
@@ -1226,6 +1226,9 @@ class Date(Number[_T]):
         if self.allow_None and value is None:
             return
 
+        if callable(value) and not inspect.isgeneratorfunction(value):
+            return
+
         if not isinstance(value, _dt_types) and not (allow_None and value is None):
             raise ValueError(
                 f"{_validate_error_prefix(self)} only takes datetime and "
@@ -1322,6 +1325,9 @@ class CalendarDate(Number[_T]):
         bounds; if not, an exception is raised.
         """
         if self.allow_None and value is None:
+            return
+
+        if callable(value) and not inspect.isgeneratorfunction(value):
             return
 
         if (not isinstance(value, dt.date) or isinstance(value, dt.datetime)) and not (allow_None and value is None):

--- a/tests/testdynamicparams.py
+++ b/tests/testdynamicparams.py
@@ -250,6 +250,50 @@ class TestDynamicSharedNumbergen(TestDynamicParameters):
             self.assertNotEqual(call_1, t12.x)
 
 
+class TestDynamicCallableAcrossNumberSiblings(unittest.TestCase):
+    """
+    Number, Integer, Date and CalendarDate all subclass Dynamic, whose
+    contract is that any such parameter may be set to a callable that is
+    invoked to produce the value on get. Every sibling must accept a callable
+    uniformly; Date and CalendarDate used to reject it at validation time.
+    """
+
+    def setUp(self):
+        super().setUp()
+        param.Dynamic.time_dependent = False
+
+        import datetime as dt
+
+        self.cases = [
+            (param.Number, lambda: 5, 5),
+            (param.Integer, lambda: 5, 5),
+            (param.Date, lambda: dt.datetime(2021, 5, 5), dt.datetime(2021, 5, 5)),
+            (param.CalendarDate, lambda: dt.date(2021, 5, 5), dt.date(2021, 5, 5)),
+        ]
+
+    def test_set_callable_and_get_resolves(self):
+        for ptype, gen, expected in self.cases:
+            with self.subTest(ptype=ptype.__name__):
+
+                class P(param.Parameterized):
+                    v = ptype()
+
+                p = P()
+                # Setting a callable must not raise for any Dynamic sibling.
+                p.v = gen
+                # Getting resolves the dynamic value by calling the callable.
+                self.assertEqual(p.v, expected)
+
+    def test_callable_as_constructor_default(self):
+        for ptype, gen, expected in self.cases:
+            with self.subTest(ptype=ptype.__name__):
+
+                class P(param.Parameterized):
+                    v = ptype(default=gen)
+
+                self.assertEqual(P().v, expected)
+
+
 # Commented out block in the original doctest version.
 # Maybe these are features originally planned but never implemented
 


### PR DESCRIPTION
`Date` and `CalendarDate` subclass `Number`, and all of them ultimately subclass `Dynamic` — whose contract is that a parameter may be set to a callable that is invoked to produce the value on `get`:

```python
import datetime, param

class P(param.Parameterized):
    n = param.Number()
    d = param.Date()

p = P()
p.n = lambda: 42          # fine
p.d = lambda: datetime.datetime.now()
# ValueError: Date parameter 'P.d' only takes datetime and date types, not <class 'function'>
```

`Number._validate_value` explicitly allows a callable (`callable(value) and not inspect.isgeneratorfunction(value)`), and `Integer` inherits it — but the `Date` and `CalendarDate` overrides drop that guard and go straight to the datetime type check, so they reject a callable that their sibling parameters accept.

The dynamic machinery itself already handles callable dates correctly — with the guard added, `p.d` resolves to the datetime and re-evaluates on each access like any other `Dynamic` value; only `_validate_value` was rejecting them.

**Fix.** Add the same callable guard `Number` uses to `Date._validate_value` and `CalendarDate._validate_value`, so all `Dynamic` siblings behave uniformly.

**Test.** `TestDynamicCallableAcrossNumberSiblings` (in `tests/testdynamicparams.py`) parametrizes over `Number`, `Integer`, `Date`, `CalendarDate` and asserts each accepts a callable and resolves it on get, both via assignment and via constructor `default=`. Full suite (`testdynamicparams`, `testdateparam`, `testcalendardateparam`, `testnumberparameter`): 104 passed.