### PR TITLE
Ignore python 3.10 for feather test

### DIFF
--- a/tests/testfiledeserialization.py
+++ b/tests/testfiledeserialization.py
@@ -45,12 +45,7 @@ except ModuleNotFoundError:
         xlsxm = None
 
 try:
-    import pyarrow
     import pyarrow.feather as feather
-    # pyarrow.feather.write_feather is deprecated as of pyarrow 24.0.0 in
-    # favor of pyarrow.ipc, which pandas.DataFrame.to_feather does not yet use.
-    if int(pyarrow.__version__.split('.')[0]) >= 24:
-        feather = None
 except ModuleNotFoundError:
     feather = None
 
@@ -179,7 +174,6 @@ class TestFileDeserialization(unittest.TestCase):
 
     @pd_skip
     @ods_skip
-    @skipIf(sys.version_info[0] < 3, "py2k pandas does not support 'ods'")
     def test_data_frame_ods(self):
         path = '{}/val.ods'.format(self.temp_dir)
         P.data_frame.to_excel(path, index=False)
@@ -187,6 +181,7 @@ class TestFileDeserialization(unittest.TestCase):
 
     @pd_skip
     @feather_skip
+    @skipIf(sys.version_info[:2] == (3, 10), "mismatch of pyarrow and pandas version")
     def test_data_frame_feather(self):
         path = '{}/val.feather'.format(self.temp_dir)
         P.data_frame.to_feather(path)


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

PyArrow 24+ is support by pandas 3 but it is not available on Python 3.10.