### PR TITLE
Ensure async nodes do not resolve when branched

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -2159,12 +2159,8 @@ class rx:
                     if self._is_async:
                         self._lazy_resolve(obj)
                         if self._finished_generation == self._resolve_generation:
-                            # With no running event loop async_executor drives
-                            # the coroutine to completion synchronously, so the
-                            # value is already here and the node is not waiting
-                            # on anything. Reporting a skip would strand a
-                            # branch mirroring this node, which refuses to
-                            # resolve while its input reports one.
+                            # Handle case where async call is resolved synchronously
+                            # e.g. when there is no running event loop
                             self._skipped = False
                             self._dirty = False
                             return self._current_
@@ -2233,10 +2229,8 @@ class rx:
         operation = operation or self._operation
         depth = self._depth + 1
         if copy:
-            # A mirror of an asynchronous node discards the value it is handed
-            # (__init__ resets _current_ to Undefined and marks it dirty), so
-            # reading the resolving _current here would schedule — or, with no
-            # running loop, run — a compute purely to throw its result away.
+            # Do not trigger resolve via self._current since result is discarded
+            # by the cloned nodes constructor anyway
             current = self._current_ if self._is_async else self._current
             kwargs = dict(
                 self._kwargs, _current=current, method=self._method,

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -2158,6 +2158,16 @@ class rx:
                     obj = self._eval_operation(obj, operation)
                     if self._is_async:
                         self._lazy_resolve(obj)
+                        if self._finished_generation == self._resolve_generation:
+                            # With no running event loop async_executor drives
+                            # the coroutine to completion synchronously, so the
+                            # value is already here and the node is not waiting
+                            # on anything. Reporting a skip would strand a
+                            # branch mirroring this node, which refuses to
+                            # resolve while its input reports one.
+                            self._skipped = False
+                            self._dirty = False
+                            return self._current_
                         obj = Skip
                     if obj is Skip:
                         raise Skip
@@ -2223,8 +2233,13 @@ class rx:
         operation = operation or self._operation
         depth = self._depth + 1
         if copy:
+            # A mirror of an asynchronous node discards the value it is handed
+            # (__init__ resets _current_ to Undefined and marks it dirty), so
+            # reading the resolving _current here would schedule — or, with no
+            # running loop, run — a compute purely to throw its result away.
+            current = self._current_ if self._is_async else self._current
             kwargs = dict(
-                self._kwargs, _current=self._current, method=self._method,
+                self._kwargs, _current=current, method=self._method,
                 prev=self._prev, _shared=self, **kwargs
             )
         else:

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1513,6 +1513,47 @@ async def test_async_shared_rx_branch_while_awaiting_resolves():
     assert first.rx.value is param.Undefined
     await async_wait_until(lambda: first.rx.value == 2)
 
+def test_async_shared_rx_branch_does_not_resolve_on_creation():
+    """Branching an async node must not compute to seed the mirror.
+
+    A mirror of an asynchronous node discards the value it is constructed
+    with, so resolving to obtain it is wasted work. With no running loop the
+    fallback executor runs the body to completion on the calling thread,
+    which is how this was found: taking a branch during graph construction
+    ran the compute there.
+    """
+    calls = []
+
+    async def counted_pair(value):
+        calls.append(value)
+        await asyncio.sleep(0.02)
+        return (value * 2, value * 3)
+
+    node = rx(1).rx.pipe(counted_pair)
+    first, second = node[0], node[1]
+    assert calls == []
+
+    # Reading drives the compute; with no running loop async_executor runs it
+    # to completion, so both branches resolve off the one call.
+    assert first.rx.value == 2
+    assert second.rx.value == 3
+    assert calls == [1]
+
+def test_shared_rx_branch_still_reuses_a_synchronous_input():
+    """The synchronous mirror keeps its value, so branches share one compute."""
+    calls = []
+
+    def counted_pair(value):
+        calls.append(value)
+        return (value * 2, value * 3)
+
+    node = rx(1).rx.pipe(counted_pair)
+    first, second = node[0], node[1]
+    assert (first.rx.value, second.rx.value) == (2, 3)
+    assert calls == [1]
+
+
+
 async def test_async_shared_rx_branch_before_resolving_resolves():
     irx = rx(1)
     node = irx.rx.pipe(_pair)

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1515,12 +1515,6 @@ async def test_async_shared_rx_branch_while_awaiting_resolves():
 
 def test_async_shared_rx_branch_does_not_resolve_on_creation():
     """Branching an async node must not compute to seed the mirror.
-
-    A mirror of an asynchronous node discards the value it is constructed
-    with, so resolving to obtain it is wasted work. With no running loop the
-    fallback executor runs the body to completion on the calling thread,
-    which is how this was found: taking a branch during graph construction
-    ran the compute there.
     """
     calls = []
 

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1514,8 +1514,7 @@ async def test_async_shared_rx_branch_while_awaiting_resolves():
     await async_wait_until(lambda: first.rx.value == 2)
 
 def test_async_shared_rx_branch_does_not_resolve_on_creation():
-    """Branching an async node must not compute to seed the mirror.
-    """
+    """Branching an async node must not compute to seed the mirror."""
     calls = []
 
     async def counted_pair(value):


### PR DESCRIPTION
This PR stops `rx` computing an asynchronous node in order to build a branch of it. `_clone(copy=True)` read the resolving `_current` property to seed the mirror, but `__init__` resets an asynchronous node's `_current_` to `Undefined` and marks it dirty, so that value was always discarded: with a running loop the branch scheduled a compute nobody had asked for, and with no running loop `async_executor` fell back to driving the coroutine to completion on the calling thread. Branching now reads the cached `_current_` slot for an asynchronous node and keeps resolving `_current` for a synchronous one, where the mirror does keep the value and is what lets sibling branches share a single input compute.

I found this building a `(value, trace)` pair on top of #1178: taking `node[0]` and `node[1]` during graph construction ran the body there, which is exactly what a library offloading work to a thread is trying to avoid.

```python
import asyncio
import param

calls = []

async def pair(value):
    calls.append(value)
    await asyncio.sleep(0.02)
    return (value * 2, value * 3)

node = param.rx(1).rx.pipe(pair)
first, second = node[0], node[1]
assert calls == []          # before: [1], run on this thread

assert first.rx.value == 2  # a read drives it, as documented for async_executor
assert second.rx.value == 3
assert calls == [1]
```

Not resolving on clone exposed a second defect that the discarded compute had been masking, fixed here too: when `async_executor` has no loop to schedule onto it drives the coroutine to completion inside `_lazy_resolve`, yet `_resolve` still reported the node as skipped, so a mirror copied that skip state and any branch reading through it refused to resolve and stayed `None` forever. `_resolve` now checks whether the resolution finished during `_lazy_resolve`, and publishes the value instead of skipping when it did.

I added regression tests in `tests/testreactive.py` covering that branching an asynchronous node does not compute, that both branches then resolve off one call, and that a synchronous node's branches still share a single input compute.

## AI Disclosure

Tool & Model: Kilo + Claude Opus 5
Usage: Used to trace the resolve path and localize both defects, implement the fix and regression tests, and draft this PR description.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
