### PR TITLE
Fix branching off an async rx node

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1616,6 +1616,12 @@ class rx:
         if operation and (iscoroutinefunction(operation['fn']) or inspect.isgeneratorfunction(operation['fn'])):
             self._trigger = Trigger(internal=True)
             self._current_ = Undefined
+            # An asynchronous operation has not resolved yet, even when cloned
+            # from a node that has already settled, so the node must be marked
+            # dirty. Otherwise the discarded _current would leave it clean while
+            # holding Undefined, i.e. permanently stranded since nothing else
+            # will mark it dirty until an input changes.
+            self._dirty = True
         else:
             self._trigger = None
         self._root = self._compute_root()
@@ -1907,15 +1913,27 @@ class rx:
                     # If this rx is cloned from an shared input then we make use
                     # of the shared.rx.value to ensure branching pipelines do
                     # not have to recompute the inputs multiple times.
-                    if self._is_async:
-                        self._shared.rx.value # trigger async resolve
+                    shared = self._shared
+                    value = shared.rx.value # triggers async resolve
+                    if self._is_async and (
+                        shared._awaiting or shared._current_task is not None
+                    ):
+                        # The shared node has not settled on a value for the
+                        # current generation, so adopt it once its task is done.
                         self._lazy_resolve()
                         raise Skip
                     # Returns instead of raising Skip because this path does
                     # resolve to a value, so it must mirror the shared node's
                     # skip state rather than be marked skipped by the handler.
-                    self._current_ = self._shared.rx.value
-                    self._skipped = self._shared._skipped
+                    self._current_ = value
+                    self._skipped = shared._skipped
+                    if self._is_async:
+                        # The value was adopted without scheduling a task, so
+                        # claim a generation for it. This supersedes a task an
+                        # earlier read may have scheduled and keeps _awaiting
+                        # from reporting a resolution that is not in flight.
+                        self._resolve_generation += 1
+                        self._finished_generation = self._resolve_generation
                     self._dirty = False
                     return self._current_
                 operation = self._operation

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1615,11 +1615,8 @@ class rx:
         self._trigger: Trigger | None
         if operation and (iscoroutinefunction(operation['fn']) or inspect.isgeneratorfunction(operation['fn'])):
             self._trigger = Trigger(internal=True)
-            # An async node's value is owned by _resolve, so discard any
-            # _current a branching clone inherited and mark it dirty,
-            # otherwise it is stuck as Undefined.
             self._current_ = Undefined
-            self._dirty = True
+            self._dirty = True  # Otherwise current will be stuck as Undefined.
         else:
             self._trigger = None
         self._root = self._compute_root()
@@ -1916,8 +1913,7 @@ class rx:
                     if self._is_async and (
                         shared._awaiting or shared._current_task is not None
                     ):
-                        # The shared node has not settled on a value for the
-                        # current generation, so adopt it once its task is done.
+                        # The shared node is still processing, resolve when finished
                         self._lazy_resolve()
                         raise Skip
                     # Returns instead of raising Skip because this path does
@@ -1928,8 +1924,7 @@ class rx:
                     if self._is_async:
                         # The value was adopted without scheduling a task, so
                         # claim a generation for it. This supersedes a task an
-                        # earlier read may have scheduled and keeps _awaiting
-                        # from reporting a resolution that is not in flight.
+                        # earlier operation may have scheduled and still awaits a resolution.
                         self._resolve_generation += 1
                         self._finished_generation = self._resolve_generation
                     self._dirty = False

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1615,12 +1615,10 @@ class rx:
         self._trigger: Trigger | None
         if operation and (iscoroutinefunction(operation['fn']) or inspect.isgeneratorfunction(operation['fn'])):
             self._trigger = Trigger(internal=True)
+            # An async node's value is owned by _resolve, so discard any
+            # _current a branching clone inherited and mark it dirty,
+            # otherwise it is stuck as Undefined.
             self._current_ = Undefined
-            # An asynchronous operation has not resolved yet, even when cloned
-            # from a node that has already settled, so the node must be marked
-            # dirty. Otherwise the discarded _current would leave it clean while
-            # holding Undefined, i.e. permanently stranded since nothing else
-            # will mark it dirty until an input changes.
             self._dirty = True
         else:
             self._trigger = None

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1069,6 +1069,99 @@ async def test_async_shared_rx_superseded_updates_computed_once(lazy):
     # the superseded updates are not computed at all.
     assert call_count == 2
 
+async def _pair(value):
+    await asyncio.sleep(0.02)
+    return (value * 2, value * 3)
+
+async def test_async_shared_rx_branch_after_settling_resolves():
+    irx = rx(1)
+    node = irx.rx.pipe(_pair)
+    node.rx.value
+    await async_wait_until(lambda: node.rx.value == (2, 3))
+
+    # The branch mirrors a node that has already settled, so it must resolve
+    # on its first read rather than being stranded on Undefined.
+    first = node[0]
+    assert first.rx.value == 2
+
+    irx.rx.value = 3
+    await async_wait_until(lambda: first.rx.value == 6)
+
+async def test_async_shared_rx_branch_while_awaiting_resolves():
+    irx = rx(1)
+    node = irx.rx.pipe(_pair)
+    node.rx.value
+
+    first = node[0]
+    assert first.rx.value is param.Undefined
+    await async_wait_until(lambda: first.rx.value == 2)
+
+async def test_async_shared_rx_branch_before_resolving_resolves():
+    irx = rx(1)
+    node = irx.rx.pipe(_pair)
+    first, second = node[0], node[1]
+
+    assert first.rx.value is param.Undefined
+    await async_wait_until(lambda: first.rx.value == 2)
+
+    # The shared node has settled by now, so the sibling branch resolves on
+    # its first read.
+    assert second.rx.value == 3
+
+async def test_async_shared_rx_branch_computed_once():
+    call_count = 0
+
+    async def pair(value):
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.02)
+        return (value * 2, value * 3)
+
+    irx = rx(1)
+    node = irx.rx.pipe(pair)
+    first, second = node[0], node[1]
+
+    first.rx.value
+    second.rx.value
+    await async_wait_until(lambda: first.rx.value == 2 and second.rx.value == 3)
+
+    # The branches resolve through the shared node rather than recomputing.
+    assert call_count == 1
+
+    irx.rx.value = 3
+    await async_wait_until(lambda: first.rx.value == 6 and second.rx.value == 9)
+    assert call_count == 2
+
+async def test_async_shared_rx_branch_notifies_watcher():
+    irx = rx(1)
+    node = irx.rx.pipe(_pair)
+    node.rx.value
+    await async_wait_until(lambda: node.rx.value == (2, 3))
+
+    items = []
+    first = node[0]
+    assert first.rx.value == 2
+    first.rx.watch(items.append)
+
+    irx.rx.value = 3
+    await async_wait_until(lambda: items == [6])
+    assert items == [6]
+
+async def test_async_gen_shared_rx_branch_resolves():
+    async def gen(value):
+        for i in range(3):
+            await asyncio.sleep(0.02)
+            yield (value + i, i)
+
+    irx = rx(1)
+    node = irx.rx.pipe(gen)
+    node.rx.value
+    await async_wait_until(lambda: node.rx.value == (3, 2))
+
+    # A branch of a generator node adopts the value the generator settled on.
+    first = node[0]
+    assert first.rx.value == 3
+
 @pytest.mark.parametrize('lazy', [False, True])
 def test_root_invalidation(lazy):
     arx = rx('a', lazy=lazy)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1121,6 +1121,7 @@ async def test_async_shared_rx_branch_computed_once():
     node = irx.rx.pipe(count_pair)
     first, second = node[0], node[1]
 
+    # Request the value for both nodes
     first.rx.value
     second.rx.value
     await async_wait_until(lambda: first.rx.value == 2 and second.rx.value == 3)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1111,14 +1111,14 @@ async def test_async_shared_rx_branch_before_resolving_resolves():
 async def test_async_shared_rx_branch_computed_once():
     call_count = 0
 
-    async def pair(value):
+    async def count_pair(value):
         nonlocal call_count
         call_count += 1
         await asyncio.sleep(0.02)
         return (value * 2, value * 3)
 
     irx = rx(1)
-    node = irx.rx.pipe(pair)
+    node = irx.rx.pipe(count_pair)
     first, second = node[0], node[1]
 
     first.rx.value


### PR DESCRIPTION
A branch taken off an async node that has already settled never resolves. It reports
`Undefined` forever, silently, and no internal state flags the condition: the node is not dirty
and not awaiting, so nothing will ever schedule a resolution for it.

```python
async def pair(v):
    await asyncio.sleep(0.01)
    return (v * 2, {"trace": v})

node = rx(1).rx.pipe(pair)
node.rx.value
await async_wait_until(lambda: node.rx.value == (2, {"trace": 1}))

first = node[0]
first.rx.value   # Undefined on main, forever
```

Branching a tuple- or dict-returning node into its components (`node[0]`, `node[1]`,
`node.attr`) is the normal way to fan a single computation out to several consumers, and for a
synchronous node it works and costs one compute. For an async node it depends entirely on *when*
the branch is created: before the node is driven it resolves, in flight it resolves, and after it
has settled it never resolves at all.

## Cause

`node[0]` builds a two-node chain: a `_clone(copy=True)` mirror that carries the same async
operation with `_shared` pointing at the original, and the `getitem` node on top of it.

`_clone(copy=True)` passes `_current=self._current`, so `__init__` computes
`self._dirty = _current is None or _current is Undefined` and gets `False` because the shared
node has a value. A few lines later the async branch of `__init__` discards that value:

```python
if operation and (iscoroutinefunction(operation['fn']) or inspect.isgeneratorfunction(operation['fn'])):
    self._trigger = Trigger(internal=True)
    self._current_ = Undefined     # _dirty is left False
```

The mirror is born clean while holding `Undefined`. `_resolve` therefore takes its `else` branch
and returns `Undefined` without scheduling anything, and the `getitem` node on top sees
`obj is Undefined` and skips. Generations stay at `0 == 0`, so `_awaiting` is `False`, and only an
input change would ever mark the mirror dirty again.

The same applies to async generator nodes, which are cloned through the same branch of
`__init__`.

## Fix

Two changes in `param/reactive.py`.

`__init__` marks a node with an async operation dirty when it clears `_current_`. An async
operation has not resolved yet even when cloned from a node that has settled, so the node has to
be born dirty for the first read to resolve it.

`_resolve`'s shared-input path then adopts the shared node's value synchronously when that node
has settled, instead of always scheduling a task to copy it one event loop iteration later:

```python
shared = self._shared
value = shared.rx.value                  # triggers async resolve
if self._is_async and (shared._awaiting or shared._current_task is not None):
    self._lazy_resolve()                 # adopt it once the task is done
    raise Skip
self._current_ = value
self._skipped = shared._skipped
```

Adopting synchronously claims a generation (`_resolve_generation`/`_finished_generation`), which
supersedes a task an earlier read may have scheduled and keeps `_awaiting` from reporting a
resolution that is not in flight.

This also removes the second-read wart that motivated the workaround in downstream code: with
`first, second = node[0], node[1]`, reading `first` to completion previously left `second`
returning `Undefined` on its first read and the value only on its next. The shared node has
settled by the time `second` is first read, so it now resolves immediately.

A branch created before the node is driven still returns `Undefined` on its first read; nothing
has been computed yet, and that is the ordinary demand-driven async pattern.

## AI Disclosure

Developed with the assistance of Claude Opus 5 and manually tested.