### PR TITLE
Update announcement text from Param 2.4 to Param 2.4.1

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -113,7 +113,7 @@ html_theme_options = {
         "version_match": switcher_version,
     },
     "show_version_warning_banner": True,
-    "announcement": "Param 2.4 has just been released! Check out the <a href='https://blog.holoviz.org/posts/param_release_2.4/'>release blog post</a> and support Param by giving it a 🌟 on <a href='https://github.com/holoviz/param'>Github</a>.",
+    "announcement": "Param 2.4.1 has just been released! Check out the <a href='https://blog.holoviz.org/posts/param_release_2.4/'>release blog post</a> and support Param by giving it a 🌟 on <a href='https://github.com/holoviz/param'>Github</a>.",
 
 }
 


### PR DESCRIPTION

Or is the policy for Param to not announce point releases in the announcement banner on the parameter website?

For comparison, the release text on the Panel website does state the point version.