### PR TITLE
Add `.rx.awaiting` to report whether an expression is still resolving

### DIFF
--- a/doc/user_guide/Reactive_Expressions.ipynb
+++ b/doc/user_guide/Reactive_Expressions.ipynb
@@ -321,27 +321,7 @@
    "cell_type": "markdown",
    "id": "227a230b-98b2-4097-8a6d-798ddb63b74a",
    "metadata": {},
-   "source": [
-    "## Special Methods on `.rx`\n",
-    "\n",
-    "To circumvent the limitations explained above, the `.rx` namespace provides reactive versions of the operations that can't be made reactive through overloading:\n",
-    "\n",
-    "- `.rx.and_`: Reactive version of `and`.\n",
-    "- `.rx.bool`: Reactive version of `bool()`.\n",
-    "- `.rx.in_`: Reactive version of `in`, testing if the value is in the provided collection.\n",
-    "- `.rx.is_`: Reactive version of `is`, testing the object identity against another object.\n",
-    "- `.rx.is_not`: Reactive version of `is not`, testing the absence of object identity with another object.\n",
-    "- `.rx.len`: Reactive version of `len()`, returning the length of the expression\n",
-    "- `.rx.map`: Applies a function to each item in a collection.\n",
-    "- `.rx.not_`: Reactive version of `not`.\n",
-    "- `.rx.or_`: Reactive version of `or`.\n",
-    "- `.rx.pipe`: Applies the given function (with static or reactive arguments) to this object.\n",
-    "- `.rx.updating`: Returns a boolean indicating whether the expression is currently updating.\n",
-    "- `.rx.when`: Generates a new expression that only updates when the provided dependency updates.\n",
-    "- `.rx.where`: Returns either the first or the second argument, depending on the current value of the expression.\n",
-    "\n",
-    "Unlike their corresponding standard Python equivalent, each of these returns a reactive expression that can thus be combined with other reactive expressions to make reactive pipelines."
-   ]
+   "source": "## Special Methods on `.rx`\n\nTo circumvent the limitations explained above, the `.rx` namespace provides reactive versions of the operations that can't be made reactive through overloading:\n\n- `.rx.and_`: Reactive version of `and`.\n- `.rx.bool`: Reactive version of `bool()`.\n- `.rx.in_`: Reactive version of `in`, testing if the value is in the provided collection.\n- `.rx.is_`: Reactive version of `is`, testing the object identity against another object.\n- `.rx.is_not`: Reactive version of `is not`, testing the absence of object identity with another object.\n- `.rx.len`: Reactive version of `len()`, returning the length of the expression\n- `.rx.map`: Applies a function to each item in a collection.\n- `.rx.not_`: Reactive version of `not`.\n- `.rx.or_`: Reactive version of `or`.\n- `.rx.pipe`: Applies the given function (with static or reactive arguments) to this object.\n- `.rx.updating`: Returns a boolean indicating whether the expression is currently updating.\n- `.rx.when`: Generates a new expression that only updates when the provided dependency updates.\n- `.rx.where`: Returns either the first or the second argument, depending on the current value of the expression.\n\nUnlike their corresponding standard Python equivalent, each of these returns a reactive expression that can thus be combined with other reactive expressions to make reactive pipelines.\n\nThe namespace also provides `.rx.awaiting`, which reports whether an asynchronous operation in the expression is still resolving. Unlike the methods above it is a plain boolean rather than a reactive expression."
   },
   {
    "cell_type": "markdown",
@@ -603,6 +583,20 @@
    "source": [
     "expr.rx.value += 1"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a2b23f9",
+   "source": "#### `.rx.awaiting`\n\nWhile `.rx.updating()` tracks a synchronous computation, an asynchronous operation outlives the update that scheduled it. `.rx.awaiting` reports whether such an operation is still resolving, i.e. whether it has been scheduled but has not yet produced a value for the current inputs.\n\nWhile an expression is awaiting, its value is reported as `Undefined` rather than the value it computed from the previous inputs, so `awaiting` is what distinguishes \"not resolved yet\" from an operation that deliberately skipped. The whole graph feeding the expression is considered, so a synchronous operation downstream of an asynchronous one also reports `True` while its input resolves:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "1d5991d8",
+   "source": "import asyncio\n\nasync def slow_double(value):\n    await asyncio.sleep(1)\n    return value * 2\n\nasync_expr = rx(1).rx.pipe(slow_double) + 1\n\nprint(f'requested: value={async_expr.rx.value!r}, awaiting={async_expr.rx.awaiting}')\n\nawait asyncio.sleep(1.5)\n\nprint(f'settled:   value={async_expr.rx.value!r}, awaiting={async_expr.rx.awaiting}')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2647,10 +2647,7 @@ class Selector(SelectorBase, _SignatureSelector[_T]):
         object.__setattr__(self, 'check_on_set', check_on_set)
 
         instantiate = params.pop("instantiate", Undefined)
-        instantiate_value = False
-        if isinstance(instantiate, bool):
-            instantiate_value = instantiate
-        params["instantiate"] = instantiate_value
+        params["instantiate"] = False if instantiate is Undefined else instantiate  # pyrefly: ignore[bad-assignment]
         super().__init__(default=default, **params)
         # Required as Parameter sets allow_None=True if default is None
         if allow_None is Undefined:

--- a/param/parameters.py
+++ b/param/parameters.py
@@ -2647,7 +2647,10 @@ class Selector(SelectorBase, _SignatureSelector[_T]):
         object.__setattr__(self, 'check_on_set', check_on_set)
 
         instantiate = params.pop("instantiate", Undefined)
-        params["instantiate"] = False if instantiate is Undefined else instantiate  # pyrefly: ignore[bad-assignment]
+        instantiate_value = False
+        if isinstance(instantiate, bool):
+            instantiate_value = instantiate
+        params["instantiate"] = instantiate_value
         super().__init__(default=default, **params)
         # Required as Parameter sets allow_None=True if default is None
         if allow_None is Undefined:

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -763,6 +763,67 @@ class reactive_ops:
         resolver = resolver_type(object=self._reactive, recursive=recursive)
         return resolver.param.value.rx()
 
+    @property
+    def awaiting(self) -> bool:
+        """
+        Whether any asynchronous operation in this expression is still resolving.
+
+        ``True`` from the moment an asynchronous operation is scheduled until it
+        produces a value for the current inputs. While a node is awaiting, the
+        expression still holds the value it computed from the previous inputs,
+        so ``.rx.value`` reports :obj:`param.Undefined` rather than that stale
+        value; ``awaiting`` distinguishes "not resolved yet" from an operation
+        that deliberately skipped.
+
+        The whole graph feeding the expression is considered, not just the node
+        it is accessed on, so a synchronous operation downstream of an
+        asynchronous one reports ``True`` while its input resolves.
+
+        Reading this does not itself schedule anything, so an expression whose
+        value has never been requested reports ``False`` until something asks
+        for it.
+
+        Both routes an asynchronous callable can take are tracked: one applied
+        as an operation, e.g. passed to ``.rx.pipe``, and one passed to ``rx``
+        as the object itself, which is held on a parameter and resolved by the
+        reference machinery. A generator settles on each value it yields, so it
+        reports ``True`` only until its next value arrives rather than until it
+        is exhausted. Accessed on a parameter rather than an expression this is
+        always ``False``.
+
+        Returns
+        -------
+        bool
+            ``True`` while an asynchronous operation has not yet produced a
+            value for the current inputs, ``False`` otherwise.
+
+        Examples
+        --------
+        Pipe through a coroutine function and observe the expression settle:
+
+        >>> import asyncio, param
+        >>> async def double(value):
+        ...     await asyncio.sleep(0.1)
+        ...     return value * 2
+        >>> expr = param.rx(1).rx.pipe(double) + 1
+
+        Requesting the value schedules the operation:
+
+        >>> expr.rx.value is param.Undefined
+        True
+        >>> expr.rx.awaiting
+        True
+
+        Once the coroutine has resolved the expression reports a value again:
+
+        >>> expr.rx.awaiting  # doctest: +SKIP
+        False
+        """
+        reactive = self._reactive
+        if not isinstance(reactive, rx):
+            return False
+        return any(node._settling for node in reactive._upstream())
+
     def updating(self) -> 'rx':
         """
         Return a new expression that indicates whether the current expression is updating.
@@ -1708,8 +1769,63 @@ class rx:
         """
         Whether an asynchronous resolution is in flight that has not yet
         produced a value for the current generation.
+
+        While a node is awaiting, the cached ``_current_`` value was computed
+        from inputs that have since been superseded, so resolving the node
+        skips instead of reporting the stale value as if it were current.
         """
         return self._resolve_generation != self._finished_generation
+
+    @property
+    def _awaiting_ref(self) -> bool:
+        """
+        Whether an asynchronous reference feeding this node has not yet
+        produced a value for the current inputs.
+
+        A coroutine or generator function passed to ``rx`` as the object rather
+        than as an operation is held on a parameter and resolved by the
+        reference machinery, so its settlement is tracked there instead of by
+        this node's own generations.
+        """
+        for p in self._internal_params:
+            owner, name = p.owner, p.name
+            if name is None or not isinstance(owner, Parameterized):
+                continue
+            if owner.param._awaiting_ref(name):
+                return True
+        return False
+
+    @property
+    def _settling(self) -> bool:
+        """Whether this node is waiting on an asynchronous result of its own."""
+        return self._awaiting or self._awaiting_ref
+
+    def _upstream(self) -> Iterator[rx]:
+        """
+        Yield this node and every ``rx`` node it derives its value from.
+
+        Inputs reach a node by three routes, all of which have to be visited
+        because an operation is only as settled as the nodes feeding it: the
+        ``_prev`` chain of the pipeline the node belongs to, the ``_shared``
+        input it was cloned from when a pipeline branches, and any ``rx``
+        passed as an argument to one of its operations.
+        """
+        seen: set[int] = set()
+        stack: list[rx] = [self]
+        while stack:
+            node = stack.pop()
+            if id(node) in seen:
+                continue
+            seen.add(id(node))
+            yield node
+            for inp in (node._prev, node._shared):
+                if isinstance(inp, rx):
+                    stack.append(inp)
+            operation = node._operation
+            if operation:
+                stack.extend(_iter_rx((
+                    operation['fn'], operation.get('args', ()), operation.get('kwargs', {})
+                )))
 
     @property
     def _current(self):
@@ -2297,6 +2413,27 @@ class rx:
                 "'<reactive_expr>.rx.value = <val>'."
             )
         super().__setattr__(name, value)
+
+
+def _iter_rx(value: t.Any) -> Iterator[rx]:
+    """
+    Yield the reactive expressions nested anywhere inside a reference.
+
+    Mirrors the containers ``resolve_value`` descends into, so an ``rx`` used
+    as an operation argument is found wherever ``resolve_value`` would find it.
+    """
+    if isinstance(value, rx):
+        yield value
+    elif isinstance(value, (list, tuple, set)):
+        for v in value:
+            yield from _iter_rx(v)
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            yield from _iter_rx(k)
+            yield from _iter_rx(v)
+    elif isinstance(value, slice):
+        for v in (value.start, value.stop, value.step):
+            yield from _iter_rx(v)
 
 
 def _rx_transform(obj):

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -113,6 +113,7 @@ from .parameters import Boolean, Event
 from ._utils import _to_async_gen, iscoroutinefunction, full_groupby
 
 if t.TYPE_CHECKING:
+    import builtins
     from typing_extensions import Self
 
     from .parameterized import Watcher
@@ -764,7 +765,7 @@ class reactive_ops:
         return resolver.param.value.rx()
 
     @property
-    def awaiting(self) -> bool:
+    def awaiting(self) -> builtins.bool:
         """
         Whether any asynchronous operation in this expression is still resolving.
 
@@ -1800,7 +1801,7 @@ class rx:
         """Whether this node is waiting on an asynchronous result of its own."""
         return self._awaiting or self._awaiting_ref
 
-    def _upstream(self) -> Iterator[rx]:
+    def _upstream(self) -> Iterator[t.Any]:
         """
         Yield this node and every ``rx`` node it derives its value from.
 

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -677,6 +677,246 @@ def test_reactive_resolve_recursive(lazy):
     assert resolved_prx.rx.value == 'string'
     assert changes == [4, 3.14, 'string']
 
+def test_reactive_awaiting_sync_expression():
+    expr = rx(1) + 2
+
+    assert expr.rx.value == 3
+    assert not expr.rx.awaiting
+
+def test_reactive_awaiting_on_parameter():
+    class P(param.Parameterized):
+        a = param.Number(default=1)
+
+    assert not P().param.a.rx.awaiting
+
+def test_reactive_awaiting_skip_is_not_awaiting():
+    def maybe(value):
+        if value < 5:
+            raise Skip
+        return value
+
+    expr = rx(0).rx.pipe(maybe)
+
+    assert expr.rx.value != 0
+    assert expr._skipped
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_async_pipe():
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    expr = rx(0).rx.pipe(async_func)
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 2)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_not_scheduled_until_requested():
+    """
+    Reading awaiting must not itself schedule a resolution, so an expression
+    whose value has never been requested is not awaiting.
+    """
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    expr = rx(0).rx.pipe(async_func)
+
+    assert not expr.rx.awaiting
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+
+async def test_reactive_awaiting_visible_downstream_of_async_node():
+    """
+    Only the async node itself tracks its resolution, so awaiting has to
+    consider the whole graph feeding the expression it is accessed on.
+    """
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    expr = rx(0).rx.pipe(async_func) + 10
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 12)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_on_recompute():
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    number = rx(0)
+    expr = number.rx.pipe(async_func) + 10
+    expr.rx.watch()
+
+    await async_wait_until(lambda: expr.rx.value == 12)
+    assert not expr.rx.awaiting
+
+    number.rx.value = 5
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 17)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_through_operation_argument():
+    """An rx passed as an operation argument is upstream of the operation."""
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    inner = rx(0).rx.pipe(async_func)
+    expr = rx(100) + inner
+
+    # Requesting the value schedules the inner resolve
+    unsettled = expr.rx.value
+
+    assert unsettled != 102
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 102)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_branching_pipeline():
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    base = rx(0).rx.pipe(async_func)
+    branch1 = base + 100
+    branch2 = base + 200
+
+    assert branch1.rx.value is param.Undefined
+    assert branch2.rx.value is param.Undefined
+    assert branch1.rx.awaiting
+    assert branch2.rx.awaiting
+    await async_wait_until(lambda: branch1.rx.value == 102)
+    await async_wait_until(lambda: branch2.rx.value == 202)
+    assert not branch1.rx.awaiting
+    assert not branch2.rx.awaiting
+
+async def test_reactive_awaiting_async_gen_settles_per_emission():
+    async def gen(value):
+        yield value + 1
+        await asyncio.sleep(0.1)
+        yield value + 2
+
+    expr = rx(0).rx.pipe(gen)
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 1, interval=10)
+    assert not expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 2)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_root_async_func():
+    """
+    A coroutine function passed to rx as the object is held on a parameter and
+    resolved by the reference machinery rather than as an operation, so its
+    settlement is tracked there.
+    """
+    async def async_func():
+        await asyncio.sleep(0.02)
+        return 2
+
+    expr = rx(async_func) + 2
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 4)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_root_async_func_on_recompute():
+    async def async_func(i):
+        await asyncio.sleep(0.02)
+        return i * 10
+
+    number = rx(1)
+    expr = rx(bind(async_func, number)) + 1
+
+    await async_wait_until(lambda: expr.rx.value == 11)
+    assert not expr.rx.awaiting
+
+    number.rx.value = 5
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 51)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_root_gen_settles_per_emission():
+    def gen():
+        yield 1
+        time.sleep(0.1)
+        yield 2
+
+    expr = rx(gen) + 100
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 101, interval=10)
+    assert not expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 102)
+    assert not expr.rx.awaiting
+
+async def test_reactive_awaiting_async_ref_on_parameterized():
+    """An async ref on a Parameterized feeding an expression is tracked too."""
+    class P(param.Parameterized):
+        value = param.Parameter(default=0, allow_refs=True)
+
+    async def async_func():
+        await asyncio.sleep(0.02)
+        return 7
+
+    p = P()
+    expr = p.param.value.rx() + 1
+    expr.rx.watch()
+
+    assert expr.rx.value == 1
+    assert not expr.rx.awaiting
+
+    p.value = async_func
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 8)
+    assert not expr.rx.awaiting
+
+def test_reactive_awaiting_sync_ref_never_awaits():
+    class P(param.Parameterized):
+        source = param.Number(default=1)
+        target = param.Number(default=0, allow_refs=True)
+
+    p = P()
+    p.target = p.param.source
+    expr = p.param.target.rx() + 1
+
+    assert not expr.rx.awaiting
+    p.source = 5
+    assert not expr.rx.awaiting
+    assert expr.rx.value == 6
+
+async def test_reactive_awaiting_settles_when_async_ref_yields_nothing():
+    """A resolution that never produces a value must not stay in flight."""
+    def gen():
+        return
+        yield  # pragma: no cover
+
+    expr = rx(gen) + 100
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: not expr.rx.awaiting)
+
+def test_reactive_upstream_walk_terminates_on_reused_input():
+    a = rx(1)
+    b = a + 1
+    expr = b + a
+
+    nodes = list(expr._upstream())
+
+    assert expr.rx.value == 3
+    assert len(nodes) == len({id(node) for node in nodes})
+    assert any(node is expr for node in nodes)
+
 @pytest.mark.parametrize('lazy', [False, True])
 async def test_reactive_async_func(lazy):
     async def async_func():


### PR DESCRIPTION
## Problem

Since #1173 an `rx` node whose asynchronous operation is in flight reports `param.Undefined`
rather than the value it computed from inputs that have since been superseded. That fixed the
stale value, but it left no way to ask a reactive expression whether anything feeding it is
still in flight. 

## API

`reactive_ops.awaiting` is a read-only property on the `.rx` namespace:

```python
>>> expr = param.rx(1).rx.pipe(slow_double) + 1
>>> expr.rx.value is param.Undefined
True
>>> expr.rx.awaiting
True
```

It is a plain `bool`, not a reactive expression, which makes it the only member of the
namespace that is not composable (apart from `.rx.value`).

## Changes

`reactive_ops.awaiting` walks the graph and asks each node whether it is settling:

```python
return any(node._settling for node in reactive._upstream())
```

`rx._upstream()` yields the node and everything it derives its value from. Inputs reach a node
by three routes and all of them have to be followed, because an operation is only as settled
as the nodes feeding it:

- the `_prev` chain of the pipeline the node belongs to,
- the `_shared` input it was cloned from when a pipeline branches,
- and any `rx` passed as an argument to one of its operations, which
  `_iter_rx` finds by descending the same containers `resolve_value` does (list, tuple, set,
  dict keys and values, slice components).

The walk is iterative with an `id()`-keyed seen-set, because reusing an input clones it and
links the clones through `_shared`, so the graph is a DAG rather than a chain and a naive walk
would revisit nodes.

`rx._settling` is `self._awaiting or self._awaiting_ref`, i.e. either of the two resolution
mechanisms. `rx._awaiting_ref` checks the node's internal parameters against
`Parameters._awaiting_ref` from #1175, covering the case where the asynchronous callable is
held on a parameter rather than applied as an operation. Both are private; `_awaiting` keeps
its existing meaning and `awaiting` is the only public addition.

## Design notes

**Reading it does not schedule anything.** `awaiting` deliberately does not touch `_obj` or
otherwise resolve the node, so an expression whose value has never been requested reports
`False` rather than `True`. "Nothing has been asked for yet" is not the same as "a result is
pending", and a property that started work as a side effect of being read would be a trap in
a loading indicator.

**Generators settle per emission.** A generator or async generator ref settles on each value
it yields rather than on exhaustion, so `awaiting` is `True` only until the next value
arrives. A spinner driven by it stops between emissions instead of spinning until the stream
ends, which is the useful reading for a streaming source.

**`_skipped` was not usable for this.** It conflates "the async result is not in yet" with
"an operation raised `Skip`", which are precisely the two states `awaiting` exists to tell
apart.

## Docs

Adds a `.rx.awaiting` section to the `Reactive_Expressions.ipynb` user guide, contrasting it
with `.rx.updating()`: `updating()` tracks a synchronous computation, while an asynchronous
operation outlives the update that scheduled it. The list of special methods on `.rx` closes
by saying each entry returns a reactive expression, so `awaiting` is mentioned after it with
the difference called out rather than being added to the list.

The example uses a single top-level `await` in one cell so a docs build is deterministic
rather than depending on when the notebook's kernel gets around to a background task.

## AI Disclosure

Written with the assistance of Claude Opus 5.