### PR TITLE
Skip unresolved async rx operation arguments

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -2386,12 +2386,16 @@ class rx:
         fn, args, kwargs = operation['fn'], operation['args'], operation['kwargs']
         resolved_args = []
         for arg in args:
+            if any(ref._settling for ref in _iter_rx(arg)):
+                raise Skip
             val = resolve_value(arg)
             if val is Skip or val is Undefined:
                 raise Skip
             resolved_args.append(val)
         resolved_kwargs = {}
         for k, arg in kwargs.items():
+            if any(ref._settling for ref in _iter_rx(arg)):
+                raise Skip
             val = resolve_value(arg)
             if val is Skip or val is Undefined:
                 raise Skip

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -744,6 +744,34 @@ async def test_reactive_awaiting_visible_downstream_of_async_node():
     await async_wait_until(lambda: expr.rx.value == 12)
     assert not expr.rx.awaiting
 
+
+async def test_reactive_awaiting_subscript_skips_until_async_node_settles():
+    async def async_func():
+        await asyncio.sleep(0.02)
+        return {'value': 42}
+
+    expr = rx(async_func)['value']
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 42)
+    assert not expr.rx.awaiting
+
+
+async def test_reactive_awaiting_subscript_argument_skips_until_async_node_settles():
+    async def async_func():
+        await asyncio.sleep(0.02)
+        return {'value': 42}
+
+    source = rx(async_func)
+    expr = source[rx('value')]
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 42)
+    assert not expr.rx.awaiting
+
+
 async def test_reactive_awaiting_on_recompute():
     async def async_func(value):
         await asyncio.sleep(0.02)


### PR DESCRIPTION
This PR prevents reactive operations from consuming an `rx` argument while an upstream asynchronous node is still resolving. Previously, an early subscript or similar operation could reach `_eval_operation` with an unset cached value and raise an opaque `TypeError` such as `'NoneType' object is not subscriptable`; unresolved arguments now propagate as `Skip` and are evaluated when the async node settles.

The regression is covered for both an async root being subscripted and an async `rx` used as a subscript operand:

```python
import asyncio
import param

async def get_value():
    await asyncio.sleep(0.02)
    return {'value': 42}

expr = param.rx(get_value)['value']
assert expr.rx.value is param.Undefined
assert expr.rx.awaiting

await asyncio.sleep(0.05)
assert expr.rx.value == 42
```

No public API, dependency, or migration changes are introduced. The focused reactive suite passes with `189 passed, 11 skipped`, and the repository lint task passes.

## AI Disclosure

Tool & Model: Kilo Code + `openai/gpt-5.6-luna`
Usage: Used to inspect the reactive evaluation code, implement the unresolved async propagation guard, add regression tests, and run the repository test and lint tasks.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
