### PR TITLE
Fix async_executor leaking an event loop per call and leaking cancell…

### DIFF
--- a/param/_utils.py
+++ b/param/_utils.py
@@ -12,7 +12,7 @@ import warnings
 from collections import OrderedDict, abc, defaultdict
 from contextlib import contextmanager
 from textwrap import dedent
-from threading import get_ident
+from threading import get_ident, local
 
 if t.TYPE_CHECKING:
     import asyncio
@@ -608,18 +608,69 @@ def _in_ipython():
 
 _running_tasks: set[asyncio.Task] = set()
 
+_thread_state = local()
+
+def _fallback_event_loop() -> asyncio.AbstractEventLoop:
+    """
+    Return the event loop to drive coroutines on when nothing else is running.
+
+    The loop is cached per thread and reused, since creating one per call leaks
+    the file descriptors each loop holds. It is kept thread-local because
+    ``run_until_complete`` may not be driven from two threads at once.
+    """
+    import asyncio
+    event_loop = getattr(_thread_state, 'event_loop', None)
+    if event_loop is None or event_loop.is_closed():
+        event_loop = asyncio.new_event_loop()
+        _thread_state.event_loop = event_loop
+    return event_loop
+
+def _drain_fallback_loop(event_loop: asyncio.AbstractEventLoop) -> None:
+    """
+    Finish off anything left running on the fallback loop.
+
+    A coroutine driven by :func:`async_executor` may schedule further work
+    before it completes, which ``run_until_complete`` leaves pending. Since the
+    loop is reused, such a leftover would otherwise resume in the middle of an
+    unrelated drive, so it is cancelled and given the chance to clean up here.
+    """
+    import asyncio
+    pending = [task for task in asyncio.all_tasks(event_loop) if not task.done()]
+    if not pending:
+        return
+    for task in pending:
+        task.cancel()
+    event_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+
 def async_executor(func):
+    """
+    Schedule the awaitable returned by ``func`` on the running event loop.
+
+    Without a running loop the awaitable is instead driven to completion on a
+    loop of param's own, i.e. the call blocks the caller until the coroutine
+    has finished. Applications that can offer a loop (such as Panel) are
+    expected to override ``param.parameterized.async_executor``.
+    """
     import asyncio
     try:
         event_loop = asyncio.get_running_loop()
     except RuntimeError:
-        event_loop = asyncio.new_event_loop()
-    if event_loop.is_running():
+        event_loop = None
+    if event_loop is not None:
         task = asyncio.ensure_future(func())
         _running_tasks.add(task)
         task.add_done_callback(_running_tasks.discard)
-    else:
+        return
+    event_loop = _fallback_event_loop()
+    try:
         event_loop.run_until_complete(func())
+    except asyncio.CancelledError:
+        # A coroutine superseded while it was being driven synchronously must
+        # not surface the cancellation in the caller, which is generally an
+        # unrelated attribute access or parameter update.
+        pass
+    finally:
+        _drain_fallback_loop(event_loop)
 
 @t.runtime_checkable
 class _HasTypes(t.Protocol):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime as dt
 import os
 
@@ -16,6 +17,7 @@ from param._utils import (
     _abbreviate_paths,
     _is_abstract,
     _is_mutable_container,
+    async_executor,
     concrete_descendents,
     descendents,
     iscoroutinefunction,
@@ -574,3 +576,52 @@ def test_abbreviate_paths():
 #         cd = concrete_descendents(X)
 #     # y not returned
 #     assert cd == {'X': X, 'Y': Y}
+
+
+def test_async_executor_reuses_fallback_loop():
+    loops = []
+
+    async def record():
+        loops.append(asyncio.get_running_loop())
+
+    async_executor(record)
+    async_executor(record)
+
+    assert len(loops) == 2
+    assert loops[0] is loops[1]
+    assert not loops[0].is_closed()
+
+
+def test_async_executor_ignores_cancellation():
+    async def cancel_self():
+        asyncio.current_task().cancel()
+        await asyncio.sleep(0)
+
+    # A cancellation must not surface in the caller, which is generally an
+    # unrelated attribute access or parameter update.
+    async_executor(cancel_self)
+
+
+def test_async_executor_does_not_resume_leftover_tasks():
+    progress = []
+
+    async def leftover():
+        progress.append('started')
+        await asyncio.sleep(10)
+        progress.append('finished')
+
+    async def schedule():
+        # There is a running loop at this point, so this is scheduled rather
+        # than driven to completion.
+        async_executor(leftover)
+        await asyncio.sleep(0)
+
+    async def noop():
+        await asyncio.sleep(0)
+
+    async_executor(schedule)
+    assert progress == ['started']
+
+    # The abandoned task must not resume in the middle of a later drive.
+    async_executor(noop)
+    assert progress == ['started']


### PR DESCRIPTION
## Problem

`param._utils.async_executor` is the default hook that runs the coroutines behind async
watchers, async references and async `rx` nodes. When there is no running event loop it built
a brand new loop, drove the coroutine to completion on it, and then dropped it on the floor:

```python
def async_executor(func):
    try:
        event_loop = asyncio.get_running_loop()
    except RuntimeError:
        event_loop = asyncio.new_event_loop()
    if event_loop.is_running():
        task = asyncio.ensure_future(func())
        _running_tasks.add(task)
        task.add_done_callback(_running_tasks.discard)
    else:
        event_loop.run_until_complete(func())
```

Three problems follow from that.

**A loop, and its file descriptors, per call.** Every event loop owns a selector and a
self-pipe, so each call to the fallback path costs three file descriptors that are never
released. Resolving an async reference a hundred times off the event loop:

```python
class P(param.Parameterized):
    a = param.Integer(default=0)
    b = param.Parameter(allow_refs=True)

src = P()

async def double(a):
    await asyncio.sleep(0)
    return a * 2

sink = P(b=param.bind(double, src.param.a))
for i in range(1, 101):
    src.a = i
```

takes the process from 4 to 85 open descriptors, and keeps climbing linearly with the number
of resolutions. Long-running scripts, notebooks and worker threads that update async refs in a
loop eventually hit the per-process descriptor limit.

**Coroutines and tasks retained forever.** A coroutine driven synchronously can schedule more
work before it finishes, e.g. `Parameters._async_ref` re-schedules itself when the object it
belongs to is still initializing. That nested schedule sees the fallback loop running, so it
goes through `ensure_future` and into `_running_tasks`, but `run_until_complete` returns as
soon as the outer coroutine is done and the loop is then abandoned. The task never runs, never
completes, and is never discarded from `_running_tasks`, so the task, its coroutine and the
whole loop stay reachable for the lifetime of the process.

**Cancellations surfacing in unrelated callers.** `run_until_complete` re-raises whatever the
coroutine raised, including `asyncio.CancelledError`. param cancels superseded async
resolutions on purpose, so an ordinary attribute read or parameter assignment that happens to
drive one of those resolutions could raise `CancelledError` from inside `__getattribute__`.
`CancelledError` is a `BaseException`, so it sails through the usual `except Exception`
handling in application and test frameworks.

## Changes

`async_executor` now keeps one fallback loop per thread, and each synchronous drive is
self-contained:

```python
def async_executor(func):
    try:
        event_loop = asyncio.get_running_loop()
    except RuntimeError:
        event_loop = None
    if event_loop is not None:
        task = asyncio.ensure_future(func())
        _running_tasks.add(task)
        task.add_done_callback(_running_tasks.discard)
        return
    event_loop = _fallback_event_loop()
    try:
        event_loop.run_until_complete(func())
    except asyncio.CancelledError:
        pass
    finally:
        _drain_fallback_loop(event_loop)
```

- `_fallback_event_loop` caches the loop on a `threading.local`, recreating it only if it has
  been closed. It is deliberately per-thread rather than global, since `run_until_complete`
  cannot be driven from two threads at once. The loop is not installed with
  `asyncio.set_event_loop`, so nothing outside param sees it.
- `_drain_fallback_loop` cancels whatever the drive left pending and runs the loop once more to
  let those tasks unwind. Without it, reusing the loop would be worse than leaking one: a
  leftover task would resume in the middle of an unrelated later drive, where it interleaves
  with the resolution that superseded it. That is exactly what happened in the reference
  example above: the leftover task cancelled the live resolution and mutated
  `_param__private.refs` while `Parameters._sync_refs` was iterating it, raising
  `RuntimeError: dictionary changed size during iteration`.
- `CancelledError` from the synchronous drive is swallowed. A resolution being superseded is
  normal control flow inside param, and the caller of the attribute access or the parameter
  update has no part in it. The running-loop branch is unchanged: there, cancellation is
  observed through the task.
- The `is_running()` check on the running-loop branch is gone, because
  `asyncio.get_running_loop` only ever returns a running loop.

The fallback path still blocks the caller until the coroutine has finished, which is the
existing contract for using param without an event loop; applications that can provide a loop
(Panel, IPython) override the hook.

## Results

The reference example above now stays at 7 descriptors across the 100 resolutions instead of
climbing to 85, and eight threads each doing 50 resolutions concurrently create exactly one
loop per thread and produce the correct final value in every thread.

## Note on a newly visible warning

Assigning an async ref in a constructor while off the event loop, `P(b=param.bind(double,
src.param.a))`, has never resolved the initial value: `Parameters._async_ref` defers itself
because the object is not initialized yet, and the deferred resolution cannot run before
`__init__` returns. Previously that deferred task was retained forever; now it is cancelled by
the drain, which surfaces a `RuntimeWarning: coroutine ... was never awaited` where there used
to be a silent leak. The value is `None` either way. Flushing deferred resolutions once
`initialized` flips would fix the underlying gap and is left for a follow-up.

## Tests

Three tests in `tests/testutils.py`:

- `test_async_executor_reuses_fallback_loop` asserts two successive drives run on the same
  loop and that it is left open. Fails before this change (two different loops).
- `test_async_executor_ignores_cancellation` drives a coroutine that cancels itself. Fails
  before this change with `CancelledError`.
- `test_async_executor_does_not_resume_leftover_tasks` asserts a task scheduled during one
  drive does not resume during the next. Passes before this change as well, since the loop was
  thrown away; it guards the drain that makes loop reuse safe.

Full suite: 1541 passed, 4 skipped, 2 xfailed.

## AI Disclosure

Fixed with the help of Claude Opus 5
