### PR TITLE
Fix List item_type validation rejecting subclasses with a custom metaclass

### DIFF
--- a/param/parameters.py
+++ b/param/parameters.py
@@ -3731,7 +3731,7 @@ class List(Parameter[_T]):
             if is_instance and not isinstance(v, item_type):
                 err_kind = "instances"
                 obj_display = lambda v: type(v)
-            elif not is_instance and (type(v) is not type or not issubclass(v, item_type)):
+            elif not is_instance and (not isinstance(v, type) or not issubclass(v, item_type)):
                 err_kind = "subclasses"
             if err_kind:
                 raise TypeError(

--- a/tests/testlist.py
+++ b/tests/testlist.py
@@ -1,3 +1,4 @@
+import abc
 import re
 import unittest
 
@@ -16,6 +17,7 @@ class Obj: pass
 class SubObj1(Obj): pass
 class SubObj2(Obj): pass
 class DiffObj: pass
+class SubObjMeta(Obj, metaclass=abc.ABCMeta): pass
 
 class TestListParameters(unittest.TestCase):
 
@@ -108,6 +110,12 @@ class TestListParameters(unittest.TestCase):
             match=re.escape("List parameter 'P.o' items must be subclasses of <class 'tests.testlist.Obj'>, not")
         ):
             p.o = [DiffObj]
+
+    def test_set_object_subclass_custom_metaclass(self):
+        # A subclass defined with a custom metaclass should be accepted.
+        p = self.P()
+        p.o = [SubObjMeta]
+        assert p.o == [SubObjMeta]
 
     def test_set_object_wrong_type(self):
         p = self.P()


### PR DESCRIPTION
`_validate_item_type` used `type(v) is not type` to check that an item is a class. This strict identity check only holds for classes whose metaclass is
exactly `type`, so valid subclasses defined with a custom metaclass were wrongly rejected. Use `isinstance(v, type)` instead.