### PR TITLE
Ensure rx node does not publish previous value on second read

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -2063,6 +2063,7 @@ class rx:
                 if stale():
                     return
                 self._current_ = shared.rx.value
+                self._skipped = False
                 self._finished_generation = generation
                 trigger.param.trigger('value')
             elif inspect.isasyncgen(obj):
@@ -2071,6 +2072,7 @@ class rx:
                         await _close_stale(obj)
                         break
                     self._current_ = val
+                    self._skipped = False
                     self._finished_generation = generation
                     trigger.param.trigger('value')
             else:
@@ -2078,6 +2080,7 @@ class rx:
                 if stale():
                     return
                 self._current_ = value
+                self._skipped = False
                 self._finished_generation = generation
                 trigger.param.trigger('value')
         except asyncio.CancelledError:
@@ -2179,8 +2182,9 @@ class rx:
             current = self._current_
             # A node awaiting an asynchronous result still holds the value it
             # computed from the previous inputs; report it as skipped so it is
-            # not propagated as if it were current.
-            self._skipped = self._awaiting
+            # not propagated as if it were current. Preserve an explicit skip
+            # across rereads so a second watcher cannot publish that value.
+            self._skipped = self._skipped or self._awaiting
         self._dirty = False
         if self._method:
             # E.g. `pi = dfi.A` leads to `pi._method` equal to `'A'`.

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1256,6 +1256,29 @@ def test_reactive_skip_value_does_not_notify_watcher():
     assert items == [3]
     assert i.rx.value == 3
 
+
+def test_reactive_skip_value_does_not_notify_later_watchers():
+    """A skipped resolution must remain skipped for every watcher reread."""
+    P = Parameters(integer=1)
+
+    def skip_values(v):
+        if v % 2 == 0:
+            return Skip
+        return v * 10
+
+    i = rx(P.param.integer).rx.pipe(skip_values)
+    first, second, third = [], [], []
+    i.rx.watch(first.append)
+    i.rx.watch(second.append)
+    i.rx.watch(third.append)
+
+    assert i.rx.value == 10
+    P.integer = 2
+    assert first == second == third == []
+
+    P.integer = 3
+    assert first == second == third == [30]
+
 async def test_reactive_async_ref_not_synced_while_awaiting():
     class Ref(param.Parameterized):
         value = param.Integer(default=0, allow_refs=True)
@@ -1503,6 +1526,24 @@ async def test_async_shared_rx_branch_after_settling_resolves():
 
     irx.rx.value = 3
     await async_wait_until(lambda: first.rx.value == 6)
+
+
+async def test_async_shared_rx_branch_does_not_republish_previous_value():
+    """An async branch must not notify later watchers with its prior value."""
+    irx = rx(1)
+    node = irx.rx.pipe(_pair)
+    branch = node[0]
+    first, second, third = [], [], []
+    branch.rx.watch(first.append)
+    branch.rx.watch(second.append)
+    branch.rx.watch(third.append)
+
+    branch.rx.value
+    await async_wait_until(lambda: first == second == third == [2])
+
+    irx.rx.value = 3
+    await async_wait_until(lambda: first == [2, 6])
+    await async_wait_until(lambda: second == [2, 6] and third == [2, 6])
 
 async def test_async_shared_rx_branch_while_awaiting_resolves():
     irx = rx(1)


### PR DESCRIPTION
This PR fixes `rx` nodes that return `Skip` or are awaiting an asynchronous result notifying later watchers with the value computed from the previous inputs. A clean reread now preserves the node's `_skipped` state, while each value published by `_resolve_async` clears that state so downstream expressions continue resolving after an asynchronous result arrives.

Before this change, the second watcher in this example received a spurious `10` when the operation skipped:

```python
import param
from param.parameterized import Skip

class Model(param.Parameterized):
    value = param.Integer(default=1)

m = Model()
node = param.rx(m.param.value).rx.pipe(
    lambda value: Skip if value % 2 == 0 else value * 10
)
first, second = [], []
node.rx.watch(first.append)
node.rx.watch(second.append)

node.rx.value
m.value = 2
assert first == []
assert second == []

m.value = 3
assert first == second == [30]
```

I added synchronous and asynchronous multi-watcher regression tests in `tests/testreactive.py`.

## AI Disclosure

Tool & Model: Kilo + GPT-5.6 Luna
Usage: Used to inspect the implementation and plan, implement the `rx` state fix and regression tests, and draft this PR description.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
