### PR TITLE
Settle an rx generator operation whose stream ends without yielding

### DIFF
--- a/param/reactive.py
+++ b/param/reactive.py
@@ -2077,14 +2077,8 @@ class rx:
                     trigger.param.trigger('value')
                 else:
                     if not stale() and self._finished_generation != generation:
-                        # The stream ended without yielding anything for these
-                        # inputs, so it declined to produce a value, like an
-                        # operation raising Skip. Claim the generation anyway,
-                        # otherwise the node stays in flight forever even though
-                        # nothing is running, and mark it skipped so the value it
-                        # computed from earlier inputs is not propagated as if it
-                        # were current. Nothing is triggered because there is no
-                        # new value to publish.
+                        # The generator did not yield anything, so we skip and keep
+                        # the previous output
                         self._skipped = True
                         self._finished_generation = generation
             else:

--- a/param/reactive.py
+++ b/param/reactive.py
@@ -2075,6 +2075,18 @@ class rx:
                     self._skipped = False
                     self._finished_generation = generation
                     trigger.param.trigger('value')
+                else:
+                    if not stale() and self._finished_generation != generation:
+                        # The stream ended without yielding anything for these
+                        # inputs, so it declined to produce a value, like an
+                        # operation raising Skip. Claim the generation anyway,
+                        # otherwise the node stays in flight forever even though
+                        # nothing is running, and mark it skipped so the value it
+                        # computed from earlier inputs is not propagated as if it
+                        # were current. Nothing is triggered because there is no
+                        # new value to publish.
+                        self._skipped = True
+                        self._finished_generation = generation
             else:
                 value = await obj
                 if stale():

--- a/tests/testreactive.py
+++ b/tests/testreactive.py
@@ -976,6 +976,88 @@ async def test_reactive_awaiting_settles_when_async_ref_yields_nothing():
     assert expr.rx.awaiting
     await async_wait_until(lambda: not expr.rx.awaiting)
 
+async def test_reactive_awaiting_settles_when_async_gen_operation_yields_nothing():
+    """
+    A generator operation whose stream ends without yielding declined to
+    produce a value, so it must settle rather than stay in flight forever.
+    """
+    async def gen(value):
+        return
+        yield  # pragma: no cover
+
+    expr = rx(1).rx.pipe(gen)
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: not expr.rx.awaiting)
+    assert expr._skipped
+
+async def test_reactive_awaiting_settles_when_gen_operation_yields_nothing():
+    """A synchronous generator operation is wrapped, so it settles too."""
+    def gen(value):
+        return
+        yield  # pragma: no cover
+
+    expr = rx(1).rx.pipe(gen)
+
+    assert expr.rx.value is param.Undefined
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: not expr.rx.awaiting)
+
+async def test_reactive_awaiting_settles_when_async_gen_stream_becomes_empty():
+    """
+    A stream that yielded for earlier inputs and yields nothing for the current
+    ones settles, keeping its previous value without publishing it again.
+    """
+    async def gen(value):
+        if value > 0:
+            yield value * 2
+
+    number = rx(1)
+    expr = number.rx.pipe(gen)
+    items = []
+    expr.rx.watch(items.append)
+
+    await async_wait_until(lambda: expr.rx.value == 2)
+    assert items == [2]
+    assert not expr.rx.awaiting
+
+    number.rx.value = 0
+    await async_wait_until(lambda: not expr.rx.awaiting)
+    assert items == [2]
+    assert expr._skipped
+    assert expr.rx.value == 2
+
+    # A later stream that does yield recovers
+    number.rx.value = 5
+    await async_wait_until(lambda: items == [2, 10])
+    assert not expr.rx.awaiting
+    assert not expr._skipped
+
+async def test_reactive_awaiting_superseded_stream_does_not_claim_generation():
+    """
+    A stream abandoned because its inputs changed must not settle the newer
+    resolution that superseded it.
+    """
+    started = []
+
+    async def gen(value):
+        started.append(value)
+        await asyncio.sleep(0.05)
+        yield value * 2
+
+    number = rx(1)
+    expr = number.rx.pipe(gen)
+    expr.rx.watch()
+
+    await async_wait_until(lambda: expr.rx.value == 2)
+
+    number.rx.value = 2
+    number.rx.value = 3
+    assert expr.rx.awaiting
+    await async_wait_until(lambda: expr.rx.value == 6)
+    assert not expr.rx.awaiting
+
 def test_reactive_upstream_walk_terminates_on_reused_input():
     a = rx(1)
     b = a + 1


### PR DESCRIPTION
An `rx` node whose operation is a generator stays "in flight" forever when the stream ends without yielding a value for the current inputs. 

This PR adds ensures that when the loop completes without having produced a value it marks the node skipped so the value it computed from earlier inputs is not propagated as if it were current. That is the same outcome as an operation raising `Skip`: the pipeline responded to the current inputs by declining to produce a value, and the previous value stands

```python
import asyncio
import param

async def gen(value):
    if value > 0:
        yield value * 2

async def main():
    number = param.rx(1)
    expr = number.rx.pipe(gen)
    expr.rx.watch()

    while expr.rx.value != 2:
        await asyncio.sleep(0.02)
    assert not expr.rx.awaiting

    number.rx.value = 0          # this stream yields nothing
    await asyncio.sleep(0.2)
    assert not expr.rx.awaiting  # fails on main: stuck True with no task running
    assert expr.rx.value == 2    # previous value stands, as with Skip

asyncio.run(main())
```

The stuck flag is observable through `.rx.awaiting`, and it also wedges anything built on the same generation machinery, so a consumer polling for an expression to settle waits forever instead of learning that no value is coming.

## AI Disclosure

Tool & Model: Kilo Code + Claude Opus

Usage: Diagnosed the stuck generation from the observable `awaiting` behavior, wrote the fix and the tests, and confirmed the tests fail without the fix.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
- [ ] Added documentation
