### PR TITLE
Fix an unhandled exception in an async rx operation

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1840,11 +1840,11 @@ class rx:
             # it from the next _lazy_resolve.
             await _close_stale(obj)
             return
-        self._current_task = task = asyncio.current_task()
         trigger = self._trigger
+        if trigger is None:
+            return
+        self._current_task = task = asyncio.current_task()
         try:
-            if trigger is None:
-                return
             if obj is None:
                 shared = self._shared
                 if shared is None:
@@ -1873,6 +1873,20 @@ class rx:
                 trigger.param.trigger('value')
         except asyncio.CancelledError:
             return
+        except Exception as e:
+            if stale():
+                # A newer resolution superseded this one, so bail.
+                return
+            self._finished_generation = generation
+            if self._dirty or self._root._dirty_obj:
+                # The inputs were invalidated while this computation was in
+                # flight, so ignore the error.
+                return
+            # Mirror the synchronous path in _resolve: record the error so it is
+            # re-raised on every read until an invalidation clears it. For an
+            # async generator the raise ends the stream.
+            self._error_state = e
+            trigger.param.trigger('value')
         finally:
             if self._current_task is task:
                 self._current_task = None

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -1875,16 +1875,13 @@ class rx:
             return
         except Exception as e:
             if stale():
-                # A newer resolution superseded this one, so bail.
                 return
             self._finished_generation = generation
             if self._dirty or self._root._dirty_obj:
-                # The inputs were invalidated while this computation was in
-                # flight, so ignore the error.
+                # Ignoring as the inputs were invalidated while the async operation was running
                 return
-            # Mirror the synchronous path in _resolve: record the error so it is
-            # re-raised on every read until an invalidation clears it. For an
-            # async generator the raise ends the stream.
+            # Mirror the synchronous path in _resolve.
+            # For an async generator an raised exception ends the stream.
             self._error_state = e
             trigger.param.trigger('value')
         finally:

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1069,6 +1069,114 @@ async def test_async_shared_rx_superseded_updates_computed_once(lazy):
     # the superseded updates are not computed at all.
     assert call_count == 2
 
+async def test_reactive_async_error_raised_on_read():
+    async def mul(value):
+        await asyncio.sleep(0.01)
+        if value == 2:
+            raise RuntimeError('boom')
+        return value*2
+
+    irx = rx(1)
+    async_rx = irx.rx.pipe(mul)
+    async_rx.rx.value
+    await async_wait_until(lambda: async_rx.rx.value == 2)
+
+    irx.rx.value = 2
+    async_rx.rx.value
+
+    # The failed operation must settle the node and store the error, so it is
+    # re-raised on every read instead of leaving the node awaiting forever.
+    await async_wait_until(lambda: async_rx._error_state is not None)
+    assert not async_rx._awaiting
+    with pytest.raises(RuntimeError, match='boom'):
+        async_rx.rx.value
+
+    # A new input clears the error and the pipeline recovers.
+    irx.rx.value = 3
+    async_rx.rx.value
+    await async_wait_until(lambda: async_rx.rx.value == 6)
+
+async def test_reactive_async_error_propagates_downstream():
+    async def mul(value):
+        await asyncio.sleep(0.01)
+        raise RuntimeError('boom')
+
+    irx = rx(1)
+    downstream = irx.rx.pipe(mul) + 10
+    downstream.rx.value
+    await async_wait_until(lambda: downstream._prev._error_state is not None)
+    with pytest.raises(RuntimeError, match='boom'):
+        downstream.rx.value
+
+async def test_reactive_async_error_propagates_to_shared_branches():
+    async def compute(value):
+        await asyncio.sleep(0.01)
+        raise RuntimeError('boom')
+
+    shared = rx(1).rx.pipe(compute)
+    x_rx = shared.rx.pipe(lambda d: d['x'])
+    y_rx = shared.rx.pipe(lambda d: d['y'])
+
+    x_rx.rx.value
+    y_rx.rx.value
+    await async_wait_until(lambda: not shared._awaiting)
+    for branch in (x_rx, y_rx):
+        with pytest.raises(RuntimeError, match='boom'):
+            branch.rx.value
+
+async def test_reactive_async_gen_error_ends_stream():
+    async def gen(value):
+        for i in range(3):
+            await asyncio.sleep(0.01)
+            if i == 2:
+                raise RuntimeError('boom')
+            yield value+i
+
+    async_rx = rx(1).rx.pipe(gen)
+    async_rx.rx.value
+    await async_wait_until(lambda: async_rx._error_state is not None)
+
+    # The raise ends the generator's stream and is reported on the next read.
+    assert not async_rx._awaiting
+    with pytest.raises(RuntimeError, match='boom'):
+        async_rx.rx.value
+
+async def test_reactive_gen_error_ends_stream():
+    def gen(value):
+        yield value
+        raise RuntimeError('boom')
+
+    async_rx = rx(1).rx.pipe(gen)
+    async_rx.rx.value
+    await async_wait_until(lambda: async_rx._error_state is not None)
+    assert not async_rx._awaiting
+    with pytest.raises(RuntimeError, match='boom'):
+        async_rx.rx.value
+
+async def test_reactive_async_superseded_error_not_recorded():
+    async def mul(value):
+        await asyncio.sleep(0.02)
+        if value == 2:
+            raise RuntimeError('boom')
+        return value*2
+
+    irx = rx(1)
+    async_rx = irx.rx.pipe(mul)
+    async_rx.rx.value
+    await async_wait_until(lambda: async_rx.rx.value == 2)
+
+    irx.rx.value = 2
+    async_rx.rx.value
+    # Yield to the event loop so the failing task is suspended on its await and
+    # is superseded while in flight.
+    await asyncio.sleep(0.01)
+    irx.rx.value = 3
+    async_rx.rx.value
+
+    # The error belongs to a superseded input, so it must not poison the node.
+    await async_wait_until(lambda: async_rx.rx.value == 6)
+    assert async_rx._error_state is None
+
 @pytest.mark.parametrize('lazy', [False, True])
 def test_root_invalidation(lazy):
     arx = rx('a', lazy=lazy)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1074,7 +1074,7 @@ async def test_reactive_async_error_raised_on_read():
         await asyncio.sleep(0.01)
         if value == 2:
             raise RuntimeError('boom')
-        return value*2
+        return 10 * value
 
     irx = rx(1)
     async_rx = irx.rx.pipe(mul)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1079,7 +1079,7 @@ async def test_reactive_async_error_raised_on_read():
     irx = rx(1)
     async_rx = irx.rx.pipe(mul)
     async_rx.rx.value
-    await async_wait_until(lambda: async_rx.rx.value == 2)
+    await async_wait_until(lambda: async_rx.rx.value == 10)
 
     irx.rx.value = 2
     async_rx.rx.value
@@ -1094,7 +1094,7 @@ async def test_reactive_async_error_raised_on_read():
     # A new input clears the error and the pipeline recovers.
     irx.rx.value = 3
     async_rx.rx.value
-    await async_wait_until(lambda: async_rx.rx.value == 6)
+    await async_wait_until(lambda: async_rx.rx.value == 30)
 
 async def test_reactive_async_error_propagates_downstream():
     async def mul(value):


### PR DESCRIPTION
An exception raised inside an async operation is never surfaced to the reader. The node reports
`_awaiting == True` forever, every read returns the stale value, and the only trace is an asyncio
"Task exception was never retrieved" warning on stderr.

```python
async def boom(v):
    await asyncio.sleep(0)
    raise RuntimeError("boom")

e = rx(1).rx.pipe(boom)
e.rx.watch(lambda v: print("watch", v))
e.rx.value               # Undefined, as expected on the first read
await asyncio.sleep(0.1)
e.rx.value               # Undefined on main, forever
e._awaiting              # True on main, forever
```

The synchronous path does the right thing: `_resolve` stores the exception in `_error_state` and
re-raises it on every read until an invalidation clears it, so a failing operation reports its
failure and a new input recovers the pipeline. The async path has neither property.

## Cause

`_resolve_async` catches only `asyncio.CancelledError`. Anything else escapes the task, so none of
the three publish paths (shared adoption, async generator, awaited coroutine) ever runs its tail:
`_finished_generation` is not advanced, `_error_state` is not set, and no trigger fires.

`_awaiting` is defined as `_resolve_generation != _finished_generation`, so leaving the finished
generation behind is what strands the node. Since #1173 that also makes the node report itself as
skipped on every read, which is why the stale value stops propagating but nothing replaces it.

## Fix

One new handler in `_resolve_async` (`param/reactive.py:1876`), in order:

```python
except Exception as e:
    if stale():
        return
    self._finished_generation = generation
    if self._dirty or self._root._dirty_obj:
        return
    self._error_state = e
    trigger.param.trigger('value')
```

1. A stale generation returns without touching state, matching the existing stale paths: a newer
   resolution owns the state and the abandoned computation's error is irrelevant.
2. `_finished_generation` is advanced either way, so `_awaiting` settles.
3. If the node was invalidated while the computation was in flight, the error is dropped. This
   case matters because resolution is demand-driven: `_resolve_generation` only bumps when
   something reads the node, so a task can raise *after* a new input arrived and before anyone
   read the node again. Recording the error there would poison the node permanently, because only
   an invalidation clears `_error_state` and reads raise before ever reaching `_lazy_resolve`.
   Dropping it is safe: the next read resolves the new input and supersedes the failed one.
4. Otherwise the error is recorded and the node triggers, mirroring `_resolve`. Every read
   re-raises until an invalidation clears `_error_state`, and a new input recovers the pipeline.
   For an async generator the raise ends the stream.

The exception is no longer re-raised out of the task, so the raise itself no longer produces a
"Task exception was never retrieved" warning. With a watcher attached, the trigger invokes it, the
watcher reads the value and raises, and that propagates out of the task to the loop's exception
handler. This is the async analogue of the synchronous path raising at the mutation point, and it
matches what already happens today when a watcher raises on a successful async resolution.

Errors reach downstream and branching consumers without extra work: a downstream node's
`_prev._resolve()` raises and is recorded by the existing `except Exception` in `_resolve`, and each
`_shared` mirror records the error when it adopts the shared node's value.

The `trigger is None` guard also moved above the `_current_task` claim. It was the first statement
inside the `try` with no `await` between, so this is behavior-identical, and it keeps the type
narrowing valid inside the new handler.
