### PR TITLE
Fix rx invalidation finalizer keeping its own node alive

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -115,6 +115,8 @@ from ._utils import _to_async_gen, iscoroutinefunction, full_groupby
 if t.TYPE_CHECKING:
     from typing_extensions import Self
 
+    from .parameterized import Watcher
+
     _P = t.ParamSpec('_P')
     _R = t.TypeVar('_R')
     _Y = t.TypeVar('_Y')
@@ -1376,6 +1378,8 @@ class _WeakInvalidator:
 
     __slots__ = ('_ref', '_watcher', '__weakref__')
 
+    _watcher: Watcher | None
+
     def __init__(self, method):
         self._ref = weakref.WeakMethod(method)
         self._watcher = None
@@ -1399,7 +1403,7 @@ def _remove_watcher(
     and cannot be weakly referenced, so it is reached via the invalidator.
     """
     owner, invalidator = owner_ref(), invalidator_ref()
-    if owner is None or invalidator is None:
+    if owner is None or invalidator is None or invalidator._watcher is None:
         return
     try:
         owner.param.unwatch(invalidator._watcher)

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1374,10 +1374,11 @@ class _WeakInvalidator:
     ``rx._watch_invalidation``).
     """
 
-    __slots__ = ('_ref', '__weakref__')
+    __slots__ = ('_ref', '_watcher', '__weakref__')
 
     def __init__(self, method):
         self._ref = weakref.WeakMethod(method)
+        self._watcher = None
 
     def __call__(self, *events):
         method = self._ref()
@@ -1385,10 +1386,25 @@ class _WeakInvalidator:
             return method(*events)
 
 
-def _remove_watcher(owner, watcher):
-    """Unwatch ``watcher`` from ``owner``, ignoring if it is already gone."""
+def _remove_watcher(owner_ref, invalidator_ref):
+    """
+    Unwatch a dead node's invalidation watcher, ignoring if it is already gone.
+
+    Both arguments are weak references. ``weakref.finalize`` keeps its callback
+    arguments alive in a process-global registry until the referent is
+    collected, so holding either the owner or the ``Watcher`` (whose ``inst``
+    field *is* the owner) strongly would risk making the referent permanently
+    reachable — and therefore uncollectable — whenever the owner can reach it,
+    e.g. a function-rooted pipeline whose root function closes over the object
+    that stores the pipeline. The ``Watcher`` cannot be referenced weakly (it
+    subclasses ``tuple``) so it is reached via the invalidator, which is kept
+    alive by the owner's watcher list for exactly as long as it is registered.
+    """
+    owner, invalidator = owner_ref(), invalidator_ref()
+    if owner is None or invalidator is None:
+        return
     try:
-        owner.param.unwatch(watcher)
+        owner.param.unwatch(invalidator._watcher)
     except Exception:
         pass
 
@@ -1758,9 +1774,14 @@ class rx:
         source does not pin the (potentially short-lived) derived node alive.
         A finalizer removes the watcher automatically once this node is garbage
         collected, keeping the source's watcher list from growing without bound.
+        The finalizer is handed weak references only, since anything it owns
+        strongly would keep this node alive forever (see ``_remove_watcher``).
         """
-        watcher = owner.param._watch(_WeakInvalidator(method), names, precedence=-1)
-        weakref.finalize(self, _remove_watcher, owner, watcher)
+        invalidator = _WeakInvalidator(method)
+        invalidator._watcher = owner.param._watch(invalidator, names, precedence=-1)
+        weakref.finalize(
+            self, _remove_watcher, weakref.ref(owner), weakref.ref(invalidator)
+        )
 
     def _invalidate_current(self, *events):
         if all(event.obj is self._trigger for event in events):

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1386,19 +1386,17 @@ class _WeakInvalidator:
             return method(*events)
 
 
-def _remove_watcher(owner_ref, invalidator_ref):
+def _remove_watcher(
+    owner_ref: weakref.ref[Parameterized | type[Parameterized]],
+    invalidator_ref: weakref.ref[_WeakInvalidator],
+) -> None:
     """
     Unwatch a dead node's invalidation watcher, ignoring if it is already gone.
 
-    Both arguments are weak references. ``weakref.finalize`` keeps its callback
-    arguments alive in a process-global registry until the referent is
-    collected, so holding either the owner or the ``Watcher`` (whose ``inst``
-    field *is* the owner) strongly would risk making the referent permanently
-    reachable — and therefore uncollectable — whenever the owner can reach it,
-    e.g. a function-rooted pipeline whose root function closes over the object
-    that stores the pipeline. The ``Watcher`` cannot be referenced weakly (it
-    subclasses ``tuple``) so it is reached via the invalidator, which is kept
-    alive by the owner's watcher list for exactly as long as it is registered.
+    Both refs must be weak: ``weakref.finalize`` holds its arguments until the
+    referent dies, so a strong owner (or ``Watcher``, whose ``inst`` is the
+    owner) would make the node uncollectable. ``Watcher`` subclasses ``tuple``
+    and cannot be weakly referenced, so it is reached via the invalidator.
     """
     owner, invalidator = owner_ref(), invalidator_ref()
     if owner is None or invalidator is None:
@@ -1774,8 +1772,7 @@ class rx:
         source does not pin the (potentially short-lived) derived node alive.
         A finalizer removes the watcher automatically once this node is garbage
         collected, keeping the source's watcher list from growing without bound.
-        The finalizer is handed weak references only, since anything it owns
-        strongly would keep this node alive forever (see ``_remove_watcher``).
+        The finalizer is handed weak references only (see ``_remove_watcher``).
         """
         invalidator = _WeakInvalidator(method)
         invalidator._watcher = owner.param._watch(invalidator, names, precedence=-1)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1056,3 +1056,57 @@ def test_reactive_derived_node_is_garbage_collected():
     a.rx.value = 5
     assert c.rx.value == 15
     assert watcher_count(a) > baseline
+
+
+def _rx_from_closure():
+    """Build an object holding an rx pipeline whose root function closes over it."""
+    class Owner:
+        pass
+
+    owner = Owner()
+
+    def compute(x):
+        return x + len(repr(owner)) * 0
+
+    owner.expr = param.rx(compute)(41)
+    return owner
+
+
+def _rx_from_bound_method():
+    """Build an object holding an rx pipeline rooted in one of its own methods."""
+    class Owner:
+        def __init__(self):
+            self.expr = param.rx(self._compute)(41)
+
+        def _compute(self, x):
+            return x
+
+    return Owner()
+
+
+@pytest.mark.parametrize('factory', [_rx_from_closure, _rx_from_bound_method])
+def test_reactive_function_rooted_node_does_not_pin_its_owner(factory):
+    # weakref.finalize keeps its arguments alive in a process-global registry
+    # until the referent is collected, so the invalidation cleanup must not own
+    # a path back to the node it cleans up. A root function that can reach the
+    # object storing the pipeline used to close that path, making the object
+    # permanently reachable and therefore uncollectable.
+    owner = factory()
+    assert owner.expr.rx.value == 41
+
+    ref = weakref.ref(owner)
+    del owner
+    gc.collect()
+    assert ref() is None
+
+
+@pytest.mark.parametrize('factory', [_rx_from_closure, _rx_from_bound_method])
+def test_reactive_function_rooted_nodes_do_not_accumulate(factory):
+    refs = []
+    for _ in range(50):
+        owner = factory()
+        owner.expr.rx.value
+        refs.append(weakref.ref(owner))
+        del owner
+    gc.collect()
+    assert all(ref() is None for ref in refs)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1086,11 +1086,8 @@ def _rx_from_bound_method():
 
 @pytest.mark.parametrize('factory', [_rx_from_closure, _rx_from_bound_method])
 def test_reactive_function_rooted_node_does_not_pin_its_owner(factory):
-    # weakref.finalize keeps its arguments alive in a process-global registry
-    # until the referent is collected, so the invalidation cleanup must not own
-    # a path back to the node it cleans up. A root function that can reach the
-    # object storing the pipeline used to close that path, making the object
-    # permanently reachable and therefore uncollectable.
+    # weakref.finalize holds its arguments until the referent is collected, so
+    # the invalidation cleanup must not own a path back to the node it cleans up.
     owner = factory()
     assert owner.expr.rx.value == 41
 


### PR DESCRIPTION
## Problem

The invalidation-watcher cleanup added in #1156 introduces a leak that is
stricter than the one it fixes: any **function-rooted pipeline**
(`param.rx(fn)(...)`) whose root function can reach the object that owns the
pipeline becomes permanently uncollectable. On 2.4.1 the same object graph is
an ordinary reference cycle that `gc.collect()` reclaims; since #1156 it can
never be freed.

`rx._watch_invalidation` did:

```python
watcher = owner.param._watch(_WeakInvalidator(method), names, precedence=-1)
weakref.finalize(self, _remove_watcher, owner, watcher)
```

`weakref.finalize` stores its callback and arguments **strongly**, in a
process-global registry, until the referent is collected. The CPython docs warn
about exactly this: `func`, `args` and `kwargs` must not own any references to
the referent, directly or indirectly.

Both arguments violate that. `owner` is passed directly, and `watcher.inst` is
also the owner. For a function-rooted pipeline `owner` is the `Wrapper` whose
`object` parameter holds the user's function, so as soon as that function's
closure reaches the object that stores the expression (the natural shape for an
object caching an rx expression built from its own state) the chain closes:

```
finalize registry ─strong─▶ owner (Wrapper) ─▶ fn closure ─▶ owning object ─▶ rx expr
                                                                             = the finalize referent
```

The referent stays strongly reachable from the global registry, so it is never
collected, so the finalizer never fires, so the watcher is never pruned. The
cleanup's own bookkeeping is what prevents the cleanup. The node, everything it
captured, one registry entry and one live watcher per watched source all leak,
without bound, in any long-running process.

Reproduction, param-only:

```python
import gc, weakref, param

class Owner:
    pass

def make_owner():
    owner = Owner()
    def compute(x):
        return x + id(owner) * 0   # closure reaches the owner
    owner.expr = param.rx(compute)(41)
    return owner

owner = make_owner()
ref = weakref.ref(owner)
del owner
gc.collect()
print(f"owner collected: {ref() is None}")
```

```
2.4.1     ->  owner collected: True
2.4.2rc0  ->  owner collected: False
```

## Fix

Hand the finalizer weak references only.

The owner is passed as a `weakref.ref`, and `_remove_watcher` no-ops when it is
dead (if the owner is gone its watchers went with it). The `Watcher` cannot be
referenced weakly, since it subclasses `tuple` and CPython does not allow a
`__weakref__` slot on variable-length types, so it is stored on the
`_WeakInvalidator` and reached through a weakref to *that* instead. The
invalidator is held only by `watcher.fn` in the owner's watcher list, so it
stays alive for exactly as long as the watcher is registered and a dead weakref
correctly means there is nothing left to unwatch.

The cleanup guarantee from #1156 is unchanged: watchers are still pruned as
soon as the derived node is collected, so a long-lived source's watcher list
still does not grow without bound.

Lazy pruning (removing the watcher when the `WeakMethod` resolves to `None`
during dispatch) was considered as an alternative and rejected: the slot-watcher
dispatch path at `Parameter.__setattr__` iterates `self.watchers[attribute]`
in place, so unwatching mid-dispatch would be unsafe there.

## Verification

- The reported reproduction now prints `owner collected: True`, for both a
  closure-rooted and a bound-method-rooted pipeline.
- 200 short-lived function-rooted pipelines: all 200 owners collected, and the
  `weakref.finalize` registry grows by 0.
- 100 short-lived owners against one long-lived `Parameterized` source: all
  collected and the source's watcher list returns to 0. Before the fix the same
  loop left 101 watchers registered and collected none of the owners.
- Both invalidation paths exercised: argument refs (`_invalidate_current`) and a
  `param.bind` root (`_invalidate_obj`). Live expressions still re-evaluate
  correctly while referenced.
- `test_reactive_derived_node_is_garbage_collected` from #1156 still passes;
  full suite: 1525 passed, 4 skipped, 2 xfailed.

New regression tests cover both the single-owner case and the accumulation
case, parametrized over closure-rooted and bound-method-rooted pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
