### PR TITLE
Stop rx from propagating a stale value while an async node is awaiting

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1786,7 +1786,7 @@ class rx:
         t.cast('t.Any', self._root)._dirty_obj = True
         self._error_state = None
 
-    async def _resolve_async(self, obj=None, generation=None):
+    async def _resolve_async(self, obj=None, generation: int = 0):
         import asyncio
         self._current_task = task = asyncio.current_task()
         trigger = self._trigger

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1597,7 +1597,7 @@ class rx:
         self._dirty_obj = False
         self._current_task = None
         self._resolve_generation = 0
-        self._resolved_generation = 0
+        self._finished_generation = 0
         self._skipped = False
         self._error_state = None
         self._current_ = _current
@@ -1707,12 +1707,8 @@ class rx:
         """
         Whether an asynchronous resolution is in flight that has not yet
         produced a value for the current generation.
-
-        While a node is awaiting, the cached ``_current_`` value was computed
-        from inputs that have since been superseded, so resolving the node
-        skips instead of reporting the stale value as if it were current.
         """
-        return self._resolve_generation != self._resolved_generation
+        return self._resolve_generation != self._finished_generation
 
     @property
     def _current(self):
@@ -1858,7 +1854,7 @@ class rx:
                 if stale():
                     return
                 self._current_ = shared.rx.value
-                self._resolved_generation = generation
+                self._finished_generation = generation
                 trigger.param.trigger('value')
             elif inspect.isasyncgen(obj):
                 async for val in obj:
@@ -1866,14 +1862,14 @@ class rx:
                         await _close_stale(obj)
                         break
                     self._current_ = val
-                    self._resolved_generation = generation
+                    self._finished_generation = generation
                     trigger.param.trigger('value')
             else:
                 value = await obj
                 if stale():
                     return
                 self._current_ = value
-                self._resolved_generation = generation
+                self._finished_generation = generation
                 trigger.param.trigger('value')
         except asyncio.CancelledError:
             return
@@ -1902,9 +1898,6 @@ class rx:
                     self._current_ = Undefined
                     raise Skip
                 elif self._prev is not None and self._prev._skipped:
-                    # The previous node did not produce a value for the current
-                    # inputs, so applying this operation would compute on a
-                    # value that has already been superseded.
                     raise Skip
                 elif (
                     self._shared is not None and
@@ -1918,9 +1911,9 @@ class rx:
                         self._shared.rx.value # trigger async resolve
                         self._lazy_resolve()
                         raise Skip
-                    # Mirroring the shared input is not a skip, it resolves to
-                    # a value, so it must report the shared node's skip state
-                    # rather than being treated as skipped itself.
+                    # Returns instead of raising Skip because this path does
+                    # resolve to a value, so it must mirror the shared node's
+                    # skip state rather than be marked skipped by the handler.
                     self._current_ = self._shared.rx.value
                     self._skipped = self._shared._skipped
                     self._dirty = False
@@ -2290,9 +2283,6 @@ def _rx_transform(obj):
     def resolve(*_):
         value = obj.rx.value
         if obj._skipped or value is Skip or value is Undefined:
-            # The expression did not produce a value for the current inputs,
-            # e.g. because an asynchronous node has not resolved yet. Skipping
-            # ensures consumers are not handed a sentinel or a stale value.
             raise Skip
         return value
     return bind(resolve, *obj._params)

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1393,6 +1393,27 @@ def _remove_watcher(owner, watcher):
         pass
 
 
+async def _close_stale(obj):
+    """
+    Discard an awaitable or async generator whose result is no longer needed.
+
+    Closing a coroutine that was never awaited also suppresses the warning
+    Python emits when it is garbage collected.
+    """
+    try:
+        if inspect.isasyncgen(obj):
+            await obj.aclose()
+        elif inspect.iscoroutine(obj):
+            obj.close()
+    except (StopAsyncIteration, GeneratorExit):
+        pass
+    except Exception:
+        logger.debug(
+            "Ignoring close error for stale reactive task.",
+            exc_info=True,
+        )
+
+
 # When we only support python >= 3.11 we should exchange 'rx' with Self type annotation below.
 # See https://peps.python.org/pep-0673/
 
@@ -1788,12 +1809,21 @@ class rx:
 
     async def _resolve_async(self, obj=None, generation: int = 0):
         import asyncio
-        self._current_task = task = asyncio.current_task()
-        trigger = self._trigger
 
         def stale():
             return generation != self._resolve_generation
 
+        if stale():
+            # A newer resolution was requested before this task was scheduled,
+            # so nothing has awaited obj yet and the operation has not begun.
+            # Close it instead of computing a result that is already superseded.
+            # This must happen before _current_task is claimed below, otherwise
+            # the finally clause would clear the genuinely current task and hide
+            # it from the next _lazy_resolve.
+            await _close_stale(obj)
+            return
+        self._current_task = task = asyncio.current_task()
+        trigger = self._trigger
         try:
             if trigger is None:
                 return
@@ -1811,15 +1841,7 @@ class rx:
             elif inspect.isasyncgen(obj):
                 async for val in obj:
                     if stale():
-                        try:
-                            await obj.aclose()
-                        except (StopAsyncIteration, GeneratorExit):
-                            pass
-                        except Exception:
-                            logger.debug(
-                                "Ignoring async generator close error for stale reactive task.",
-                                exc_info=True,
-                            )
+                        await _close_stale(obj)
                         break
                     self._current_ = val
                     self._resolved_generation = generation

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1558,6 +1558,8 @@ class rx:
         self._dirty_obj = False
         self._current_task = None
         self._resolve_generation = 0
+        self._resolved_generation = 0
+        self._skipped = False
         self._error_state = None
         self._current_ = _current
         # _shared is used for branching rx pipelines where we clone the input.
@@ -1660,6 +1662,18 @@ class rx:
             inspect.isasyncgenfunction(fn) or
             inspect.isgeneratorfunction(fn)
         )
+
+    @property
+    def _awaiting(self) -> bool:
+        """
+        Whether an asynchronous resolution is in flight that has not yet
+        produced a value for the current generation.
+
+        While a node is awaiting, the cached ``_current_`` value was computed
+        from inputs that have since been superseded, so resolving the node
+        skips instead of reporting the stale value as if it were current.
+        """
+        return self._resolve_generation != self._resolved_generation
 
     @property
     def _current(self):
@@ -1792,6 +1806,7 @@ class rx:
                 if stale():
                     return
                 self._current_ = shared.rx.value
+                self._resolved_generation = generation
                 trigger.param.trigger('value')
             elif inspect.isasyncgen(obj):
                 async for val in obj:
@@ -1807,12 +1822,14 @@ class rx:
                             )
                         break
                     self._current_ = val
+                    self._resolved_generation = generation
                     trigger.param.trigger('value')
             else:
                 value = await obj
                 if stale():
                     return
                 self._current_ = value
+                self._resolved_generation = generation
                 trigger.param.trigger('value')
         except asyncio.CancelledError:
             return
@@ -1840,6 +1857,11 @@ class rx:
                 if obj is Skip or obj is Undefined:
                     self._current_ = Undefined
                     raise Skip
+                elif self._prev is not None and self._prev._skipped:
+                    # The previous node did not produce a value for the current
+                    # inputs, so applying this operation would compute on a
+                    # value that has already been superseded.
+                    raise Skip
                 elif (
                     self._shared is not None and
                     self._method is None and
@@ -1851,9 +1873,14 @@ class rx:
                     if self._is_async:
                         self._shared.rx.value # trigger async resolve
                         self._lazy_resolve()
-                    else:
-                        self._current_ = self._shared.rx.value
-                    raise Skip
+                        raise Skip
+                    # Mirroring the shared input is not a skip, it resolves to
+                    # a value, so it must report the shared node's skip state
+                    # rather than being treated as skipped itself.
+                    self._current_ = self._shared.rx.value
+                    self._skipped = self._shared._skipped
+                    self._dirty = False
+                    return self._current_
                 operation = self._operation
                 if operation:
                     obj = self._eval_operation(obj, operation)
@@ -1864,13 +1891,19 @@ class rx:
                         raise Skip
             except Skip:
                 self._dirty = False
+                self._skipped = True
                 return self._current_
             except Exception as e:
                 self._error_state = e
                 raise e
             self._current_ = current = obj
+            self._skipped = False
         else:
             current = self._current_
+            # A node awaiting an asynchronous result still holds the value it
+            # computed from the previous inputs; report it as skipped so it is
+            # not propagated as if it were current.
+            self._skipped = self._awaiting
         self._dirty = False
         if self._method:
             # E.g. `pi = dfi.A` leads to `pi._method` equal to `'A'`.
@@ -2210,6 +2243,14 @@ class rx:
 def _rx_transform(obj):
     if not isinstance(obj, rx):
         return obj
-    return bind(lambda *_: obj.rx.value, *obj._params)
+    def resolve(*_):
+        value = obj.rx.value
+        if obj._skipped or value is Skip or value is Undefined:
+            # The expression did not produce a value for the current inputs,
+            # e.g. because an asynchronous node has not resolved yet. Skipping
+            # ensures consumers are not handed a sentinel or a stale value.
+            raise Skip
+        return value
+    return bind(resolve, *obj._params)
 
 register_reference_transform(_rx_transform)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -866,6 +866,97 @@ async def test_reactive_async_gen_pipe_with_dep():
     await async_wait_until(lambda: rxgen.rx.value == 10, interval=10)
     await async_wait_until(lambda: rxgen.rx.value == 11)
 
+async def mul_slowly(value):
+    await asyncio.sleep(0.02)
+    return value*2
+
+async def test_reactive_async_watcher_not_notified_while_awaiting():
+    irx = rx(1)
+    async_rx = irx.rx.pipe(mul_slowly)
+    items = []
+    async_rx.rx.watch(items.append)
+    assert async_rx.rx.value is param.Undefined
+    await async_wait_until(lambda: items == [2])
+    irx.rx.value = 2
+
+    # The awaited value has not resolved yet, so the watcher must not be
+    # notified with the value computed from the previous input.
+    assert items == [2]
+
+    await async_wait_until(lambda: items == [2, 4])
+
+async def test_reactive_async_downstream_watcher_not_notified_while_awaiting():
+    irx = rx(1)
+    downstream = irx.rx.pipe(mul_slowly) + 10
+    items = []
+    downstream.rx.watch(items.append)
+    assert downstream.rx.value is param.Undefined
+    await async_wait_until(lambda: items == [12])
+    irx.rx.value = 2
+    assert items == [12]
+    await async_wait_until(lambda: items == [12, 14])
+
+async def test_reactive_async_downstream_not_computed_while_awaiting():
+    computed = []
+    def add(value):
+        computed.append(value)
+        return value+10
+
+    irx = rx(1)
+    downstream = irx.rx.pipe(mul_slowly).rx.pipe(add)
+    downstream.rx.watch()
+    downstream.rx.value
+    await async_wait_until(lambda: computed == [2])
+    irx.rx.value = 2
+
+    # The downstream operation must not be applied to the superseded value.
+    assert computed == [2]
+
+    await async_wait_until(lambda: computed == [2, 4])
+
+async def test_reactive_async_rapid_updates_notify_once():
+    irx = rx(1)
+    async_rx = irx.rx.pipe(mul_slowly)
+    items = []
+    async_rx.rx.watch(items.append)
+    async_rx.rx.value
+    await async_wait_until(lambda: items == [2])
+    for value in (2, 3, 4):
+        irx.rx.value = value
+    await async_wait_until(lambda: items == [2, 8])
+    assert items == [2, 8]
+
+def test_reactive_skip_value_does_not_notify_watcher():
+    P = Parameters(integer=1)
+
+    def skip_values(v):
+        if v > 2:
+            raise Skip
+        return v+1
+
+    i = rx(P.param.integer).rx.pipe(skip_values)
+    items = []
+    i.rx.watch(items.append)
+    P.integer = 2
+    assert items == [3]
+
+    # The operation skipped, so the watcher must not be notified with the
+    # value computed from the previous input.
+    P.integer = 3
+    assert items == [3]
+    assert i.rx.value == 3
+
+async def test_reactive_async_ref_not_synced_while_awaiting():
+    class Ref(param.Parameterized):
+        value = param.Integer(default=0, allow_refs=True)
+
+    irx = rx(1)
+    p = Ref(value=irx.rx.pipe(mul_slowly))
+    await async_wait_until(lambda: p.value == 2)
+    irx.rx.value = 2
+    assert p.value == 2
+    await async_wait_until(lambda: p.value == 4)
+
 @pytest.mark.parametrize('lazy', [False, True])
 def test_root_invalidation(lazy):
     arx = rx('a', lazy=lazy)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -957,6 +957,118 @@ async def test_reactive_async_ref_not_synced_while_awaiting():
     assert p.value == 2
     await async_wait_until(lambda: p.value == 4)
 
+async def test_reactive_async_superseded_updates_not_computed():
+    started, finished = [], []
+
+    async def mul(value):
+        started.append(value)
+        await asyncio.sleep(0.02)
+        finished.append(value)
+        return value*2
+
+    irx = rx(1)
+    async_rx = irx.rx.pipe(mul)
+    items = []
+    async_rx.rx.watch(items.append)
+    async_rx.rx.value
+    await async_wait_until(lambda: items == [2])
+    assert started == [1]
+
+    # The updates arrive without yielding to the event loop, so the tasks they
+    # schedule have not started by the time the next one supersedes them.
+    for value in (2, 3, 4, 5):
+        irx.rx.value = value
+
+    await async_wait_until(lambda: items == [2, 10])
+
+    # Only the final update was computed; the superseded coroutines were closed
+    # before their bodies began.
+    assert started == [1, 5]
+    assert finished == [1, 5]
+
+async def test_reactive_async_gen_superseded_updates_not_computed():
+    started = []
+
+    async def gen(value):
+        started.append(value)
+        yield value*2
+
+    irx = rx(1)
+    async_rx = irx.rx.pipe(gen)
+    async_rx.rx.watch()
+    async_rx.rx.value
+    await async_wait_until(lambda: async_rx.rx.value == 2)
+    assert started == [1]
+
+    for value in (2, 3, 4, 5):
+        irx.rx.value = value
+
+    await async_wait_until(lambda: async_rx.rx.value == 10)
+
+    # A superseded async generator is closed before it is first iterated, so
+    # its body never runs.
+    assert started == [1, 5]
+
+async def test_reactive_async_running_task_is_cancelled():
+    cancelled = []
+
+    async def mul(value):
+        try:
+            await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            cancelled.append(value)
+            raise
+        return value*2
+
+    irx = rx(1)
+    async_rx = irx.rx.pipe(mul)
+    async_rx.rx.watch()
+    async_rx.rx.value
+
+    # Yield to the event loop so the body is actually suspended on its await;
+    # a task in that state cannot be skipped, it has to be cancelled.
+    await asyncio.sleep(0.01)
+    irx.rx.value = 2
+
+    await async_wait_until(lambda: async_rx.rx.value == 4)
+    assert cancelled == [1]
+
+@pytest.mark.parametrize('lazy', [False, True])
+async def test_async_shared_rx_superseded_updates_computed_once(lazy):
+    call_count = 0
+
+    class Model(param.Parameterized):
+        a = param.Number(1.0)
+
+    model = Model()
+
+    async def expensive_compute(a):
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.02)
+        return {"x": a + 1, "y": a * 2}
+
+    shared = rx(model.param.a, lazy=lazy).rx.pipe(expensive_compute)
+    x_rx = shared.rx.pipe(lambda d: d["x"])
+    y_rx = shared.rx.pipe(lambda d: d["y"])
+
+    x_rx.rx.value
+    y_rx.rx.value
+    await async_wait_until(lambda: call_count == 1)
+
+    for value in (2.0, 3.0, 4.0):
+        model.a = value
+
+    x_rx.rx.value
+    y_rx.rx.value
+    await async_wait_until(
+        lambda: x_rx.rx.value == 5 and y_rx.rx.value == 8
+    )
+
+    # The branches resolve through the shared node rather than recomputing, and
+    # the superseded updates are not computed at all.
+    assert call_count == 2
+
 @pytest.mark.parametrize('lazy', [False, True])
 def test_root_invalidation(lazy):
     arx = rx('a', lazy=lazy)


### PR DESCRIPTION
Two defects in the same handful of lines of `rx._resolve_async` / `rx._resolve`, both caused by
an async node not distinguishing "the result I hold is current" from "the result I hold was
computed from inputs that have since changed". One leaks a stale value to consumers, the other
wastes computation. They share the generation machinery, so they are fixed together.

## Problem 1: a stale value is propagated while an async node is awaiting

When a reactive expression contains an async operation, every consumer downstream of it is
notified with the *previous* value the moment an input changes, before the new result has
resolved. On the first change that previous value is `Undefined`, so consumers are handed a
sentinel; on later changes they are handed a value computed from inputs that have already been
superseded.

```python
async def mul_slowly(value):
    await asyncio.sleep(0.02)
    return value * 2

i = rx(1)
doubled = i.rx.pipe(mul_slowly)

items = []
doubled.rx.watch(items.append)
await async_wait_until(lambda: items == [2])

i.rx.value = 2
assert items == [2]   # fails on main: [2, 2]
```

The watcher fires twice for one input change: once immediately with the stale `2`, then again
with `4` when the await completes. The same happens for `allow_refs` parameters fed from the
expression, and for `bind`-style consumers, because all three go through the same reference
machinery.

This is not cosmetic. A consumer that renders or persists what it is handed writes the wrong
value and then corrects itself, and a downstream operation is *executed* on the stale value, so
every node in a chain runs twice per change. With more than one async node in a pipeline the
redundant work multiplies.

## Problem 2: superseded async tasks still run to completion

When an async node's inputs change several times without the event loop getting a chance to run
in between, every change spawns a task and every one of those bodies runs to completion
concurrently. Only the last result is used, so the rest is pure waste. For a body that hits a
database or an HTTP API, that is N redundant round trips per burst.

```python
async def body(v):
    started.append(v)
    await asyncio.sleep(0.05)
    finished.append(v)
    return v * 2

expr = rx(1).rx.pipe(body)
...
for v in (2, 3, 4, 5):
    i.rx.value = v          # no await between assignments
```

On main:

```
started=[1, 2, 3, 4, 5]  finished=[2, 3, 4, 5]  notified=[10]
```

Four bodies ran to completion for one burst. Inserting `await asyncio.sleep(0)` between the
assignments gives `finished=[5]`, which is the intended behaviour, so the defect only shows when
updates arrive within a single synchronous block. That is the common case in practice: a callback
that sets several parameters, a `param.update` batch, or a widget that writes value and range
together. Note the notification side was already correct here; this is wasted computation, not
wrong output.

## Root causes

**Problem 1.** `rx._resolve()` catches `Skip` and returns `self._current_`, the last resolved
value. That is the documented behaviour for a user-raised `Skip` (`.rx.value` deliberately keeps
reporting the last value; `test_reactive_skip_value` pins it), but the same code path is what an
async node takes while its result is in flight, and `_rx_transform` turned the resolved value
straight into a reference:

```python
return bind(lambda *_: obj.rx.value, *obj._params)
```

The watchers behind that `bind` are param watchers on the expression's *upstream* parameters, not
on the async result. They fire synchronously when an input changes, pull `obj.rx.value`, and get
the stale value back with nothing distinguishing it from a real one. `Skip` was raised internally
and then discarded.

**Problem 2.** `_lazy_resolve` cancels the previous task before queueing a new one:

```python
previous_task = self._current_task
if previous_task is not None and not previous_task.done():
    previous_task.cancel()
async_executor(partial(self._resolve_async, obj, generation))
```

But `_current_task` was only assigned *inside* `_resolve_async`, which runs once the task is
actually scheduled. A task that `async_executor` has created but the loop has not started yet was
therefore invisible to the next `_lazy_resolve`: it read a `_current_task` still pointing at an
older, already-finished task, saw `.done()` was true, and cancelled nothing. Since two
synchronous parameter assignments never yield to the loop, every task queued in that window
escaped cancellation.

The obvious alternative, having `_lazy_resolve` record the handle it just created, does not work:
`async_executor` returns `None` (`param/_utils.py:611`) and it is a user-replaceable hook that
both Panel and the IPython integration swap out, so changing it to return a task would break
third-party executors.

## Changes

### Problem 1

The fix separates "what value does this node hold" from "did this node produce a value for the
current inputs". The former stays exactly as it was; only the latter is new, and only propagation
consults it.

`rx` gains a `_skipped` flag, set in the `except Skip` handler and cleared on a successful
resolution. Alongside it, `_completed_generation` records the generation whose result has actually
landed, and the `_awaiting` property compares it against `_resolve_generation` to tell whether an
async resolution is still in flight. `_resolve_async` stamps `_completed_generation` at each of the
three sites where it assigns `_current_`, immediately before triggering, including inside the
async-generator loop, so every yield counts as a resolution.

`_resolve()` then reports skip state in three places: a node whose `_prev` is skipped skips too
(rather than computing its operation on a superseded value), a clean node that is awaiting reports
itself skipped while still returning its cached value, and the `_shared`-reuse branch mirrors the
shared node's skip state.

`_rx_transform` raises `Skip` instead of handing over a value when the expression is skipped or
resolves to `Skip`/`Undefined`. `Skip` is already honoured throughout the reference machinery
(`_sync_refs`, `_resolve_ref`, `_execute_watcher`), so watchers, refs and bound functions all
simply do not fire, and fire once with the real value when it lands.

The `_shared`-reuse branch needed restructuring: it used `raise Skip` as plain control flow
*after* assigning `self._current_ = self._shared.rx.value`, so with `_skipped` in place the clone
was mislabelled as skipped and a downstream async node then refused to schedule at all. The sync
path now returns its value directly and mirrors `self._shared._skipped`; only the async path still
raises.

`_current` (the property Panel's render path reads via `rx._callback`) is deliberately untouched,
so panes keep displaying the last good value while a recompute is in flight rather than blanking.

### Problem 2

A task whose generation has already been superseded now declines to run rather than relying on
being cancelled. The generation counter is incremented synchronously in `_lazy_resolve`, so by the
time a queued task starts it can always tell whether it is still the current one, and nothing has
awaited `obj` yet at that point so no body has begun.

The guard runs *before* `self._current_task = task`. That ordering matters: a superseded task that
claimed `_current_task` would clear it again in its `finally` block, hiding the genuinely live task
from the next `_lazy_resolve` and reintroducing the same bug by a different route.

Discarding `obj` is factored into a module-level `_close_stale` helper, since it has three shapes:
a coroutine closes with `obj.close()` (which also suppresses the warning Python emits for a
coroutine that is never awaited), an async generator needs `await obj.aclose()`, and `obj` is
`None` on the `_shared` mirror path, where there is nothing to close. The stale branch of the
async-generator loop, which already did this inline, now calls the same helper.

`_lazy_resolve` keeps its explicit `previous_task.cancel()`. The guard only helps tasks that have
not started; cancellation is still what stops a body already suspended at an await. The two
mechanisms are complementary, and there is a test for each.

## Behaviour change

A user-raised `Skip` inside an `rx` operation no longer notifies watchers with the stale value.

```python
def skip_values(v):
    if v > 2:
        raise Skip
    return v + 1

i = rx(P.param.integer).rx.pipe(skip_values)
items = []
i.rx.watch(items.append)

P.integer = 2   # items == [3]
P.integer = 3   # skipped; on main items becomes [3, 3], now stays [3]
```

The skip used to re-notify with the previous value. This is the same defect as the async case and what `Skip` was always meant to do (it's called `Skip` after all). `.rx.value` still returns the last value in both cases, so the existing `Skip`
contract and its tests are unaffected.

## Tests

Eleven tests in `tests/testreactive.py`, all failing before this change.

Problem 1:

- `test_reactive_async_watcher_not_notified_while_awaiting`
- `test_reactive_async_downstream_watcher_not_notified_while_awaiting`
- `test_reactive_async_downstream_not_computed_while_awaiting`, which counts operation invocations
  to show the downstream node is no longer executed on the stale value
- `test_reactive_async_rapid_updates_notify_once`
- `test_reactive_async_ref_not_synced_while_awaiting`, covering the `allow_refs` path
- `test_reactive_skip_value_does_not_notify_watcher`, pinning the behaviour change above

Problem 2:

- `test_reactive_async_superseded_updates_not_computed`, asserting which bodies start and which
  finish, rather than timing anything
- `test_reactive_async_gen_superseded_updates_not_computed`, where a superseded generator is closed
  before its first iteration so its body never runs at all
- `test_reactive_async_running_task_is_cancelled`, the complementary path: with a yield to the loop
  the body is genuinely suspended and must still be cancelled
- `test_async_shared_rx_superseded_updates_computed_once[False, True]`, a branching pipeline, which
  exercises the `obj=None` mirror path through the new guard

Full suite: 1532 passed, 4 skipped, 2 xfailed, in both random and fixed test order. No existing
test needed modification. Verified separately that async generators still stream every yield, that
several consumers of one awaiting node are each notified exactly once, and that a chain of async
nodes notifies once with the final value. Panel's test suite is unaffected and `mypy` is clean on
`param/reactive.py`.

## AI Disclosure

Developed with the assistance of Claude Opus 5

