### PR TITLE
Implement .rx.stale

### DIFF
--- a/doc/user_guide/Reactive_Expressions.ipynb
+++ b/doc/user_guide/Reactive_Expressions.ipynb
@@ -342,7 +342,7 @@
     "\n",
     "Unlike their corresponding standard Python equivalent, each of these returns a reactive expression that can thus be combined with other reactive expressions to make reactive pipelines.\n",
     "\n",
-    "The namespace also provides `.rx.awaiting`, which reports whether an asynchronous operation in the expression is still resolving. Unlike the methods above it is a plain boolean rather than a reactive expression."
+    "The namespace also provides two plain booleans rather than reactive expressions: `.rx.stale`, which reports whether the expression has produced a value for its current inputs, and `.rx.awaiting`, which reports whether an asynchronous operation in the expression is still resolving."
    ]
   },
   {
@@ -616,6 +616,37 @@
    "cell_type": "code",
    "id": "1d5991d8",
    "source": "import asyncio\n\nasync def slow_double(value):\n    await asyncio.sleep(1)\n    return value * 2\n\nasync_expr = rx(1).rx.pipe(slow_double) + 1\n\nprint(f'requested: value={async_expr.rx.value!r}, awaiting={async_expr.rx.awaiting}')\n\nawait asyncio.sleep(1.5)\n\nprint(f'settled:   value={async_expr.rx.value!r}, awaiting={async_expr.rx.awaiting}')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c4f1a52",
+   "source": [
+    "#### `.rx.stale`\n",
+    "\n",
+    "`.rx.stale` reports whether the expression has produced a value for its current inputs. It is `True` from the moment an input changes until the expression recomputes, as well as before the first evaluation of an expression whose value has never been requested.\n",
+    "\n",
+    "For a synchronous expression this means the next request for the value recomputes it. An asynchronous operation stays stale after it has been scheduled, since scheduling is not the same as producing a value, which is the case `.rx.awaiting` reports. `stale` and not `awaiting` therefore means the next request for the value recomputes it synchronously. Like `.rx.awaiting`, the whole graph feeding the expression is considered and reading the value neither resolves nor schedules anything:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "6b3d0c47",
+   "source": [
+    "number = rx(1)\n",
+    "stale_expr = number + 1\n",
+    "\n",
+    "print(f'created:   stale={stale_expr.rx.stale}')\n",
+    "print(f'evaluated: value={stale_expr.rx.value}, stale={stale_expr.rx.stale}')\n",
+    "\n",
+    "number.rx.value = 5\n",
+    "\n",
+    "print(f'changed:   stale={stale_expr.rx.stale}')\n",
+    "print(f'evaluated: value={stale_expr.rx.value}, stale={stale_expr.rx.stale}')"
+   ],
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -70,7 +70,9 @@ the total number of reactive instances in a pipeline.
 Instances also track their dependencies to ensure accurate updates:
 - `_method`: Temporarily stores the method or attribute accessed (e.g., `'head'`
   in `dfi.head()`).
-- `_dirty`: Indicates whether the current value needs re-computation.
+- `_dirty`: Indicates whether the current value needs re-computation. Exposed
+  publicly, together with the state of the nodes feeding a node, as
+  `.rx.stale`.
 - `_current`: Stores the result of the most recent computation.
 
 Benefits and Use Cases
@@ -901,6 +903,69 @@ class reactive_ops:
         if not isinstance(reactive, rx):
             return False
         return any(node._settling for node in reactive._upstream())
+
+    @property
+    def stale(self) -> builtins.bool:
+        """
+        Whether the expression has not yet produced a value for its current inputs.
+
+        ``True`` from the moment an input changes until the expression has
+        recomputed a value from it, and until the first evaluation of an
+        expression whose value has never been requested. While stale, the
+        expression either holds no value at all or the value it computed from
+        the previous inputs, so it should not be treated as up to date.
+
+        Both ways of falling behind the inputs are covered. A synchronous
+        operation is stale until the next request for the value recomputes it.
+        An asynchronous operation additionally remains stale after it has been
+        scheduled, since scheduling is not the same as producing a value;
+        ``.rx.awaiting`` reports that subcase, so ``stale and not awaiting``
+        means the next request for the value recomputes it synchronously.
+
+        The whole graph feeding the expression is considered, not just the node
+        it is accessed on, so an operation downstream of a stale one is itself
+        stale. Reading this neither resolves nor schedules anything, so it
+        reports ``True`` for an expression that has never been evaluated rather
+        than evaluating it. Accessed on a parameter rather than an expression
+        this is always ``False``.
+
+        Returns
+        -------
+        bool
+            ``True`` while the current value does not reflect the current
+            inputs, ``False`` otherwise.
+
+        Examples
+        --------
+        An expression is stale until its value is first requested:
+
+        >>> import param
+        >>> a = param.rx(1)
+        >>> expr = a + 1
+        >>> expr.rx.stale
+        True
+        >>> expr.rx.value
+        2
+        >>> expr.rx.stale
+        False
+
+        Changing an input makes it stale again:
+
+        >>> a.rx.value = 2
+        >>> expr.rx.stale
+        True
+        >>> expr.rx.value
+        3
+        >>> expr.rx.stale
+        False
+        """
+        reactive = self._reactive
+        if not isinstance(reactive, rx):
+            return False
+        return any(
+            node._dirty or node._root._dirty_obj or node._settling
+            for node in reactive._upstream()
+        )
 
     def updating(self) -> 'rx':
         """

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -909,25 +909,19 @@ class reactive_ops:
         """
         Whether the expression has not yet produced a value for its current inputs.
 
-        ``True`` from the moment an input changes until the expression has
-        recomputed a value from it, and until the first evaluation of an
-        expression whose value has never been requested. While stale, the
-        expression either holds no value at all or the value it computed from
-        the previous inputs, so it should not be treated as up to date.
+        ``True`` from the moment an input invalidates the expression until it
+        recomputes, and before the first evaluation of an expression whose value
+        has never been requested. An asynchronous operation stays stale after it
+        has been scheduled, since scheduling is not the same as producing a
+        value, so ``stale`` and not ``.rx.awaiting`` means the next request for
+        the value recomputes it synchronously.
 
-        Both ways of falling behind the inputs are covered. A synchronous
-        operation is stale until the next request for the value recomputes it.
-        An asynchronous operation additionally remains stale after it has been
-        scheduled, since scheduling is not the same as producing a value;
-        ``.rx.awaiting`` reports that subcase, so ``stale and not awaiting``
-        means the next request for the value recomputes it synchronously.
-
-        The whole graph feeding the expression is considered, not just the node
-        it is accessed on, so an operation downstream of a stale one is itself
-        stale. Reading this neither resolves nor schedules anything, so it
-        reports ``True`` for an expression that has never been evaluated rather
-        than evaluating it. Accessed on a parameter rather than an expression
-        this is always ``False``.
+        The whole graph feeding the expression is considered, but only inputs
+        that actually invalidate it, so an expression gated with ``.rx.when`` is
+        not stale until its gate fires. Reading this neither resolves nor
+        schedules anything. On a parameter or a bound function it is always
+        ``False``, since reading their value evaluates rather than returning a
+        cached one.
 
         Returns
         -------
@@ -937,7 +931,8 @@ class reactive_ops:
 
         Examples
         --------
-        An expression is stale until its value is first requested:
+        An expression is stale until its value is requested, and again once an
+        input changes:
 
         >>> import param
         >>> a = param.rx(1)
@@ -948,16 +943,9 @@ class reactive_ops:
         2
         >>> expr.rx.stale
         False
-
-        Changing an input makes it stale again:
-
         >>> a.rx.value = 2
         >>> expr.rx.stale
         True
-        >>> expr.rx.value
-        3
-        >>> expr.rx.stale
-        False
         """
         reactive = self._reactive
         if not isinstance(reactive, rx):

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -916,13 +916,6 @@ class reactive_ops:
         value, so ``stale`` and not ``.rx.awaiting`` means the next request for
         the value recomputes it synchronously.
 
-        The whole graph feeding the expression is considered, but only inputs
-        that actually invalidate it, so an expression gated with ``.rx.when`` is
-        not stale until its gate fires. Reading this neither resolves nor
-        schedules anything. On a parameter or a bound function it is always
-        ``False``, since reading their value evaluates rather than returning a
-        cached one.
-
         Returns
         -------
         bool

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -976,6 +976,187 @@ async def test_reactive_awaiting_settles_when_async_ref_yields_nothing():
     assert expr.rx.awaiting
     await async_wait_until(lambda: not expr.rx.awaiting)
 
+def test_reactive_stale_until_first_evaluation():
+    expr = rx(1) + 2
+
+    assert expr.rx.stale
+    assert expr.rx.value == 3
+    assert not expr.rx.stale
+
+def test_reactive_stale_on_parameter():
+    class P(param.Parameterized):
+        a = param.Number(default=1)
+
+    assert not P().param.a.rx.stale
+
+def test_reactive_stale_on_input_change():
+    number = rx(1)
+    expr = number + 2
+
+    assert expr.rx.value == 3
+    assert not expr.rx.stale
+
+    number.rx.value = 5
+    assert expr.rx.stale
+    assert expr.rx.value == 7
+    assert not expr.rx.stale
+
+def test_reactive_stale_visible_downstream():
+    """An expression downstream of a stale one is itself stale."""
+    number = rx(1)
+    upstream = number + 2
+    downstream = upstream * 2
+
+    assert downstream.rx.value == 6
+    assert not upstream.rx.stale
+    assert not downstream.rx.stale
+
+    number.rx.value = 5
+    assert upstream.rx.stale
+    assert downstream.rx.stale
+
+    # Resolving the upstream expression does not update the downstream one
+    assert upstream.rx.value == 7
+    assert not upstream.rx.stale
+    assert downstream.rx.stale
+
+def test_reactive_stale_on_bound_function_input_change():
+    class P(param.Parameterized):
+        a = param.Number(default=1)
+
+    p = P()
+    expr = rx(bind(lambda a: a + 1, p.param.a)) + 1
+
+    assert expr.rx.value == 3
+    assert not expr.rx.stale
+
+    p.a = 5
+    assert expr.rx.stale
+    assert expr.rx.value == 7
+    assert not expr.rx.stale
+
+def test_reactive_stale_through_operation_argument():
+    number = rx(1)
+    inner = number + 1
+    expr = rx(100) + inner
+
+    assert expr.rx.value == 102
+    assert not expr.rx.stale
+
+    number.rx.value = 5
+    assert expr.rx.stale
+    assert expr.rx.value == 106
+    assert not expr.rx.stale
+
+def test_reactive_stale_not_evaluated_when_read():
+    """Reading stale must not itself resolve the expression."""
+    calls = []
+
+    def count(value):
+        calls.append(value)
+        return value
+
+    expr = rx(1).rx.pipe(count)
+
+    assert expr.rx.stale
+    assert calls == []
+    assert expr.rx.value == 1
+    assert calls == [1]
+
+async def test_reactive_stale_while_async_operation_in_flight():
+    """
+    An async operation is stale from the moment its inputs change until it has
+    produced a value, i.e. scheduling it does not make it up to date.
+    """
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    expr = rx(0).rx.pipe(async_func) + 10
+
+    assert expr.rx.stale
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.stale
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 12)
+    assert not expr.rx.stale
+    assert not expr.rx.awaiting
+
+async def test_reactive_stale_on_async_recompute():
+    async def async_func(value):
+        await asyncio.sleep(0.02)
+        return value + 2
+
+    number = rx(0)
+    expr = number.rx.pipe(async_func) + 10
+    expr.rx.watch()
+
+    await async_wait_until(lambda: expr.rx.value == 12)
+    assert not expr.rx.stale
+
+    number.rx.value = 5
+    assert expr.rx.stale
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 17)
+    assert not expr.rx.stale
+
+async def test_reactive_stale_while_async_ref_in_flight():
+    class P(param.Parameterized):
+        value = param.Parameter(default=0, allow_refs=True)
+
+    async def async_func():
+        await asyncio.sleep(0.02)
+        return 7
+
+    p = P()
+    expr = p.param.value.rx() + 1
+    expr.rx.watch()
+
+    assert expr.rx.value == 1
+    assert not expr.rx.stale
+
+    p.value = async_func
+    assert expr.rx.stale
+    await async_wait_until(lambda: expr.rx.value == 8)
+    assert not expr.rx.stale
+
+async def test_reactive_stale_branching_pipeline():
+    number = rx(1)
+    base = number + 1
+    branch1 = base + 100
+    branch2 = base + 200
+
+    assert branch1.rx.value == 102
+    assert branch2.rx.value == 202
+    assert not branch1.rx.stale
+    assert not branch2.rx.stale
+
+    number.rx.value = 5
+    assert branch1.rx.stale
+    assert branch2.rx.stale
+
+    assert branch1.rx.value == 106
+    assert not branch1.rx.stale
+    assert branch2.rx.stale
+
+def test_reactive_stale_skip_keeps_previous_value():
+    """A skipped operation deliberately keeps its value, so it is not stale."""
+    def maybe(value):
+        if value < 5:
+            raise Skip
+        return value
+
+    number = rx(10)
+    expr = number.rx.pipe(maybe)
+
+    assert expr.rx.value == 10
+    assert not expr.rx.stale
+
+    number.rx.value = 0
+    assert expr.rx.stale
+    assert expr.rx.value == 10
+    assert not expr.rx.stale
+
 def test_reactive_upstream_walk_terminates_on_reused_input():
     a = rx(1)
     b = a + 1

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -1157,6 +1157,88 @@ def test_reactive_stale_skip_keeps_previous_value():
     assert expr.rx.value == 10
     assert not expr.rx.stale
 
+def test_reactive_stale_gated_by_when_ignores_upstream_change():
+    """
+    A gated expression reflects its inputs as of the last gate event, so an
+    upstream change alone does not make it stale.
+    """
+    class State(param.Parameterized):
+        submit = param.Event()
+
+    state = State()
+    number = rx(1)
+    gated = (number + 1).rx.when(state.param.submit)
+
+    assert gated.rx.value == 2
+    assert not gated.rx.stale
+
+    number.rx.value = 10
+    assert not gated.rx.stale
+    assert gated.rx.value == 2
+
+    state.submit = True
+    assert gated.rx.stale
+    assert gated.rx.value == 11
+    assert not gated.rx.stale
+
+def test_reactive_stale_downstream_of_when_gate():
+    class State(param.Parameterized):
+        submit = param.Event()
+
+    state = State()
+    number = rx(1)
+    expr = (number + 1).rx.when(state.param.submit) + 100
+
+    assert expr.rx.value == 102
+    assert not expr.rx.stale
+
+    number.rx.value = 10
+    assert not expr.rx.stale
+
+    state.submit = True
+    assert expr.rx.stale
+    assert expr.rx.value == 111
+    assert not expr.rx.stale
+
+def test_reactive_stale_where_tracks_selected_branch_only():
+    condition = rx(True)
+    x = rx('x')
+    y = rx('y')
+    expr = condition.rx.where(x, y).rx() + '!'
+
+    assert expr.rx.value == 'x!'
+    assert not expr.rx.stale
+
+    # The unselected branch cannot change the value
+    y.rx.value = 'y2'
+    assert not expr.rx.stale
+
+    x.rx.value = 'x2'
+    assert expr.rx.stale
+    assert expr.rx.value == 'x2!'
+    assert not expr.rx.stale
+
+    condition.rx.value = False
+    assert expr.rx.stale
+    assert expr.rx.value == 'y2!'
+    assert not expr.rx.stale
+
+def test_reactive_stale_on_bound_function():
+    """A bound function evaluates on every read, so it never holds a stale value."""
+    class P(param.Parameterized):
+        a = param.Number(default=1)
+
+    p = P()
+    fn = bind(lambda a: a + 1, p.param.a)
+
+    assert not fn.rx.stale
+    assert fn.rx.value == 2
+    assert not fn.rx.stale
+
+    p.a = 5
+    assert not fn.rx.stale
+    assert fn.rx.value == 6
+
 def test_reactive_upstream_walk_terminates_on_reused_input():
     a = rx(1)
     b = a + 1


### PR DESCRIPTION
This PR exposes the internal `rx._dirty` invalidation flag as `.rx.stale`, a plain boolean reporting whether an expression has produced a value for its *current* inputs. It is `True` from the moment an input changes until the expression recomputes, and before the first evaluation of an expression whose value has never been requested, which makes it possible to ask "is the value I can read up to date?" without resolving the expression to find out.

The property is deliberately a superset of the raw `_dirty` flag rather than a one-to-one alias, because `_dirty` is cleared when an async operation is *scheduled*, not when it produces a value. A node awaiting an async result therefore has `_dirty == False` while still holding a value computed from superseded inputs, so a flag mapped straight onto `_dirty` would report "up to date" at exactly the moment the value is not. `.rx.stale` reports `node._dirty or node._root._dirty_obj or node._settling` across the whole graph returned by `_upstream()`, matching how `.rx.awaiting` already aggregates, so an operation downstream of a stale one is itself stale and a bound function whose parameters changed (`_dirty_obj`) counts too. `.rx.awaiting` remains the async-specific subcase, giving the reader `stale and not awaiting` for "the next read recomputes synchronously". Reading the property neither resolves nor schedules anything, so it reports `True` for a never-evaluated expression instead of quietly evaluating it, and it is always `False` when accessed on a parameter rather than an expression.

Synchronous behavior:

```python
import param

number = param.rx(1)
expr = number + 1

assert expr.rx.stale          # never evaluated
assert expr.rx.value == 2
assert not expr.rx.stale

number.rx.value = 5
assert expr.rx.stale          # input changed, not recomputed yet
assert expr.rx.value == 6
assert not expr.rx.stale
```

Asynchronous behavior, where scheduling alone does not clear it:

```python
import asyncio
import param

async def slow_double(value):
    await asyncio.sleep(0.1)
    return value * 2

async def main():
    expr = param.rx(1).rx.pipe(slow_double) + 1

    assert expr.rx.value is param.Undefined
    assert expr.rx.stale and expr.rx.awaiting   # scheduled, no value yet

    await asyncio.sleep(0.2)
    assert expr.rx.value == 3
    assert not expr.rx.stale and not expr.rx.awaiting

asyncio.run(main())
```

An operation that raises `Skip` deliberately keeps its previous value, so it is not reported as stale once the skip has been processed.

No behavior changes, no new dependencies, and no breaking changes: this only adds a read-only property on the `.rx` namespace.

## AI Disclosure

Tool & Model: Kilo Code + Claude Opus

Usage: Explored the invalidation machinery, implemented the property, wrote the tests and the user guide section, and verified the sync/async state transitions empirically before settling on the semantics.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
- [x] Added documentation
